### PR TITLE
[W3C-32] Fix dark mode font color issue on slider

### DIFF
--- a/src/components/common/MmrSelect.vue
+++ b/src/components/common/MmrSelect.vue
@@ -64,7 +64,13 @@ export default class MmrSelect extends Vue {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .v-messages {
-  font-size: 15px;
+::v-deep {
+  .v-messages {
+    font-size: 15px;
+  }
+
+  .theme--dark .v-slider__thumb-label {
+    color: black;
+  }
 }
 </style>


### PR DESCRIPTION
Before change:
![image](https://user-images.githubusercontent.com/21004208/182874292-b6196f16-88f2-4096-b04f-d1b80a81568d.png)

After change:
![image](https://user-images.githubusercontent.com/21004208/182874188-d8a85694-4321-4cac-a772-a7e83cd75a8f.png)
