### PR TITLE
Dispatch single action on matches game mode change

### DIFF
--- a/src/store/match/index.ts
+++ b/src/store/match/index.ts
@@ -95,6 +95,7 @@ const mod = {
     ) {
       const { commit, dispatch } = moduleActionContext(context, mod);
       commit.SET_GAME_MODE(gameMode);
+      commit.SET_MAP("Overall");
       commit.SET_PAGE(0);
       await dispatch.loadMatches(undefined);
     },

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -140,7 +140,6 @@ export default class MatchesView extends Vue {
   }
 
   gameModeChanged(gameMode: EGameMode) {
-    this.mapChanged("Overall");
     this.$store.direct.dispatch.matches.setGameMode(gameMode);
   }
 


### PR DESCRIPTION
Two actions were being dispatched, one for resetting the map selection, and one for setting the game mode. Depending on the quicker action, it would update the results. Moved the setting of the map to a synchronous commit inside the mode action to remove the extraneous API call, and prevent the race condition.