### PR TITLE
feat: hero win rate on players statistics tab

### DIFF
--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -5,7 +5,7 @@
       <span v-if="race.raceId === raceEnums.TOTAL">
         {{ $t("common.allraces") }}
       </span>
-      <race-icon :race="race.raceId" />
+      <race-icon v-else :race="race.raceId" />
     </v-tab>
 
     <v-tab-item
@@ -41,6 +41,31 @@ export default class PlayerHeroStatistics extends Vue {
   public raceEnums = ERaceEnum;
   @Prop() playerStatsHeroVersusRaceOnMap!: PlayerStatsHeroOnMapVersusRace;
   @Prop() selectedMap!: string;
+
+  @Watch("isPlayerInitialized")
+  onPlayerInitialized(): void {
+    this.setSelectedTab();
+  }
+
+  setSelectedTab(): void {
+    let maxRace = ERaceEnum.RANDOM;
+    let maxGames = 0;
+    this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
+      .filter((s: any) => s.race !== ERaceEnum.TOTAL)
+      .forEach((s: any) =>
+        s.winLossesOnMap.forEach((w: any) => {
+          const gamesOfRace = w.winLosses
+            .map((wl: any) => wl.games)
+            .reduce((a: any, b:any) => a + b, 0);
+
+          if (maxGames < gamesOfRace) {
+            maxRace = s.race;
+            maxGames = gamesOfRace;
+          }
+        })
+      );
+    this.selectedTab = `tab-${maxRace}`;
+  }
 
   get selectedRace() {
     return Number(this.selectedTab.split('-')[1]);

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -1,0 +1,223 @@
+<template>
+  <v-tabs v-model="selectedTab">
+    <v-tabs-slider></v-tabs-slider>
+    <v-tab v-for="race of races" :key="race.raceId" :href="`#tab-${race.raceId}`">
+      <span v-if="race.raceId === raceEnums.TOTAL">
+        {{ $t("common.allraces") }}
+      </span>
+      <race-icon v-else :race="race.raceId" />
+    </v-tab>
+
+    <v-tab-item
+      v-for="race of races"
+      :key="race.raceId"
+      :value="'tab-' + race.raceId"
+    >
+      <v-card-text>
+        <v-row>
+          <v-col cols="md-12">
+            <div>
+              <v-simple-table>
+                  <template v-slot:default>
+                    <thead>
+                      <tr>
+                        <th v-for="header in headers" :key="header.value" class="text-left">
+                          {{ header.text }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr
+                        v-for="item in heroStatsCurrentPage"
+                        :key="item.hero"
+                      >
+                        <td v-for="header in headers" :key="header.value" v-html="item[header.value]"></td>
+                      </tr>
+                    </tbody>
+                  </template>
+              </v-simple-table>
+              
+              <v-pagination
+                v-model="page"
+                :length="pageLength"
+                prev-icon="mdi-menu-left"
+                next-icon="mdi-menu-right"
+              ></v-pagination>
+            </div>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-tab-item>
+  </v-tabs>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import RaceIcon from "@/components/player/RaceIcon.vue";
+import { Component, Prop, Watch } from "vue-property-decorator";
+import { getAsset } from "@/helpers/url-functions"
+import { PlayerStatsHeroOnMapVersusRace, RaceWinsOnMap, WinLossesOnMap, RaceStat, PlayerHeroWinRateForStatisticsTab, PlayerHeroStatistic } from "@/store/player/types";
+import { ERaceEnum } from "@/store/typings";
+
+@Component({
+  components: { RaceIcon },
+})
+export default class PlayerHeroWinRate extends Vue {
+  public selectedTab = "tab-16";
+  public raceEnums = ERaceEnum;
+  public page = 1;
+  public paginationSize = 10;
+  @Prop() playerStatsHeroVersusRaceOnMap!: PlayerStatsHeroOnMapVersusRace;
+  @Prop() selectedMap!: string;
+
+  @Watch("isPlayerInitialized")
+  onPlayerInitialized(): void {
+    this.setSelectedTab();
+  }
+
+  setSelectedTab(): void {
+    let maxRace = ERaceEnum.RANDOM;
+    let maxGames = 0;
+    this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
+      .filter((s: any) => s.race !== ERaceEnum.TOTAL)
+      .forEach((s: any) =>
+        s.winLossesOnMap.forEach((w: any) => {
+          const gamesOfRace = w.winLosses
+            .map((wl: any) => wl.games)
+            .reduce((a: any, b:any) => a + b, 0);
+
+          if (maxGames < gamesOfRace) {
+            maxRace = s.race;
+            maxGames = gamesOfRace;
+          }
+        })
+      );
+    this.selectedTab = `tab-${maxRace}`;
+  }
+
+  get selectedRace() {
+    return Number(this.selectedTab.split('-')[1]);
+  }
+
+  get isPlayerInitialized(): boolean {
+    return this.$store.direct.state.player.isInitialized;
+  }
+
+  get headers() { 
+    return [
+      { text: "", value: "image"},
+      { text: "Hero", value: "name"},
+      { text: "Total", value: ERaceEnum.TOTAL},
+      { text: "vs. Human", value: ERaceEnum.HUMAN},
+      { text: "vs. Orc", value: ERaceEnum.ORC},
+      { text: "vs. Undead", value: ERaceEnum.UNDEAD},
+      { text: "vs. Night Elf", value: ERaceEnum.NIGHT_ELF},
+      { text: "vs. Random", value: ERaceEnum.RANDOM},
+    ]
+  }
+  
+  get pageOffset(): number {
+    return this.paginationSize * this.page;
+  }
+
+  get pageLength(): number {
+    return Math.ceil(this.heroWinRates.length / this.paginationSize);
+  }
+
+  get heroStatsCurrentPage(): PlayerHeroWinRateForStatisticsTab[] {
+    return this.heroWinRates.slice((this.pageOffset - this.paginationSize), this.pageOffset);
+  }
+
+  get heroWinRates(): PlayerHeroWinRateForStatisticsTab[] {
+    const heroStatsItemList = this.playerStatsHeroVersusRaceOnMap.heroStatsItemList;
+    if (!heroStatsItemList) {
+      return [];
+    }
+    let hasData = false;
+    heroStatsItemList.map((item) => {
+      const filteredByMap = item.stats
+        .filter((byRace) => byRace.race == this.selectedRace)[0]
+        .winLossesOnMap.filter((byMap) => byMap.map == this.selectedMap)[0];
+      hasData = hasData || Boolean(filteredByMap);
+    });
+    if (!hasData) {
+      return [];
+    }
+    const resp: PlayerHeroWinRateForStatisticsTab[] = [];
+    heroStatsItemList.map((item) => {
+      let total = 0;
+      let wins = 0;
+      const playerWinRate = {
+        hero: item.heroId,
+        name: this.$t(`heroNames.${item.heroId}`).toString(),
+        image: this.getImageForTable(item.heroId),
+        [ERaceEnum.TOTAL]: '',
+        [ERaceEnum.UNDEAD]: '',
+        [ERaceEnum.ORC]: '',
+        [ERaceEnum.HUMAN]: '',
+        [ERaceEnum.NIGHT_ELF]: '',
+        [ERaceEnum.RANDOM]: '',
+        [ERaceEnum.STARTER]: '',
+      };
+      const filtered = item.stats
+        .filter((byRace) => byRace.race == this.selectedRace)[0]
+        .winLossesOnMap
+        .filter((byMap) => byMap.map == this.selectedMap)[0];
+      if (!filtered) {
+        return;
+      }
+      filtered
+        .winLosses
+        .map((winLoss) => {
+          playerWinRate[winLoss.race] = '-';
+          if (winLoss.games > 0) {
+            playerWinRate[winLoss.race] = `${(winLoss.winrate*100).toFixed(2)}%`;
+          }
+          total += winLoss.games;
+          wins += winLoss.wins;
+        });
+      playerWinRate[ERaceEnum.TOTAL] = `${(wins/total*100).toFixed(2)}%`
+      resp.push(playerWinRate);
+    }) || [];
+    return resp;
+  }
+
+  getImageForTable(heroId: string) {
+    const src: string = getAsset(`heroes/${heroId}.png`)
+    return `<img class="player-hero-statistics-table__hero-image" src="${src}" height="40" width="40" />`
+  }
+
+  getHeroCell(name: string, heroId: string) {
+    return `<span>${this.getImageForTable(heroId)}${name}</span>`
+  }
+
+  get races() {
+    return [
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.HUMAN]}`),
+        raceId: ERaceEnum.HUMAN,
+      },
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.ORC]}`),
+        raceId: ERaceEnum.ORC,
+      },
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.NIGHT_ELF]}`),
+        raceId: ERaceEnum.NIGHT_ELF,
+      },
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.UNDEAD]}`),
+        raceId: ERaceEnum.UNDEAD,
+      },
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.RANDOM]}`),
+        raceId: ERaceEnum.RANDOM,
+      },
+      {
+        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.TOTAL]}`),
+        raceId: ERaceEnum.TOTAL,
+      },
+    ];
+  }
+}
+</script>

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -5,7 +5,7 @@
       <span v-if="stat.race === raceEnums.TOTAL">
         {{ $t("common.allraces") }}
       </span>
