### PR TITLE
W3c 153/remove old game modes from stastistics

### DIFF
--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -68,13 +68,10 @@ export default class ActivityPerDayChart extends Vue {
         return "rgb(41,128,101)";
 
       case EGameMode.UNDEFINED:
-        return "rgba(54, 162, 235, 1)";
+        return "rgb(54, 162, 235)";
 
       case EGameMode.GM_2ON2:
         return "rgb(163,54,255)";
-
-      case EGameMode.GM_2ON2_AT:
-        return "rgb(255,99,240)";
 
       case EGameMode.GM_4ON4:
         return "rgb(237, 0, 8)";
@@ -82,23 +79,26 @@ export default class ActivityPerDayChart extends Vue {
       case EGameMode.GM_FFA:
         return "rgb(255,114,20)";
 
-      case EGameMode.GM_4ON4_AT:
-        return "rgb(21, 189, 124)";
-
       case EGameMode.GM_LEGION_4v4_X20:
         return "rgb(191, 121, 0)";
 
       case EGameMode.GM_LEGION_1v1_x20:
         return "rgb(13, 13, 189)";
 
-      case EGameMode.GM_LEGION_4v4_X20_AT:
-        return "rgb(58, 58, 186)";
+      case EGameMode.GM_LEGION_2v2_X20:
+        return "rgb(255,99,240)";
 
       case EGameMode.GM_ROC_1ON1:
         return "rgb(120, 0, 4)";
 
+      case EGameMode.GM_RH_1ON1:
+        return "rgb(21, 189, 124)";
+
+      case EGameMode.GM_BANJOBALL_4ON4:
+        return "rgb(58, 58, 186)";
+
       default:
-        return "rgba(54, 162, 235, 1)";
+        return "rgb(54, 162, 235)";
     }
   }
 
@@ -113,17 +113,11 @@ export default class ActivityPerDayChart extends Vue {
       case EGameMode.GM_2ON2:
         return 2;
 
-      case EGameMode.GM_2ON2_AT:
-        return 2;
-
       case EGameMode.GM_4ON4:
         return 4;
 
       case EGameMode.GM_FFA:
         return 2;
-
-      case EGameMode.GM_4ON4_AT:
-        return 4;
 
       case EGameMode.GM_LEGION_4v4_X20:
         return 4;
@@ -134,13 +128,10 @@ export default class ActivityPerDayChart extends Vue {
       case EGameMode.GM_LEGION_2v2_X20:
         return 2;
 
-      case EGameMode.GM_LEGION_4v4_X20_AT:
-        return 4;
-
       case EGameMode.GM_ROC_1ON1:
         return 1;
 
-      case EGameMode.GM_LTW_1ON1:
+      case EGameMode.GM_RH_1ON1:
         return 1;
 
       case EGameMode.GM_BANJOBALL_4ON4:

--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -31,9 +31,9 @@ export default class ActivityPerDayChart extends Vue {
       datasets: this.gameDays
         .filter((c) => {
           // Filter out all game modes that are not present in enum "EGameMode"
-          // and gameMode 6 as it is 2v2 AT which has been merged with 2v2 RT
+          // and other old game modes.
           return (
-            Object.values(EGameMode).includes(c.gameMode) && c.gameMode !== 6
+            Object.values(EGameMode).includes(c.gameMode) && !this.disabledGameModes.includes(c.gameMode)
           );
         })
         // then only show the data that user selected
@@ -60,6 +60,16 @@ export default class ActivityPerDayChart extends Vue {
           };
         }),
     };
+  }
+
+  get disabledGameModes(): Array<number> {
+    return [
+      EGameMode.GM_2ON2_AT,
+      EGameMode.GM_4ON4_AT,
+      EGameMode.GM_LEGION_4v4_X20_AT,
+      EGameMode.GM_LTW_1ON1,
+      EGameMode.GM_FROSTCRAFT_4ON4
+    ];
   }
 
   private mapColor(gameMode: EGameMode) {

--- a/src/components/overall-statistics/tabs/HeroTab.vue
+++ b/src/components/overall-statistics/tabs/HeroTab.vue
@@ -12,6 +12,7 @@
       <v-col cols="12" md="2">
         <v-card-text>
           <v-select
+            v-model="selectedHeroesPlayedMode"
             :items="gameModes"
             item-text="modeName"
             item-value="modeId"
@@ -20,6 +21,7 @@
             outlined
           />
           <v-select
+            v-model="selectedHeroesPlayedPick"
             :items="picks"
             item-text="pickName"
             item-value="pickId"

--- a/src/components/overall-statistics/tabs/PlayerActivityTab.vue
+++ b/src/components/overall-statistics/tabs/PlayerActivityTab.vue
@@ -6,6 +6,7 @@
         <v-col cols="12" md="2">
           <v-card-text>
             <v-select
+              v-model="selectedGamesPerDayMode"
               :items="gameModesWithAll"
               item-text="modeName"
               item-value="modeId"
@@ -63,6 +64,7 @@
       <v-col cols="12" md="2">
         <v-card-text>
           <v-select
+            v-model="selectedModeForMaps"
             :items="gameModes"
             item-text="modeName"
             item-value="modeId"
@@ -75,6 +77,7 @@
             outlined
           />
           <v-select
+            v-model="selectedSeasonForMaps"
             :items="seasons"
             item-text="id"
             item-value="id"
@@ -107,6 +110,7 @@
       <v-col cols="12" md="2">
         <v-card-text>
           <v-select
+          v-model="selectedPopularHourMode"
             :items="gameModes"
             item-text="modeName"
             item-value="modeId"
@@ -139,6 +143,7 @@
       <v-col cols="12" md="2">
         <v-card-text>
           <v-select
+            v-model="selectedLengthMode"
             :items="gameModes"
             item-text="modeName"
             item-value="modeId"

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -4,6 +4,7 @@
       <v-col cols="md-4">
         <v-card-text>
           <v-select
+            v-model="selectedMap"
             :items="maps"
             item-text="mapName"
             item-value="mapId"
@@ -14,6 +15,7 @@
             outlined
           />
           <v-select
+            v-model="selectedMmr"
             :items="mmrs"
             item-text="league"
             item-value="mmr"

--- a/src/scss/shared/overrides.scss
+++ b/src/scss/shared/overrides.scss
@@ -199,3 +199,12 @@ h3 {
 .w3app {
   overflow-y: hidden;
 }
+
+// Set cursor to 'pointer' instead of 'text' in dropdown menus.
+.v-select {
+  .v-select__selections {
+    input {
+      cursor: pointer;
+    }
+  }
+}


### PR DESCRIPTION
- Filter out old game modes from GAMES PER DAY chart
- Update colors on legends on GAMES PER DAY chart
- Set dropdown to accurately reflect what's being shown in charts, before changing the value in the dropdown
- Set cursor to 'pointer' instead of 'text' when hovering over the dropdown menu

Before change:
![image](https://user-images.githubusercontent.com/21004208/184874309-53c21fb4-26b5-439a-841e-3c9ae6602757.png)
After change:
![image](https://user-images.githubusercontent.com/21004208/184874723-2e149d96-fb3b-43f7-98ec-2e156ff751ac.png)

Before change:
![image](https://user-images.githubusercontent.com/21004208/184874835-c9409e2e-a719-4141-9554-7e9787eeb463.png)
After change:
![image](https://user-images.githubusercontent.com/21004208/184874956-40d1bd26-ef03-494d-b624-5b1e5652dc61.png)

And the same goes for other dropdowns in the statistics tab.