### PR TITLE
Fixed missing string for shattered exile in translation file

### DIFF
--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -30,9 +30,9 @@ export default class ActivityPerDayChart extends Vue {
       labels: this.gameDayDates,
       datasets: this.gameDays
         .filter((c) => {
-          // Filter out gameMode 9 as it does not exist
+          // Filter out all game modes that are not present in enum "EGameMode"
           // and gameMode 6 as it is 2v2 AT which has been merged with 2v2 RT
-          return c.gameMode !== 9 && c.gameMode !== 6;
+          return Object.values( EGameMode ).includes( c.gameMode ) && c.gameMode !== 6;
         })
         // then only show the data that user selected
         .filter((c) => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -271,8 +271,10 @@ const en = {
     BanditsRetreatv1_1: "Bandits Retreat",
 
     // S9
-
     "AutumnLeavesv2-0": "Autumn Leaves",
+
+    // S10
+    "ShatteredExilev2-07": "Shattered Exile",
 
     // tour
     ShallowGravetourney: "Shallow Grave",

--- a/src/store/typings.ts
+++ b/src/store/typings.ts
@@ -115,7 +115,7 @@ export type OngoingMatches=Record<string,{
 }>
 
 export enum EGameMode {
-  UNDEFINED,
+  UNDEFINED = 0,
   GM_1ON1 = 1,
   GM_2ON2 = 2,
   GM_2ON2_AT = 6,

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -43,7 +43,7 @@ import HeroWinrate from "@/components/overall-statistics/HeroWinrate.vue";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
 import MmrDistributionChart from "@/components/overall-statistics/MmrDistributionChart.vue";
 import {SeasonGameModeGateWayForMMR} from "@/store/overallStats/types";
-import {Season} from "@/store/ranking/types.ts";
+import {Season} from "@/store/ranking/types";
 
 @Component({
   components: {


### PR DESCRIPTION
Hey,

i noticed that a string for the new shattered exile version was missing in the english translation files, so it would not be shown correctly on the website. See screenshot. 

Issue:
![playedmaps](https://user-images.githubusercontent.com/1397816/150700593-798fc842-9d8c-431b-98f1-4d2eb21bcd30.PNG)

Also in the selector there seems to be some string missing, but it works when i run the project locally. Dont know what happened there. 

Regards,
kangaro0

