### PR TITLE
Increase opacity of secondary text from 0.6 to 0.75

### DIFF
--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -13,6 +13,7 @@ $material-light: (
     'cards': var(--w3-bg-glass),
     'text': (
         'theme': var(--v-w3-race-bg-base),
+        'secondary': rgba(0, 0, 0, 0.75),
     ),
     'bg-color': var(--v-w3-race-bg-base),
     'toolbar': var(--v-w3-race-bg-base),


### PR DESCRIPTION
Didn't bring it all the way up to 0.87, because that's used for "primary" text and card__text and card__subtitles are considered by material theme to be secondary. Agree that 0.6 is too low, so met somewhere near the middle and increased to 0.75.