### PR TITLE
Redesign main navigation bar & bugfix on /tournaments page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,8 +5,10 @@
                          v-model="isNavigationDrawerOpen">
       <v-list dense>
         <v-list-item>
-          <v-list-item-content @click="$router.push({ path: '/' })">
-            <brand-logo :is-dark-theme="isDarkTheme"/>
+          <v-list-item-content>
+            <router-link :to="{ name: 'Home'}">
+              <brand-logo :is-dark-theme="isDarkTheme"/>
+            </router-link>
           </v-list-item-content>
           <v-list-item-icon>
             <v-icon class="ml-5" @click="isNavigationDrawerOpen=false">mdi-close</v-icon>
@@ -29,9 +31,11 @@
     <v-app-bar :class="{ 'darkmode': isDarkTheme }" :dark="isDarkTheme" app>
       <!-- toggle button for drawer menu, only for lower than lg -->
       <v-app-bar-nav-icon @click.stop="isNavigationDrawerOpen=true" class="d-lg-none"></v-app-bar-nav-icon>
-      <v-app-bar-title>
-        <brand-logo :is-dark-theme="isDarkTheme" @click="$router.push({ path: '/' })" style="max-height: 30px" class="ml-2 d-none d-sm-flex" />
-      </v-app-bar-title>
+      <v-toolbar-title class="pa-0">
+        <router-link :to="{ name: 'Home'}">
+          <brand-logo :is-dark-theme="isDarkTheme"  style="max-height: 30px" class="ml-2 d-none d-sm-flex" />
+        </router-link>
+      </v-toolbar-title>
       <v-spacer></v-spacer>
 
       <!-- alternative menu for lg+ only -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
       </v-list>
       <v-divider />
       <v-list dense nav>
-        <v-list-item v-for="item in items" :key="item.title" v-show="visible(item)" link :to="item.to">
+        <v-list-item v-for="item in items" :key="item.title" v-show="isNavItemVisible(item)" link :to="{ name: item.to }">
           <v-list-item-icon>
             <v-icon>{{ item.icon }}</v-icon>
           </v-list-item-icon>
@@ -42,11 +42,11 @@
       <span class="d-none d-lg-flex">
         <v-btn
           v-for="item in items"
-          v-show="visible(item)"
+          v-show="isNavItemVisible(item)"
           :key="item.title"
           text
           tile
-          :to="item.to"
+          :to="{ name: item.to }"
           :class="item.class">
           <span class="mr-2">
             {{ $t(`views_app.${item.title}`) }}
@@ -159,32 +159,32 @@ export default class App extends Vue {
     {
       title: "tournaments",
       icon: "mdi-trophy",
-      to: "/tournaments",
+      to: "Tournaments",
     },
     {
       title: "rankings",
       icon: "mdi-view-list",
-      to: `/Rankings`,
+      to: "Rankings",
     },
     {
       title: "matches",
       icon: "mdi-controller-classic",
-      to: "/Matches",
+      to: "Matches",
     },
     {
       title: "statistics",
       icon: "mdi-chart-areaspline",
-      to: "/OverallStatistics",
+      to: "OverallStatistics",
     },
     {
       title: "admin",
       icon: "mdi-account-tie",
-      to: "/AdminOnlyView",
+      to: "Admin",
     },
     {
       title: "faq",
       icon: "mdi-help-circle-outline",
-      to: "/Faq",
+      to: "FAQ",
       class: "d-none d-md-flex",
     },
   ];
@@ -206,7 +206,14 @@ export default class App extends Vue {
     this.$store.direct.dispatch.oauth.logout();
   }
 