-      <race-icon :race="stat.race" />
+      <race-icon v-else :race="stat.race" />
     </v-tab>
 
     <v-tab-item

--- a/src/components/player/tabs/PlayerStatisticTab.vue
+++ b/src/components/player/tabs/PlayerStatisticTab.vue
@@ -90,8 +90,32 @@
       <v-col cols="md-10">
         <player-hero-statistics
           v-if="selectedSeason.id !== 0"
-          :key="updatePlayerHeroStatsKey"
           :selectedMap="selectedMap"
+          :playerStatsHeroVersusRaceOnMap="playerStatsHeroVersusRaceOnMap"
+        />
+      </v-col>
+    </v-row>
+    <v-card-title>
+      {{ $t("components_player_tabs_playerstatistictab.playerherowinratetitle") }}
+    </v-card-title>
+    <v-row v-if="selectedSeason.id !== 0">
+      <v-col cols="md-2">
+        <v-card-text class="player-hero-usage-statistics__selects">
+          <v-select
+            v-model="selectedMapHeroWinRate"
+            :items="maps"
+            item-text="mapName"
+            item-value="mapId"
+            label="Map"
+            outlined
+          />
+        </v-card-text>
+      </v-col>
+      <v-col cols="md-10">
+        <player-hero-win-rate
+          v-if="selectedSeason.id !== 0"
+          :key="updatePlayerHeroStatsKey"
+          :selectedMap="selectedMapHeroWinRate"
           :playerStatsHeroVersusRaceOnMap="playerStatsHeroVersusRaceOnMap"
         />
       </v-col>
