### PR TITLE
Fetch data onload for WinrateTab

### DIFF
--- a/src/components/overal-statistics/tabs/MmrDistributionTab.vue
+++ b/src/components/overal-statistics/tabs/MmrDistributionTab.vue
@@ -163,7 +163,6 @@ export default class PlayerActivityTab extends Vue {
   private async init() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
     await this.setSelectedSeason(this.seasons[0]);
-    await this.$store.direct.dispatch.overallStatistics.loadMapAndRaceStatistics();
     this.updateMMRDistribution();
   }
 

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -82,6 +82,7 @@ export default class OverallStatisticsView extends Vue {
     await this.$store.direct.dispatch.overallStatistics.loadPlayersPerDayStatistics();
     await this.$store.direct.dispatch.overallStatistics.loadGameLengthStatistics();
     await this.$store.direct.dispatch.overallStatistics.loadpopularGameHours();
+    await this.$store.direct.dispatch.overallStatistics.loadMapAndRaceStatistics();
     if (this.verifiedBtag) {
       await this.$store.direct.dispatch.player.loadProfile({
         battleTag: this.verifiedBtag,


### PR DESCRIPTION
Moved `overallStatistics.loadMapAndRaceStatistics()` call from MmrDistributionTab to parent component as this data needs to be loaded for both MmrDistributionTab and WinratesTab child components.

This addresses issue #406