-  public visible(item: any): boolean {
+  /**
+   * Check if given ItemType element is visible for
+   * the current user
+   *
+   * @return boolean
+   * @param item
+   */
+  public isNavItemVisible(item: any): boolean {
     if (item.title == "admin" && !this.isAdmin) {
       return false;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app class="w3app" :class="theme" :dark="isDarkTheme">
     <v-app-bar
-      :class="{ darkmode: isDarkTheme }"
+      :class="{ 'darkmode': isDarkTheme }"
       app
       :dark="isDarkTheme"
       style="height: 60px"
@@ -12,11 +12,8 @@
         style="padding-top: 0px"
       >
         <div class="d-none d-md-inline">
-          <div v-if="(theme == 'human') | (theme == 'orc')" id="app">
-            <img src="./assets/logos/small-logo-full-black.png" />
-          </div>
-          <div v-else id="app">
-            <img src="./assets/logos/small-logo-full.png" />
+          <div id="app">
+            <img :src="isDarkTheme ? require('./assets/logos/small-logo-full.png') : require('./assets/logos/small-logo-full-black.png')" />
           </div>
         </div>
       </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,58 +1,67 @@
 <template>
   <v-app class="w3app" :class="theme" :dark="isDarkTheme">
-    <v-app-bar
-      :class="{ 'darkmode': isDarkTheme }"
-      app
-      :dark="isDarkTheme"
-      style="height: 60px"
-    >
-      <div
-        @click="$router.push({ path: '/' })"
-        class="d-flex align-center pointer"
-        style="padding-top: 0px"
-      >
-        <div class="d-none d-md-inline">
-          <div id="app">
-            <img :src="isDarkTheme ? require('./assets/logos/small-logo-full.png') : require('./assets/logos/small-logo-full-black.png')" />
-          </div>
-        </div>
-      </div>
+    <v-navigation-drawer  temporary absolute
+                         transition="slide-x-transition"
+                         v-model="isNavigationDrawerOpen">
+      <v-list dense>
+        <v-list-item>
+          <v-list-item-content @click="$router.push({ path: '/' })">
+            <brand-logo :is-dark-theme="isDarkTheme"/>
+          </v-list-item-content>
+          <v-list-item-icon>
+            <v-icon class="ml-5" @click="isNavigationDrawerOpen=false">mdi-close</v-icon>
+          </v-list-item-icon>
+        </v-list-item>
+      </v-list>
+      <v-divider />
+      <v-list dense nav>
+        <v-list-item v-for="item in items" :key="item.title" v-show="visible(item)" link :to="item.to">
+          <v-list-item-icon>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>{{ $t(`views_app.${item.title}`) }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-navigation-drawer>
+
+    <v-app-bar :class="{ 'darkmode': isDarkTheme }" :dark="isDarkTheme" app>
+      <!-- toggle button for drawer menu, only for lower than lg -->
+      <v-app-bar-nav-icon @click.stop="isNavigationDrawerOpen=true" class="d-lg-none"></v-app-bar-nav-icon>
+      <v-app-bar-title>
+        <brand-logo :is-dark-theme="isDarkTheme" @click="$router.push({ path: '/' })" style="max-height: 30px" class="ml-2 d-none d-sm-flex" />
+      </v-app-bar-title>
       <v-spacer></v-spacer>
 
-      <v-btn
-        class="button-margin"
-        v-for="item in items"
-        v-show="visible(item)"
-        :key="item.title"
-        text
-        tile
-        :to="item.to"
-        :class="item.class"
-      >
-        <span class="mr-2 hidden-xs-only">
-          {{ $t(`views_app.${item.title}`) }}
-        </span>
-        <v-icon>{{ item.icon }}</v-icon>
-      </v-btn>
+      <!-- alternative menu for lg+ only -->
+      <span class="d-none d-lg-flex">
+        <v-btn
+          v-for="item in items"
+          v-show="visible(item)"
+          :key="item.title"
+          text
+          tile
+          :to="item.to"
+          :class="item.class">
+          <span class="mr-2">
+            {{ $t(`views_app.${item.title}`) }}
+          </span>
+          <v-icon>{{ item.icon }}</v-icon>
+        </v-btn>
+        <v-divider vertical />
+      </span>
 
-      <v-btn
-        text
-        tile
-        @click="loginOrGoToProfile"
-        v-if="!authCode"
-        class="right-menu"
-      >
-        <v-icon v-if="!authCode" class="mr-2">
-          mdi-account-circle-outline
-        </v-icon>
+      <v-btn text tile @click="loginOrGoToProfile" v-if="!authCode" >
+        <v-icon v-if="!authCode" class="mr-2">mdi-account-circle-outline</v-icon>
         <sign-in-dialog v-model="showSignInDialog" v-on:region-change="saveLoginRegion"></sign-in-dialog>
       </v-btn>
 
-      <v-menu offset-y v-if="authCode">
+      <v-menu v-if="authCode">
         <template v-slot:activator="{ on }">
-          <v-btn text tile v-on="on" class="right-menu">
-            <v-icon class="mr-2">mdi-account-circle</v-icon>
-            <span class="mr-2 hidden-xs-only">{{ loginName }}</span>
+          <v-btn text tile v-on="on">
+            <span class="d-none d-sm-flex mr-2">{{ loginName }}</span>
+            <v-icon>mdi-account-circle</v-icon>
           </v-btn>
         </template>
         <v-list>
@@ -65,47 +74,48 @@
         </v-list>
       </v-menu>
 
-      <v-menu offset-y class="menu-button">
-        <template v-slot:activator="{ on }">
-          <v-btn text tile v-on="on" class="right-menu">
-            <v-icon>mdi-invert-colors</v-icon>
-          </v-btn>
-        </template>
-        <v-list class="theme-selector">
-          <v-list-item @click="theme = 'human'">
-            <v-list-item-title>{{ $t("races.HUMAN") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="theme = 'orc'">
-            <v-list-item-title>{{ $t("races.ORC") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="theme = 'nightelf'">
-            <v-list-item-title>{{ $t("races.NIGHT_ELF") }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item @click="theme = 'undead'">
-            <v-list-item-title>{{ $t("races.UNDEAD") }}</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-menu>
+            <v-menu offset-y>
+              <template v-slot:activator="{ on }">
+                <v-btn text tile v-on="on" class="right-menu">
+                  <v-icon>mdi-invert-colors</v-icon>
+                </v-btn>
+              </template>
+              <v-list class="theme-selector">
+                <v-list-item @click="theme = 'human'">
+                  <v-list-item-title>{{ $t("races.HUMAN") }}</v-list-item-title>
+                </v-list-item>
+                <v-list-item @click="theme = 'orc'">
+                  <v-list-item-title>{{ $t("races.ORC") }}</v-list-item-title>
+                </v-list-item>
+                <v-list-item @click="theme = 'nightelf'">
+                  <v-list-item-title>{{ $t("races.NIGHT_ELF") }}</v-list-item-title>
+                </v-list-item>
+                <v-list-item @click="theme = 'undead'">
+                  <v-list-item-title>{{ $t("races.UNDEAD") }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
 
-      <v-menu offset-y class="menu-button">
-        <template v-slot:activator="{ on }">
-          <v-btn text tile v-on="on" class="right-menu">
-            <locale-icon
-              :locale="savedLocale"
-              :showTwoLetterCode="false"
-            ></locale-icon>
-          </v-btn>
-        </template>
-        <v-list class="locale-selector pa-1">
-          <v-list-item
-            v-for="lang in languages"
-            :key="lang"
-            @click="savedLocale = lang"
-          >
-            <locale-icon :locale="lang"></locale-icon>
-          </v-list-item>
-        </v-list>
-      </v-menu>
+            <v-menu>
+              <template v-slot:activator="{ on }">
+                <v-btn text tile v-on="on" style="margin-top: 2px">
+                  <locale-icon
+                    :locale="savedLocale"
+                    :showTwoLetterCode="false"
+                  ></locale-icon>
+                </v-btn>
+              </template>
+              <v-list class="locale-selector">
+                <v-list-item
+                  v-for="lang in languages"
+                  :key="lang"
+                  @click="savedLocale = lang"
+                >
+                  <locale-icon :locale="lang"></locale-icon>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+
     </v-app-bar>
 
     <v-main>
@@ -127,6 +137,7 @@ import SignInDialog from "@/components/common/SignInDialog.vue";
 import { BnetOAuthRegion } from "./store/oauth/types";
 import localeIcon from "@/components/common/LocaleIcon.vue";
 import VueI18n from "node_modules/vue-i18n/types";
+import BrandLogo from "@/components/common/BrandLogo.vue";
 
 export type ItemType= {
   title: string;
@@ -135,11 +146,11 @@ export type ItemType= {
   class?: string;
 }
 
-@Component({ components: { SignInDialog, localeIcon } })
+@Component({ components: {BrandLogo, SignInDialog, localeIcon } })
 export default class App extends Vue {
   private _savedLocale = "en";
   private selectedTheme = "human";
-
+  private isNavigationDrawerOpen = false;
   public items: ItemType[] = [
     {
       title: "tournaments",
@@ -308,10 +319,6 @@ export default class App extends Vue {
 <style lang="scss">
 @import "./scss/main.scss";
 
-.right-menu {
-  top: 10px;
-}
-
 .level {
   color: white;
   text-shadow: 0.5px 0.5px 0.5px black, 0.5px -0.5px 0.5px black,
@@ -391,8 +398,4 @@ export default class App extends Vue {
   border-color: #36393f !important;
 }
 
-.v-toolbar__content {
-  overflow: auto;
-  top: -8px;
-}
 </style>

--- a/src/components/common/BrandLogo.vue
+++ b/src/components/common/BrandLogo.vue
@@ -1,0 +1,21 @@
+<template>
+  <img :src="isDarkTheme ? require('./../../assets/logos/small-logo-full.png') : require('./../../assets/logos/small-logo-full-black.png')" />
+</template>
+
+<script lang="ts">
+import {Component, Prop} from "vue-property-decorator";
+import Vue from "vue";
+
+@Component({})
+export default class BrandLogo extends Vue {
+    @Prop() isDarkTheme! : boolean
+}
+
+</script>
+
+<style scoped>
+  img {
+    max-height: 100%;
+    max-width: 100%;
+  }
+</style>

--- a/src/components/common/LocaleIcon.vue
+++ b/src/components/common/LocaleIcon.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container class="pa-0">
     <v-row class="pa-0" align="center" justify="center">
-      <v-col class="pa-1">
-        <img :src="flag()" width="25px" height="25px" />
+      <v-col>
+        <img :src="flag()" width="22px" height="22px" />
       </v-col>
       <v-col v-if="showTwoLetterCode">{{ this.locale.toUpperCase() }}</v-col>
     </v-row>

--- a/src/components/tournaments/TournamentBracket.vue
+++ b/src/components/tournaments/TournamentBracket.vue
@@ -8,7 +8,7 @@
       >
         <template v-for="(round, roundIndex) in bracketRounds">
           <div
-            :key="round.round"
+            :key="`round.${roundIndex}`"
             class="bracket-column bracket-column-matches"
             style="width: 150px;"
           >
@@ -22,7 +22,7 @@
               v-for="(match, matchIndex) in round.matches"
               style="cursor: pointer"
               v-on:click.native="matchSelected(match)"
-              :key="matchIndex"
+              :key="`match.${roundIndex}.${matchIndex}`"
               :date="match.date"
               :topPlayer="match.players[0]"
               :bottomPlayer="match.players[1]"
@@ -31,7 +31,7 @@
             </tournamentMatch>
           </div>
           <tournamentRoundConnector
-            :key="`conn${round.round}`"
+            :key="`connector.${roundIndex}`"
             :round="round"
             :prevRound="bracketRounds[roundIndex - 1]"
             :totalRounds="totalRounds"

--- a/src/components/tournaments/TournamentBracket.vue
+++ b/src/components/tournaments/TournamentBracket.vue
@@ -14,7 +14,7 @@
           >
             <div
               style="margin-top: 0px;"
-              v-bind:style="`height: ${round.dimensions.headerHeight}px`"
+              v-bind:style="{ height: round.dimensions ? round.dimensions.headerHeight + 'px' : null }"
             >
               <div class="bracket-header">{{ round.name }}</div>
             </div>
@@ -26,7 +26,7 @@
               :date="match.date"
               :topPlayer="match.players[0]"
               :bottomPlayer="match.players[1]"
-              :cellHeight="round.dimensions.cellHeight"
+              :cellHeight="{ height: round.dimensions ? round.dimensions.cellHeight : null }"
             >
             </tournamentMatch>
           </div>

--- a/src/components/tournaments/TournamentRoundConnector.vue
+++ b/src/components/tournaments/TournamentRoundConnector.vue
@@ -5,7 +5,7 @@
     v-if="round && round.round < totalRounds"
   >
     <div class="connector-header"
-         v-bind:style="`height: ${round.dimensions.headerHeight}px;`"></div>
+         v-bind:style="{ height: round.dimensions ? round.dimensions.headerHeight + 'px' : null }"></div>
     <div class="connector-connection"
          v-for="connection in numberOfConnectors"
          :key="connection">

--- a/src/components/tournaments/TournamentStraightOpenConnector.vue
+++ b/src/components/tournaments/TournamentStraightOpenConnector.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="connector-straight-open"
-       v-bind:style="`height: ${round.dimensions.cellHeight * 2}px;`">
+       v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight * 2 + 'px': null }">
     <div class="connector-straight-open-top"
-         v-bind:style="`height: ${round.dimensions.cellHeight - 1}px;`">
+         v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight - 1 + 'px': null }">
     </div>
   </div>
 </template>

--- a/src/components/tournaments/TournamentStraightOpenDownConnector.vue
+++ b/src/components/tournaments/TournamentStraightOpenDownConnector.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="connector-straight-od"
-       v-bind:style="`height: ${round.dimensions.cellHeight * 2}px;`">
+       v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight * 2 + 'px': null }">
     <div class="connector-straight-od-top"
-         v-bind:style="`height: ${round.dimensions.cellHeight - 1}px;`">
+         v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight - 1 + 'px': null }">
     </div>
     <div class="connector-straight-od-between"></div>
     <div class="connector-straight-od-container">

--- a/src/components/tournaments/TournamentYConnector.vue
+++ b/src/components/tournaments/TournamentYConnector.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="connector-y">
-    <div class="connector-y-top" v-bind:style="`height: ${round.dimensions.cellHeight * 2}px;`">
+    <div class="connector-y-top" v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight * 2 + 'px': null }">
       <div class="connector-y-container">
         <div class="connector-y-top-left"></div>
         <div class="connector-y-offset"></div>
@@ -15,7 +15,7 @@
       </div>
       <div class="connector-y-between"></div>
     </div>
-    <div class="connector-y-bottom" v-bind:style="`height: ${round.dimensions.cellHeight * 2}px;`">
+    <div class="connector-y-bottom" v-bind:style="{ height: round.dimensions ? round.dimensions.cellHeight * 2 + 'px': null }">
       <div class="connector-y-between"></div>
       <div class="connector-y-container">
         <div class="connector-y-offset"></div>


### PR DESCRIPTION
- [x] minor code refactorings
- [x] redesign main navigation (for mobile) #407
- [x] code refactoring and component separation

Here are some previous for the updated navbar design:
<table>
<tr>
<td>

![image](https://user-images.githubusercontent.com/8781699/141367101-1a5b0c5e-d5c2-40ae-a81a-1e8eccfec183.png)
</td>
<td>

![image](https://user-images.githubusercontent.com/8781699/141367169-29f5a61b-f189-47b9-a279-5adf57b2ca27.png)
</td>
<td>

![image](https://user-images.githubusercontent.com/8781699/141367215-afa8ea37-7a67-476a-a961-316c5f90e4b4.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/8781699/141367246-e4e24978-8b27-4772-9393-130847f99cf9.png)
</td>
</tr>
</table>

And here is a preview for the (partly) fixed bug on the tournaments page:
<table>
<tr>
<td width="30%">

![image](https://user-images.githubusercontent.com/8781699/141363002-27c230b8-3fbf-4db2-a783-65cf6ab15689.png)
![image](https://user-images.githubusercontent.com/8781699/141363107-b04473a8-07d1-486f-bd8e-8269df544c25.png)

</td>
<td>

Fixed multiple bugs on [/tournaments page](https://www.w3champions.com/tournaments) which causes the bracked to not show up:

- Duplicate `:keys`
- Invalid access on undefined properties `round.dimensions`
- There is still a bug, described in #439 (but I assume this should be in a new pr)

</td>
</tr>
</table