### PR TITLE
Fixed gameMode.undefined showing up in ActivityPerDayChart

### DIFF
--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -30,9 +30,9 @@ export default class ActivityPerDayChart extends Vue {
       labels: this.gameDayDates,
       datasets: this.gameDays
         .filter((c) => {
-          // Filter out gameMode 9 as it does not exist
+          // Filter out all game modes that are not present in enum "EGameMode"
           // and gameMode 6 as it is 2v2 AT which has been merged with 2v2 RT
-          return c.gameMode !== 9 && c.gameMode !== 6;
+          return Object.values( EGameMode ).includes( c.gameMode ) && c.gameMode !== 6;
         })
         // then only show the data that user selected
         .filter((c) => {

--- a/src/store/typings.ts
+++ b/src/store/typings.ts
@@ -115,7 +115,7 @@ export type OngoingMatches=Record<string,{
 }>
 
 export enum EGameMode {
-  UNDEFINED,
+  UNDEFINED = 0,
   GM_1ON1 = 1,
   GM_2ON2 = 2,
   GM_2ON2_AT = 6,

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -43,7 +43,7 @@ import HeroWinrate from "@/components/overall-statistics/HeroWinrate.vue";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
 import MmrDistributionChart from "@/components/overall-statistics/MmrDistributionChart.vue";
 import {SeasonGameModeGateWayForMMR} from "@/store/overallStats/types";
-import {Season} from "@/store/ranking/types.ts";
+import {Season} from "@/store/ranking/types";
 
 @Component({
   components: {


### PR DESCRIPTION
Hey there, 

fixed the gameMode.undefined showing up in ActivityPerDayChart. I'm coming from this pull-request (https://github.com/w3champions/website/pull/456). 

Before:
![activityperday_chart](https://user-images.githubusercontent.com/1397816/150688765-0ace2d9f-d448-4007-a218-2f8514681555.PNG)

After:
![activityperday_chart_fix](https://user-images.githubusercontent.com/1397816/150688805-22fa2264-bf20-4d7a-9e94-00bddd13c04c.PNG)

Also did some minor cleanups. Hope it helps.

Regards,
kangaro0

 