### PR TITLE
[W3C-106] Show only first 8 items in carousel. Remove default 500px height

### DIFF
--- a/src/scss/shared/overrides.scss
+++ b/src/scss/shared/overrides.scss
@@ -197,3 +197,9 @@ header.v-app-bar--is-scrolled + main {
     background-color: var(--w3-bg-glass);
   }
 }
+
+.v-carousel {
+  .v-window-item {
+    margin-bottom: 50px;
+  }
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,8 +20,9 @@
               :show-arrows="false"
               :dark="$vuetify.theme.dark"
               :light="!$vuetify.theme.dark"
+              height="auto"
             >
-              <v-carousel-item v-for="newsItem in news" :key="newsItem.date">
+              <v-carousel-item v-for="newsItem in news.slice(0,8)" :key="newsItem.date">
                 <v-card-title>
                   {{ newsItem.date }}
                 </v-card-title>


### PR DESCRIPTION
Show only 8 items in carousel instead of all.

Set height to auto instead of default 500px to allow all content to show.

Set a 50 px margin-bottom so that the carousel-controls don't overlap the content.