@@ -113,6 +137,7 @@ import {
 import PlayerStatsRaceVersusRaceOnMap from "@/components/player/PlayerStatsRaceVersusRaceOnMap.vue";
 import PlayerMmrRpTimelineChart from "@/components/player/PlayerMmrRpTimelineChart.vue";
 import PlayerHeroStatistics from "@/components/player/PlayerHeroStatistics.vue";
+import PlayerHeroWinRate from "@/components/player/PlayerHeroWinRate.vue";
 import { MatchesOnMapPerMode, MatchesOnMapPerSeason } from "@/store/overallStats/types";
 
 @Component({
@@ -120,6 +145,7 @@ import { MatchesOnMapPerMode, MatchesOnMapPerSeason } from "@/store/overallStats
     PlayerStatsRaceVersusRaceOnMap,
     PlayerMmrRpTimelineChart,
     PlayerHeroStatistics,
+    PlayerHeroWinRate,
     MatchesGrid,
   },
 })
@@ -129,6 +155,7 @@ export default class PlayerStatisticTab extends Vue {
   public selectedRace = this.$store.direct.state.player.race;
   public updatePlayerHeroStatsKey = 0;
   public selectedMap = "Overall";
+  public selectedMapHeroWinRate = "Overall";
 
   get selectedSeason() {
     return this.$store.direct.state.player.selectedSeason;
@@ -291,27 +318,22 @@ export default class PlayerStatisticTab extends Vue {
   }
 
   get maps() {
-    const gameModes = [
-      EGameMode.GM_1ON1,
-      EGameMode.GM_2ON2,
-      EGameMode.GM_4ON4,
-      EGameMode.GM_FFA,
-      EGameMode.GM_RH_1ON1,
-      EGameMode.GM_ROC_1ON1,
-    ];
-    const maps = [];
-    this.$store.direct.state.overallStatistics
-      .matchesOnMapPerSeason?.filter((matchesOnMapPerSeason: MatchesOnMapPerSeason) => this.selectedSeason.id === matchesOnMapPerSeason.season)
-      [0].matchesOnMapPerModes.filter((matchesOnMapPerMode: MatchesOnMapPerMode) => 
-        gameModes.includes(matchesOnMapPerMode.gameMode)).map((matchesOnMapPerMode: MatchesOnMapPerMode) => {
-          matchesOnMapPerMode.maps.map((e: any) =>{
-            maps.push({mapName: e.map, mapId: e.map});
-          });
-        });
-    maps.push({
+    const maps = [{
       mapName: 'Overall',
       mapId: 'Overall',
-    })
+    }];
+    const mapsList: string[] = [];
+    this.$store.direct.state.player.playerStatsHeroVersusRaceOnMap.heroStatsItemList?.map((heroItemList) => {
+      heroItemList.stats.map((stats)=> {
+        stats.winLossesOnMap.map((winLossOnMap) => {
+          const map = winLossOnMap.map;
+          if (!mapsList.includes(map)) {
+            mapsList.push(map);
+          }
+        });
+      })
+    });
+    mapsList.forEach(map => maps.push({mapName: map, mapId: map}));
     return maps;
   }
 }

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -373,6 +373,7 @@ const data = {
         "This player hasn't played any matches fitting to the current settings.",
       title: "Matchup Statistics",
       playerheroesstatisticstitle: "Hero Usage Statistics",
+      playerherowinratetitle: "Hero Winrate"
     },
     components_player_modestatsgrid: {
       mode: "Mode",

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -136,3 +136,16 @@ export type PlayerHeroStatistic = {
   hu: string;
   ne: string;
 }
+
+export type PlayerHeroWinRateForStatisticsTab = {
+  hero: string;
+  name: string;
+  image: string;
+  [ERaceEnum.TOTAL]: string;
+  [ERaceEnum.UNDEAD]: string;
+  [ERaceEnum.ORC]: string;
+  [ERaceEnum.HUMAN]: string;
+  [ERaceEnum.NIGHT_ELF]: string;
+  [ERaceEnum.RANDOM]: string;
+  [ERaceEnum.STARTER]: string;
+}


### PR DESCRIPTION
Adds the new section Hero Winrate on players statistics tab.

![image](https://user-images.githubusercontent.com/13929995/184170428-fdced5d7-3a1c-420f-b463-b9d4b2ab59a4.png)

Changes the maps on the selector for hero usage statistics. It shows Overall as first map element and only maps the player played as options.

![image](https://user-images.githubusercontent.com/13929995/184170929-4601576e-5799-437a-9146-bad4dc02b9e3.png)

Changes the default race tab for hero usage statistics, following same logic of the matchup statistics section.

Added v-else on race icon element to prevent error trying to plot the race id raceEnums.TOTAL

