### PR TITLE
fix mobile ui bug on player profile page; closes #421

### DIFF
--- a/src/components/player/SeasonBadge.vue
+++ b/src/components/player/SeasonBadge.vue
@@ -4,7 +4,7 @@
       <div
         @click="() => onClick(season)"
         v-on="on"
-        :class="['season-badge','pointer',{'size-xs': size == 'xs'},{'size-sm': size == 'sm'},{'size-lg': size == 'lg'}]"
+        :class="[ 'season-badge', 'pointer' ]"
         :style="{ 'background-image': 'url(' + seasonBadgeBg + ')' }"
       />
     </template>
@@ -24,7 +24,6 @@ import { getAsset } from "@/helpers/url-functions";
 @Component({})
 export default class SeasonBadge extends Vue {
   @Prop() season!: Season;
-  @Prop() size!: string;
   @Prop() onClick!: (season: Season) => void;
 
   get seasonId() {
@@ -43,21 +42,7 @@ export default class SeasonBadge extends Vue {
   height: 24px;
   background-size: cover;
   display: inline-block;
-
-  &.size-xs {
-    width: 12px;
-    height: 12px;
-  }
-
-  &.size-sm {
-    width: 15px;
-    height: 15px;
-  }
-
-  &.size-lg {
-    width: 32px;
-    height: 32px;
-  }
+  vertical-align: middle;
 }
 
 </style>

--- a/src/components/player/SeasonBadge.vue
+++ b/src/components/player/SeasonBadge.vue
@@ -4,7 +4,7 @@
       <div
         @click="() => onClick(season)"
         v-on="on"
-        class="season-badge pointer"
+        :class="['season-badge','pointer',{'size-xs': size == 'xs'},{'size-sm': size == 'sm'},{'size-lg': size == 'lg'}]"
         :style="{ 'background-image': 'url(' + seasonBadgeBg + ')' }"
       />
     </template>
@@ -24,6 +24,7 @@ import { getAsset } from "@/helpers/url-functions";
 @Component({})
 export default class SeasonBadge extends Vue {
   @Prop() season!: Season;
+  @Prop() size!: string;
   @Prop() onClick!: (season: Season) => void;
 
   get seasonId() {
@@ -38,9 +39,25 @@ export default class SeasonBadge extends Vue {
 
 <style lang="scss" scoped>
 .season-badge {
-  margin-right: 10px;
   width: 24px;
   height: 24px;
   background-size: cover;
+  display: inline-block;
+
+  &.size-xs {
+    width: 12px;
+    height: 12px;
+  }
+
+  &.size-sm {
+    width: 15px;
+    height: 15px;
+  }
+
+  &.size-lg {
+    width: 32px;
+    height: 32px;
+  }
 }
+
 </style>

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -3,56 +3,50 @@
     <v-row>
       <v-col cols="12">
         <v-card tile>
-          <v-card-title class="justify-space-between">
-            <div
-              style="display: flex; flex-direction: row; align-items: center"
-            >
-              <span>
-                {{ $t("views_player.profile") }} {{ profile.battleTag }}
-              </span>
-              <div v-if="aliasName">({{ aliasName }})</div>
-              <div
-                style="display: flex; flex-direction: row; margin-left: 25px"
-              >
-                <SeasonBadge
-                  v-for="season in seasonsWithoutCurrentOne"
-                  :season="season"
-                  :key="season.id"
-                  :on-click="selectSeason"
-                />
-              </div>
-            </div>
-            <div>
-              <gateway-select @gatewayChanged="gatewayChanged" />
-              <v-menu offset-x v-if="!!seasons && seasons.length > 0">
-                <template v-slot:activator="{ on }">
-                  <v-btn tile v-on="on" class="ma-2 transparent">
+          <v-card-title>
+            <v-row no-gutters>
+              <v-col :align-self="'center'">
+                <span>{{ $t("views_player.profile") }} {{ profile.battleTag }}</span>
+                <span v-if="aliasName" class="ml-1">({{ aliasName }})</span>
+                <span class="mr-2" /> <!-- add some space between name and season badges -->
+                <span v-for="season in seasonsWithoutCurrentOne" :key="season.id" class="ml-1">
+                  <SeasonBadge :season="season" :on-click="selectSeason" :size="'sm'" />
+                </span>
+              </v-col>
+              <v-col :cols="12" :sm="'auto'">
+                <div class="ml-3">
+                  <gateway-select @gatewayChanged="gatewayChanged" />
+                  <v-menu offset-x v-if="!!seasons && seasons.length > 0">
+                  <template v-slot:activator="{ on }">
+                    <v-btn tile v-on="on" class="ma-2 transparent">
                     <span class="pa-0" v-if="selectedSeason">
                       {{ $t("views_rankings.season") }} {{ selectedSeason.id }}
                     </span>
-                  </v-btn>
-                </template>
+                    </v-btn>
+                  </template>
 
-                <v-card>
-                  <v-list>
-                    <v-subheader>
-                      {{ $t("views_player.prevseasons") }}
-                    </v-subheader>
-                    <v-list-item
-                      v-for="item in seasons"
-                      :key="item.id"
-                      @click="selectSeason(item)"
-                    >
-                      <v-list-item-content>
-                        <v-list-item-title>
-                          {{ $t("views_rankings.season") }} {{ item.id }}
-                        </v-list-item-title>
-                      </v-list-item-content>
-                    </v-list-item>
-                  </v-list>
-                </v-card>
-              </v-menu>
-            </div>
+                  <v-card>
+                    <v-list>
+                      <v-subheader>
+                        {{ $t("views_player.prevseasons") }}
+                      </v-subheader>
+                      <v-list-item
+                          v-for="item in seasons"
+                          :key="item.id"
+                          @click="selectSeason(item)"
+                      >
+                        <v-list-item-content>
+                          <v-list-item-title>
+                            {{ $t("views_rankings.season") }} {{ item.id }}
+                          </v-list-item-title>
+                        </v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-card>
+                </v-menu>
+                </div>
+              </v-col>
+            </v-row>
           </v-card-title>
           <div
             class="live-match__container"

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -9,9 +9,9 @@
                 <span>{{ $t("views_player.profile") }} {{ profile.battleTag }}</span>
                 <span v-if="aliasName" class="ml-1">({{ aliasName }})</span>
                 <span class="mr-2" /> <!-- add some space between name and season badges -->
-                <span v-for="season in seasonsWithoutCurrentOne" :key="season.id" class="ml-1">
-                  <SeasonBadge :season="season" :on-click="selectSeason" :size="'sm'" />
-                </span>
+                <div v-for="season in seasonsWithoutCurrentOne" :key="season.id" class="ml-1 d-inline-block" >
+                  <SeasonBadge :season="season" :on-click="selectSeason" />
+                </div>
               </v-col>
               <v-col :cols="12" :sm="'auto'">
                 <div class="ml-3">


### PR DESCRIPTION
I tried to find a ui solution for #421. I came up with a mixture of grid breakpoints and smaller season badges. It's not 100% ideal, but I think it's already an improvement. I decided to introduce a new property `size` on the `SeasonBadge` component to support further use-cases of this badge.

See screenshots of different screen resolutions:
<img width="376" alt="Bildschirmfoto 2021-11-06 um 02 53 52" src="https://user-images.githubusercontent.com/8781699/140594013-5fca8b73-4761-4d75-930f-363c39d9aec4.png">
<img width="613" alt="Bildschirmfoto 2021-11-06 um 02 53 33" src="https://user-images.githubusercontent.com/8781699/140594034-3ee31ba3-9f26-4f59-b120-c855ba405cb7.png">
<img width="1231" alt="Bildschirmfoto 2021-11-06 um 02 53 15" src="https://user-images.githubusercontent.com/8781699/140594030-358ea5b3-a4be-43d1-a0c6-6357a3bb0a5b.png">