### PR TITLE
enhance hero statistics ui; closes #422

### DIFF
--- a/src/components/overal-statistics/HeroPictureSelect.vue
+++ b/src/components/overal-statistics/HeroPictureSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card-text>
+  <v-card-text :class="{'pa-1': $vuetify.breakpoint.xsOnly}">
     <v-tooltip top>
       <template v-slot:activator="{ on }">
         <div v-on="on">

--- a/src/components/overal-statistics/HeroPictureSelect.vue
+++ b/src/components/overal-statistics/HeroPictureSelect.vue
@@ -23,37 +23,28 @@
       <span>{{ (heroIndex % 3) + 1 }}</span>
     </div>
     <v-dialog v-model="dialogOpened" max-width="300px">
-      <v-card>
-        <v-row
-          class="ml-2 mr-1"
+      <v-card class="pa-1">
+        <v-row no-gutters :justify="'space-between'"
           v-for="heroPickPerRace in possibleHeroPickRows"
           :key="heroPickPerRace.map((h) => h.heroId).join('_')"
         >
-          <v-col
+          <v-col :cols="3"
             v-for="heroPickSelection in heroPickPerRace"
-            :key="heroPickSelection.heroId"
-          >
+            :key="heroPickSelection.heroId">
             <v-tooltip top>
               <template v-slot:activator="{ on }">
-                <div v-on="on">
-                  <v-card-text
-                    class="hero-icon-select"
-                    :class="
-                      isEnabledForSelect(heroPickSelection)
-                        ? ''
-                        : 'hero-icon-disabled'
-                    "
-                    @click="
+                <div v-on="on" class="ma-1">
+                  <v-responsive :aspect-ratio="1/1">
+                    <div :style="{ backgroundImage: 'url(' + parsePicture(heroPickSelection) + ')' }"
+                         class="hero-icon-select"
+                         :class="isEnabledForSelect(heroPickSelection) ? '' : 'hero-icon-disabled'"
+                         @click="
                       () => {
                         if (isEnabledForSelect(heroPickSelection))
                           pickHero(heroPickSelection);
                       }
-                    "
-                    :style="{
-                      'background-image':
-                        'url(' + parsePicture(heroPickSelection) + ')',
-                    }"
-                  />
+                    " />
+                  </v-responsive>
                 </div>
               </template>
               <div>
@@ -418,10 +409,10 @@ export default class HeroPictureSelect extends Vue {
 }
 
 .hero-icon-select {
-  height: 48px;
-  width: 48px;
+  height: 100%;
+  width: 100%;
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
 }
 
 .hero-icon-disabled {

--- a/src/components/overal-statistics/HeroWinrate.vue
+++ b/src/components/overal-statistics/HeroWinrate.vue
@@ -1,27 +1,27 @@
 <template>
   <v-card-text>
     <v-card-title>Winrates of hero matchups</v-card-title>
-    <v-row>
-      <v-col cols="2">
+    <v-row no-gutters>
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="0" />
       </v-col>
-      <v-col cols="2">
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="1" />
       </v-col>
-      <v-col cols="2">
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="2" />
       </v-col>
-      <v-col cols="2">
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="3" />
       </v-col>
-      <v-col cols="2">
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="4" />
       </v-col>
-      <v-col cols="2">
+      <v-col :cols="4" :sm="2">
         <hero-picture-select :hero-index="5" />
       </v-col>
     </v-row>
-    <h2 class="justify-center text-center">
+    <h2 class="justify-center text-center mt-4">
       <span :class="winrateClass" v-if="wins !== 0 && losses !== 0">
         {{
           wins === 0 && losses === 0 ? "-" : (winrate * 100).toFixed(2) + "%"


### PR DESCRIPTION
As described in #422 smaller screen sizes are messing up the hero selection. My solution introduces a two-row layout for smaller screen sizes and a reduced padding between the hero images to save some space on low resolutions:

<table>
<tr>
<td>
<img width="1680" alt="Bildschirmfoto 2021-11-07 um 02 18 18" src="https://user-images.githubusercontent.com/8781699/140629586-4c52659a-8b5a-4e1a-9f51-b5c460ddf069.png">
</td>
<td>
<img width="583" alt="Bildschirmfoto 2021-11-07 um 02 17 54" src="https://user-images.githubusercontent.com/8781699/140629590-645fef92-189d-46d0-b8da-b55aad8cb232.png">
</td>
<td>
<img width="511" alt="Bildschirmfoto 2021-11-07 um 02 17 40" src="https://user-images.githubusercontent.com/8781699/140629592-6998a788-6858-4b96-8adb-1725c702b843.png">
</td>
</tr></table>

I also created a patch for more reliable (in terms of screen resolutions) hero selection in the popover:

<table>
<tr>
<td>Before</td>
<td>After (resolution independed)</td>
</tr>
<tr>
<td>

![image](https://user-images.githubusercontent.com/8781699/140629681-8d86f78b-b08b-4c8d-a713-539cade661ee.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/8781699/140629713-c87786cc-bdc2-49c5-a8b9-2e7263c161c1.png)

</td>
</tr>
</table>

Happy to hear your feedback!
