### PR TITLE
Team matches bugfixes

### DIFF
--- a/src/components/matches/TeamMatchInfo.vue
+++ b/src/components/matches/TeamMatchInfo.vue
@@ -1,17 +1,17 @@
 <template>
-  <div>
+  <div v-if="team">
     <div
-      v-for="(player, index) in team.players"
-      v-bind:key="index"
-      v-bind:class="{ mt2: index > 0 }"
+        v-for="(player, index) in team.players"
+        v-bind:key="index"
+        v-bind:class="{ mt2: index > 0 }"
     >
       <player-match-info
-        :unfinishedMatch="unfinishedMatch"
-        :player="team.players[index]"
-        :left="left"
-        :big-race-icon="bigRaceIcon"
-        :not-clickable="notClickable"
-        :is-anonymous="isAnonymous"
+          :unfinishedMatch="unfinishedMatch"
+          :player="team.players[index]"
+          :left="left"
+          :big-race-icon="bigRaceIcon"
+          :not-clickable="notClickable"
+          :is-anonymous="isAnonymous"
       />
     </div>
   </div>
@@ -24,7 +24,7 @@ import { Team } from "@/store/typings";
 import PlayerMatchInfo from "@/components/matches/PlayerMatchInfo.vue";
 
 @Component({
-  components: { PlayerMatchInfo },
+  components: { PlayerMatchInfo }
 })
 export default class TeamMatchInfo extends Vue {
   @Prop() public team!: Team;

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -141,7 +141,7 @@ export default class PlayerMatchesTab extends Vue {
     return decodeURIComponent(this.id);
   }
 
-  public async mounted() {
+  public async activated() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
     setTimeout(async () => await this.getMatches(), 500);
   }


### PR DESCRIPTION
- fixed bug when the 'team matches tab' showed matches of previous opened player
- added an 'if condition' to TeamMatchInfo component to prevent unhandled exceptions

Since <route-view> within player profile is added to <keep-alive> then the 'mounted' hook where was located initialization of component didn't always triggered. I put init process to the 'activated' hook instead to solve issue.

Fix of this bug: https://github.com/w3champions/website/issues/350
I dont know how to link it.