### PR TITLE
[W3C-30] Add mmr sorting for ongoing matches

### DIFF
--- a/src/components/matches/SortSelect.vue
+++ b/src/components/matches/SortSelect.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-menu offset-x>
+    <template v-slot:activator="{ on }">
+      <v-btn tile v-on="on" style="background-color: transparent">
+        <v-icon class="mr-1">mdi-sort-ascending</v-icon>
+        {{ sortName }}
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-list>
+          <v-list-item-content>
+            <v-list-item-title>{{ $t("components_matches_sortselect.sortmatchesby") }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list>
+        <v-divider></v-divider>
+        <v-list dense>
+          <v-list-item v-for="sort in sortings" :key="sort.mode" @click="setSort(sort.mode)">
+            <v-list-item-content>
+              <v-list-item-title>{{ sort.name }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { SortMode } from "@/store/match/types";
+
+@Component({})
+export default class MapSelect extends Vue {
+  get sortName() {
+    const selectedSort = this.$store.direct.state.matches.sort;
+    return this.sortings.find((sort) => sort.mode == selectedSort)!.name;
+  }
+
+  get sortings() {
+    return [
+      {
+        name: this.$t(`components_matches_sortselect.starttimedescending`),
+        mode: SortMode.startTimeDescending,
+      },
+      {
+        name: this.$t(`components_matches_sortselect.mmrdescending`),
+        mode: SortMode.mmrDescending,
+      },
+    ];
+  }
+
+  public setSort(sort: string): void {
+    this.$store.direct.dispatch.matches.setSort(sort);
+  }
+}
+</script>
+
+<style></style>

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -15,7 +15,7 @@ export default class MatchService {
     gameMode: EGameMode,
     map: string,
     mmr: number[]
-  ): Promise<{ count: number; matches: Match[] }> {    
+  ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
     const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}&minMmr=${mmr[0]}&maxMmr=${mmr[1]}`;
 
@@ -28,7 +28,8 @@ export default class MatchService {
     gateway: number,
     gameMode: EGameMode,
     map: string,
-    mmr: number[]
+    mmr: number[],
+    sort: string
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
 
@@ -38,7 +39,8 @@ export default class MatchService {
       gateway,
       gameMode,
       map,
-      mmr
+      mmr,
+      sort
     );
   }
 
@@ -48,9 +50,10 @@ export default class MatchService {
     gateway: number,
     gameMode: EGameMode,
     map: string,
-    mmr: number[]
+    mmr: number[],
+    sort: string
   ): Promise<{ count: number; matches: Match[] }> {
-    const url = `${API_URL}api/matches/ongoing?offset=${offset}&gateway=${gateway}&pageSize=${pageSize}&gameMode=${gameMode}&map=${map}&minMmr=${mmr[0]}&maxMmr=${mmr[1]}`;
+    const url = `${API_URL}api/matches/ongoing?offset=${offset}&gateway=${gateway}&pageSize=${pageSize}&gameMode=${gameMode}&map=${map}&minMmr=${mmr[0]}&maxMmr=${mmr[1]}&sort=${sort}`;
 
     const response = await fetch(url);
     return await response.json();

--- a/src/store/match/index.ts
+++ b/src/store/match/index.ts
@@ -16,7 +16,8 @@ const mod = {
     status: MatchStatus.onGoing,
     gameMode: EGameMode.GM_1ON1,
     map: "Overall",
-    mmr: [0, 3000]
+    mmr: [0, 3000],
+    sort: "startTimeDescending",
   } as MatchState,
   actions: {
     async loadMatches(
@@ -40,7 +41,8 @@ const mod = {
           rootState.gateway,
           state.gameMode,
           state.map,
-          state.mmr
+          state.mmr,
+          state.sort
         );
       } else {
         response = await rootGetters.matchService.retrieveMatches(
@@ -71,7 +73,8 @@ const mod = {
         rootState.gateway,
         gameMode || state.gameMode,
         map || state.map,
-        state.mmr
+        state.mmr,
+        state.sort
       );
 
       commit.SET_ALL_ONGOING_MATCHES(response.matches);
@@ -122,6 +125,15 @@ const mod = {
       commit.SET_PAGE(0);
       await dispatch.loadMatches(undefined);
     },
+    async setSort(
+      context: ActionContext<MatchState, RootState>,
+      sort: string
+    ) {
+      const { commit, dispatch } = moduleActionContext(context, mod);
+      commit.SET_SORT(sort);
+      commit.SET_PAGE(0);
+      await dispatch.loadMatches(undefined);
+    },
   },
   mutations: {
     SET_PAGE(state: MatchState, page: number) {
@@ -153,6 +165,9 @@ const mod = {
     },
     SET_MMR(state: MatchState, mmr: number[]) {
       state.mmr = mmr;
+    },
+    SET_SORT(state: MatchState, sort: string) {
+      state.sort = sort;
     },
   },
 } as const;

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -12,9 +12,15 @@ export type MatchState = {
   gameMode: EGameMode;
   map: string;
   mmr: number[];
+  sort: string;
 };
 
 export enum MatchStatus {
   onGoing = "onGoing",
   past = "past",
+}
+
+export enum SortMode {
+  startTimeDescending = "startTimeDescending",
+  mmrDescending = "mmrDescending",
 }

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -22,6 +22,7 @@
               @mmrChanged="mmrChanged"
               :mmr="mmr"
             ></mmr-select>
+            <sort-select v-if="unfinished"></sort-select>
           </v-card-text>
           <matches-grid
             v-model="matches"
@@ -48,6 +49,7 @@ import MatchesStatusSelect from "@/components/matches/MatchesStatusSelect.vue";
 import GameModeSelect from "@/components/common/GameModeSelect.vue";
 import MapSelect from "@/components/common/MapSelect.vue";
 import MmrSelect from "@/components/common/MmrSelect.vue";
+import SortSelect from "@/components/matches/SortSelect.vue";
 import { MatchesOnMapPerSeason } from "@/store/overallStats/types";
 import AppConstants from "@/constants";
 
@@ -58,6 +60,7 @@ import AppConstants from "@/constants";
     GameModeSelect,
     MapSelect,
     MmrSelect,
+    SortSelect,
   },
 })
 export default class MatchesView extends Vue {


### PR DESCRIPTION
Add option to sort live matches by mmr, descending. The option is only implemented for ongoing matches, not finished matches. Backend PR for same jira issue number should be merged in first.

![image](https://user-images.githubusercontent.com/21004208/183632215-6bbce283-8e55-4c75-97b8-332037a16dfb.png)

![image](https://user-images.githubusercontent.com/21004208/183632375-d9de8593-42cc-42c0-9b79-912f2d9273c4.png)

Sorting button is not visible when browsing finished matches:
![image](https://user-images.githubusercontent.com/21004208/183633442-a303e9e2-1967-4ef6-99e2-58d1412f8919.png)
