### PR TITLE
Add mixin to share logic for extracting map name, use in components

### DIFF
--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -80,7 +80,7 @@
               </v-row>
             </td>
             <td>
-              <span>{{ getMapName(item) }}</span>
+              <span>{{ $_mapNameFromMatch(item) }}</span>
             </td>
             <td>
               {{
@@ -115,12 +115,12 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Mixins, Prop } from "vue-property-decorator";
 import { Match, Team, PlayerInTeam } from "@/store/typings";
 import moment from "moment";
 import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
 import HostIcon from "@/components/matches/HostIcon.vue";
+import MatchMixin from "@/mixins/MatchMixin";
 
 @Component({
   components: {
@@ -128,7 +128,7 @@ import HostIcon from "@/components/matches/HostIcon.vue";
     HostIcon,
   },
 })
-export default class MatchesGrid extends Vue {
+export default class MatchesGrid extends Mixins(MatchMixin) {
   @Prop() public value!: Match[];
   @Prop() public totalMatches!: number;
   @Prop() public itemsPerPage!: number;
@@ -234,14 +234,6 @@ export default class MatchesGrid extends Vue {
       .utc(moment.duration(match.durationInSeconds, "seconds").asMilliseconds())
       .format(format.toString())
       .toString();
-  }
-
-  public getMapName(match: Match) {
-    if (match.mapName) {
-      return match.mapName;
-    }
-
-    return this.$t("mapNames." + match.map.replace("'", ""));
   }
 
   get headers() {

--- a/src/mixins/MatchMixin.ts
+++ b/src/mixins/MatchMixin.ts
@@ -1,0 +1,17 @@
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { Match } from "@/store/typings";
+
+@Component
+export default class MatchMixin extends Vue {
+  public $_mapNameFromMatch(match: Match) {
+    if (match.mapName) {
+      return match.mapName;
+    }
+    return this.$_translatedMapString(match.map);
+  }
+
+  public $_translatedMapString(legacyMapName: string) {
+    return this.$t("mapNames." + legacyMapName.replace("'", ""));
+  }
+}

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -59,7 +59,7 @@
           </v-card-title>
           <v-card-title class="justify-center small-title">
             <v-card-subtitle>
-              {{ $t(`mapNames.${match.map}`) }} ({{ matchDuration }})
+              {{ $_mapNameFromMatch(match) }} ({{ matchDuration }})
               {{ playedDate }}
             </v-card-subtitle>
           </v-card-title>
@@ -174,8 +174,7 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { Component, Prop, Watch } from "vue-property-decorator";
+import { Component, Mixins, Prop, Watch } from "vue-property-decorator";
 import _keyBy from "lodash/keyBy";
 import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
 import moment from "moment";
@@ -186,6 +185,7 @@ import MatchDetailHeroRow from "@/components/match-details/MatchDetailHeroRow.vu
 import { EGameMode, PlayerScore, Team } from "@/store/typings";
 import { Gateways } from "@/store/ranking/types";
 import HostIcon from "@/components/matches/HostIcon.vue";
+import MatchMixin from "@/mixins/MatchMixin";
 
 @Component({
   components: {
@@ -197,7 +197,7 @@ import HostIcon from "@/components/matches/HostIcon.vue";
     HostIcon,
   },
 })
-export default class MatchDetailView extends Vue {
+export default class MatchDetailView extends Mixins(MatchMixin) {
   @Prop() public matchId!: string;
 
   @Watch("matchId")

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -91,7 +91,7 @@
               {{ $t("views_player.playingFFA") }}
             </div>
             <span class="live-match__map">
-              {{ $t("mapNames." + ongoingMatch.map) }}
+              {{ $_mapNameFromMatch(ongoingMatch) }}
             </span>
           </div>
 
@@ -150,8 +150,7 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { Component, Prop, Watch } from "vue-property-decorator";
+import { Component, Mixins, Prop, Watch } from "vue-property-decorator";
 import { PlayerProfile } from "@/store/player/types";
 import { EGameMode, Match, PlayerInTeam, Team } from "@/store/typings";
 
@@ -173,6 +172,7 @@ import PlayerProfileTab from "@/components/player/tabs/PlayerProfileTab.vue";
 import PlayerArrangedTeamsTab from "@/components/player/tabs/PlayerArrangedTeamsTab.vue";
 import PlayerStatisticTab from "@/components/player/tabs/PlayerStatisticTab.vue";
 import SeasonBadge from "@/components/player/SeasonBadge.vue";
+import MatchMixin from "@/mixins/MatchMixin";
 
 @Component({
   components: {
@@ -193,7 +193,7 @@ import SeasonBadge from "@/components/player/SeasonBadge.vue";
     HostIcon,
   },
 })
-export default class PlayerView extends Vue {
+export default class PlayerView extends Mixins(MatchMixin) {
   @Prop() public id!: string;
   @Prop() public freshLogin!: boolean;
 


### PR DESCRIPTION
Related to #416 

The issue seems to be partially resolved in the following commits:
https://github.com/w3champions/website-backend/commit/fb8217794c781506e4c7500f6ace80b76bfd9a91
https://github.com/w3champions/website/commit/2863272ea00a06d0614a6224023134088fb2c819

So the matchmaking-service has been updated and we get the name & id from the metadata. This has been added to ongoing and finished matches in the backend and the "MatchesGrid" has been updated to use the new map name in the frontend.

I was able to find and update the other components reading the map name from matches in the frontend.
I created a "Mixin" to share the logic between components as its seems to be the idiomatic way to reuse logic between components given globals such as the localization. I was unsure about the scope of the mixin, it is now called "MatchMixin" in order to be extended with other common match-related functionality. If you prefer something like "MatchNameMixin" or just a global helper function instead just let me know and I will change.
(Regarding method naming: It seems to be idiomatic to prefix mixin properties with $_ in order to avoid potential name conflicts with components as they are merged)

There are remaining statistics components reading the map names "the old way", due to map name not being added to the statistics related models:

(VueComponent - Backend Model)
- MapSelect - MapsPerSeason
- MapsPerSeasonChart - MapsPerSeason
- RacetoMapStat - OverallRaceAndWinStats
- WinratesTab - OverallRaceAndWinStats

See the issue for discussion regarding these.