### PR TITLE
removing an scss override that was causing v-btn to not show "current" state

### DIFF
--- a/src/scss/shared/overrides.scss
+++ b/src/scss/shared/overrides.scss
@@ -33,10 +33,6 @@ h3 {
   font-family: "Friz Quadrata Std Bold";
 }
 
-.v-btn:before {
-  background-color: transparent !important;
-}
-
 .v-card {
   background: inherit !important;
   overflow: hidden !important;


### PR DESCRIPTION
News carousel, nav tabs, etc.  Looking at the blame, @kato88 added this as a bulk change, so I expect it wasn't intentional.  If anyone knows of a button where we _don't_ want this, it would be good to know

<img width="698" alt="Screen Shot 2021-01-30 at 12 50 29 PM" src="https://user-images.githubusercontent.com/16199008/106363955-be0f8900-62f9-11eb-9fb7-1fa3aeb3d5bb.png">
<img width="804" alt="Screen Shot 2021-01-30 at 12 50 54 PM" src="https://user-images.githubusercontent.com/16199008/106363971-cbc50e80-62f9-11eb-861f-07c441926af9.png">
