### PR TITLE
Ensure Vuetify and race theme defaults are in sync

### DIFF
--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -10,7 +10,8 @@ Vue.use(DatetimePicker);
 
 export default new Vuetify({
   theme: {
-    dark: true,
+    // This needs to be kept in sync the default selectedTheme in App.vue
+    dark: false,
     options: { customProperties: true },
     themes: {
       dark: {


### PR DESCRIPTION
Sets Vuetify default to light theme as the default race theme is human.

Before:
<img width="1440" alt="Screenshot 2021-07-27 at 15 05 01" src="https://user-images.githubusercontent.com/7984606/127168377-364f44cb-907a-44cc-9769-dbe50f9c9511.png">

After:
<img width="1440" alt="Screenshot 2021-07-27 at 15 06 47" src="https://user-images.githubusercontent.com/7984606/127168415-5179f37e-aaee-4cca-929b-92575d5ff75c.png">

This PR address issue #405 