### PR TITLE
fix: all races statiscs

### DIFF
--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -115,31 +115,16 @@ export default class PlayerHeroStatistics extends Vue {
       [ERaceEnum.RANDOM]: 0,
       [ERaceEnum.TOTAL]: 0,
     };
-    if (this.selectedRace != ERaceEnum.TOTAL) {
-      const winLossesOnMap = this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
-        .filter((obj: any) => obj.race == this.selectedRace)[0]
-        .winLossesOnMap
-        .filter((winLossesOnMap: WinLossesOnMap) => winLossesOnMap.map == this.selectedMap)[0];
-      if (winLossesOnMap) {
-        winLossesOnMap.winLosses
-          .map((raceStat: RaceStat) => {
-            totals[raceStat.race] += raceStat.games;
-            totals[ERaceEnum.TOTAL] += raceStat.games;
-          });
-      }
-    } else {
-      this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
-        .map((obj: any) => {
-          const selectedMapData = obj.winLossesOnMap
-            .filter((winLossesOnMap: WinLossesOnMap) => winLossesOnMap.map == this.selectedMap)[0]
-            if (selectedMapData) {
-              selectedMapData.winLosses
-                .map((raceStat: RaceStat) => {
-                  totals[raceStat.race] += raceStat.games;
-                  totals[ERaceEnum.TOTAL] += raceStat.games;
-              });
-            }
-        });        
+    const winLossesOnMap = this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
+      .filter((obj: any) => obj.race == this.selectedRace)[0]
+      .winLossesOnMap
+      .filter((winLossesOnMap: WinLossesOnMap) => winLossesOnMap.map == this.selectedMap)[0];
+    if (winLossesOnMap) {
+      winLossesOnMap.winLosses
+        .map((raceStat: RaceStat) => {
+          totals[raceStat.race] += raceStat.games;
+          totals[ERaceEnum.TOTAL] += raceStat.games;
+        });
     }
     heroStatsData.map((heroStat) => {
       if (heroStat.total === 0) {


### PR DESCRIPTION
To show correct numbers for all races tab

For the case below, where the player only plays undead, now it shows the same number for ud tab and all races tab

![image](https://user-images.githubusercontent.com/13929995/184023834-a14ec4b7-b920-45f7-ad35-c2301d707a0b.png)

![image](https://user-images.githubusercontent.com/13929995/184023879-c84cc56a-d60f-4430-8a0a-29775a0d4d82.png)

There was an unecessary tretament for ERaceEnum.TOTAL. It was removed.