### PR TITLE
Widen MMR Selector Issue #394

### DIFF
--- a/src/components/overal-statistics/tabs/WinratesTab.vue
+++ b/src/components/overal-statistics/tabs/WinratesTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-row>
-      <v-col cols="md-3">
+      <v-col cols="md-4">
         <v-card-text>
           <v-select
             :items="maps"
@@ -36,7 +36,7 @@
           />
         </v-card-text>
       </v-col>
-      <v-col cols="md-9">
+      <v-col cols="md-8">
         <v-card-text>
           <v-data-table
             hide-default-footer


### PR DESCRIPTION
Changed the column ratios from 3:9 to 4:8 for the Winrates Tab to prevent text from being cutoff when selecting Grandmaster

Before:
<img width="1426" alt="Screenshot 2021-07-26 at 12 59 04" src="https://user-images.githubusercontent.com/7984606/126987705-6d1c1980-c46e-4aa6-ba5e-3b95e87e0a19.png">

After:
<img width="1440" alt="Screenshot 2021-07-26 at 13 00 10" src="https://user-images.githubusercontent.com/7984606/126987750-0a20caff-53cc-4f68-9f40-78c8b3adcef9.png">
<img width="966" alt="Screenshot 2021-07-26 at 13 01 04" src="https://user-images.githubusercontent.com/7984606/126987759-b0ec2a57-8d98-475b-bb69-3e44b4c284bf.png">
