### PR TITLE
fix label for Season selectbox for maps chart

### DIFF
--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -300,6 +300,7 @@ const data = {
     },
     "components_overall-statistics_tabs_playeractivitytab": {
       selectmode: "Select Mode",
+      selectseason: "Select Season",
       gamemodedesc1:
         "Game Modes are normalized to compare their popularity more easily:",
       gamemodedesc2:


### PR DESCRIPTION
label was missing on the statistics page for the played maps chart select box

old
![image](https://user-images.githubusercontent.com/4327643/149393658-ceeec01a-5791-479e-9518-541249e8750b.png)

new
![image](https://user-images.githubusercontent.com/4327643/149393707-270aeb0b-eba0-4d1d-8a44-96a34ade92a2.png)
