### PR TITLE
[W3C-1] Player global search

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chart.js": "^2.9.4",
     "chartjs-plugin-annotation": "^0.5.7",
     "core-js": "^3.20.3",
+    "debounce": "^1.2.1",
     "direct-vuex": "^0.12.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@types/chart.js": "^2.9.35",
     "@types/chartjs-plugin-annotation": "^0.5.2",
+    "@types/debounce": "^1.2.1",
     "@types/google-spreadsheet": "^3.1.5",
     "@types/lodash": "^4.14.178",
     "@types/prosemirror-inputrules": "^1.0.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -77,6 +77,8 @@
         <v-divider vertical />
       </span>
 
+      <global-search />
+
       <v-btn text tile @click="loginOrGoToProfile" v-if="!authCode">
         <v-icon v-if="!authCode" class="mr-2">
           mdi-account-circle-outline
@@ -166,6 +168,7 @@ import SignInDialog from "@/components/common/SignInDialog.vue";
 import { BnetOAuthRegion } from "./store/oauth/types";
 import localeIcon from "@/components/common/LocaleIcon.vue";
 import BrandLogo from "@/components/common/BrandLogo.vue";
+import GlobalSearch from "@/components/common/GlobalSearch.vue";
 
 export type ItemType = {
   title: string;
@@ -174,7 +177,7 @@ export type ItemType = {
   class?: string;
 };
 
-@Component({ components: { BrandLogo, SignInDialog, localeIcon } })
+@Component({ components: { BrandLogo, SignInDialog, localeIcon, GlobalSearch } })
 export default class App extends Vue {
   private _savedLocale = "en";
   private selectedTheme = "human";

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -1,0 +1,163 @@
+<template>
+  <v-menu
+    content-class="global-search"
+    bottom
+    offset-y
+    transition="slide-y-transition"
+    v-model="menuOpened"
+    :nudge-bottom="10"
+    :nudge-width="300"
+    :close-on-content-click="false"
+  >
+    <template v-slot:activator="{ on }">
+      <v-btn text tile v-on="on">
+        <v-icon class="mr-2">
+          mdi-magnify
+        </v-icon>
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-title class="autocomplete-wrapper px-2 pb-2 pt-0">
+        <v-autocomplete
+          v-model="searchModel"
+          append-icon="mdi-magnify"
+          label="Search"
+          single-line
+          clearable
+          autofocus
+          :placeholder="$t(`views_rankings.searchPlaceholder`)"
+          return-object
+          :search-input.sync="search"
+          :no-data-text="noDataText"
+          :loading="isLoading"
+          :items="players"
+          item-text="id"
+          item-value="id"
+        >
+          <template v-slot:item="data">
+            <v-list-item-avatar>
+              <img :src="getPlayerAvatarUrl(data.item)" />
+            </v-list-item-avatar>
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ data.item.id }}
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                <div
+                  v-for="season in data.item.seasons"
+                  :key="season.id"
+                  class="mr-1 mt-1 d-inline-block"
+                >
+                  <season-badge :season="season" />
+                </div>
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </template>
+        </v-autocomplete>
+      </v-card-title>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Watch } from "vue-property-decorator";
+import { debounce } from "debounce";
+import { getAvatarUrl, getProfileUrl } from "@/helpers/url-functions";
+import SeasonBadge from "@/components/player/SeasonBadge.vue";
+import { PlayerSearchData } from "@/store/globalSearch/types";
+import { EAvatarCategory } from "@/store/typings";
+
+@Component({
+  components: {
+    SeasonBadge,
+  }
+})
+export default class GlobalSearch extends Vue {
+  public searchModel: PlayerSearchData = {} as PlayerSearchData;
+  public search = "";
+  public isLoading = false;
+  public menuOpened = false;
+
+  private static DEFAULT_AVATAR = {
+    race: EAvatarCategory.TOTAL,
+    pictureId: 0,
+    isClassic: false,
+  };
+
+  private static SEARCH_DELAY = 500;
+
+  private debouncedSearch = debounce((searchValue: string) => {
+    this.$store.direct.dispatch.globalSearch.search(searchValue);
+  }, GlobalSearch.SEARCH_DELAY);
+
+  // Handler when selecting a player from the list
+  @Watch("searchModel")
+  public onSearchModelChanged(player: PlayerSearchData) {
+    // We cleared the input, ignore
+    if (!player?.id) return;
+
+    // Nativate to the selected player's profile
+    this.$router.push({
+      path: getProfileUrl(player.id),
+    });
+
+    // Since the global search is present on all pages, we need to manually close it
+    this.menuOpened = false;
+
+    // Reset the global search state
+    this.$store.direct.dispatch.globalSearch.clearSearch();
+    this.searchModel = {} as PlayerSearchData;
+  }
+
+  @Watch("search")
+  public onSearchChanged(searchValue: string) {
+    if (searchValue && searchValue.length >= 3) {
+      this.isLoading = true;
+      this.debouncedSearch(searchValue);
+    } else {
+      this.$store.direct.dispatch.globalSearch.clearSearch();
+      this.isLoading = false;
+      // Prevent previous calls from executing
+      this.debouncedSearch.clear();
+    }
+  }
+
+  get noDataText(): string {
+    if (!this.search || this.search.length < 3) {
+      return "Type at least 3 letters";
+    }
+    if (this.isLoading) {
+      return "Loading..."
+    }
+
+    return "No player found";
+  }
+
+  getPlayerAvatarUrl(player: PlayerSearchData) {
+    const pfp = player.personalSetting?.profilePicture ?? GlobalSearch.DEFAULT_AVATAR;
+    
+    return getAvatarUrl(pfp.race, pfp.pictureId, pfp.isClassic);
+  }
+
+  get players(): PlayerSearchData[] {
+    return this.$store.direct.state.globalSearch.players;
+  }
+
+  @Watch("players")
+  public onPlayersChanged() {
+    // If the players array has changed it means the global search request finished
+    this.isLoading = false;
+  }
+}
+</script>
+
+<style lang="scss">
+.global-search {
+  .autocomplete-wrapper {
+    .v-text-field__details {
+      display: none;
+    }
+  }
+}
+</style>

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -79,12 +79,6 @@ export default class GlobalSearch extends Vue {
   public isLoading = false;
   public menuOpened = false;
 
-  private static DEFAULT_AVATAR = {
-    race: EAvatarCategory.TOTAL,
-    pictureId: 0,
-    isClassic: false,
-  };
-
   private static SEARCH_DELAY = 500;
 
   private debouncedSearch = debounce((searchValue: string) => {
@@ -135,7 +129,7 @@ export default class GlobalSearch extends Vue {
   }
 
   getPlayerAvatarUrl(player: PlayerSearchData) {
-    const pfp = player.personalSetting?.profilePicture ?? GlobalSearch.DEFAULT_AVATAR;
+    const pfp = player.profilePicture;
     
     return getAvatarUrl(pfp.race, pfp.pictureId, pfp.isClassic);
   }

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -5,7 +5,7 @@
     offset-y
     transition="slide-y-transition"
     v-model="menuOpened"
-    :nudge-bottom="10"
+    :nudge-bottom="18"
     :nudge-width="300"
     :close-on-content-click="false"
   >

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -66,7 +66,6 @@ import { debounce } from "debounce";
 import { getAvatarUrl, getProfileUrl } from "@/helpers/url-functions";
 import SeasonBadge from "@/components/player/SeasonBadge.vue";
 import { PlayerSearchData } from "@/store/globalSearch/types";
-import { EAvatarCategory } from "@/store/typings";
 
 @Component({
   components: {

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -167,6 +167,7 @@ export default class GlobalSearch extends Vue {
 
 <style lang="scss">
 .global-search {
+  z-index: 1000 !important;
   .autocomplete-wrapper {
     .v-text-field__details {
       display: none;

--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -31,8 +31,8 @@
           :no-data-text="noDataText"
           :loading="isLoading"
           :items="players"
-          item-text="id"
-          item-value="id"
+          item-text="battleTag"
+          item-value="battleTag"
         >
           <template v-slot:item="data">
             <v-list-item-avatar>
@@ -40,7 +40,7 @@
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title>
-                {{ data.item.id }}
+                {{ data.item.battleTag }}
               </v-list-item-title>
               <v-list-item-subtitle>
                 <div
@@ -95,11 +95,11 @@ export default class GlobalSearch extends Vue {
   @Watch("searchModel")
   public onSearchModelChanged(player: PlayerSearchData) {
     // We cleared the input, ignore
-    if (!player?.id) return;
+    if (!player?.battleTag) return;
 
     // Nativate to the selected player's profile
     this.$router.push({
-      path: getProfileUrl(player.id),
+      path: getProfileUrl(player.battleTag),
     });
 
     // Since the global search is present on all pages, we need to manually close it

--- a/src/services/GlobalSearchService.ts
+++ b/src/services/GlobalSearchService.ts
@@ -2,8 +2,14 @@ import { API_URL } from "@/main";
 import { PlayerSearchData } from "@/store/globalSearch/types";
 
 export default class GlobalSearchService {
-  public async search(search: string): Promise<PlayerSearchData[]> {
-    const url = `${API_URL}api/players/global_search?search=${encodeURIComponent(search)}`;
+  // search: the string to search by
+  // lastPlayerId: the last id in the currently loaded list (used for pagination)
+  // pageSize: the number of players to fetch at a time
+  public async search(search: string, lastPlayerId: string, pageSize: number): Promise<PlayerSearchData[]> {
+    let url = `${API_URL}api/players/global_search?search=${encodeURIComponent(search)}&pageSize=${pageSize}`;
+    if (lastPlayerId) {
+      url += `&lastObjectId=${encodeURIComponent(lastPlayerId)}`;
+    }
 
     const players = await fetch(url).then(response => response.json())
 

--- a/src/services/GlobalSearchService.ts
+++ b/src/services/GlobalSearchService.ts
@@ -5,14 +5,7 @@ export default class GlobalSearchService {
   public async search(search: string): Promise<PlayerSearchData[]> {
     const url = `${API_URL}api/players/global_search?search=${encodeURIComponent(search)}`;
 
-    const players = await fetch(url)
-      .then(response => response.json())
-      .then(players => players.map((player: any) => ({
-        id: player.battleTag,
-        name: player.name,
-        seasons: player.participatedInSeasons.slice(0, 3),
-        personalSetting: player.personalSettings[0],
-      })));
+    const players = await fetch(url).then(response => response.json())
 
     return await players;
   }

--- a/src/services/GlobalSearchService.ts
+++ b/src/services/GlobalSearchService.ts
@@ -1,0 +1,19 @@
+import { API_URL } from "@/main";
+import { PlayerSearchData } from "@/store/globalSearch/types";
+
+export default class GlobalSearchService {
+  public async search(search: string): Promise<PlayerSearchData[]> {
+    const url = `${API_URL}api/players/global_search?search=${encodeURIComponent(search)}`;
+
+    const players = await fetch(url)
+      .then(response => response.json())
+      .then(players => players.map((player: any) => ({
+        id: player.battleTag,
+        name: player.name,
+        seasons: player.participatedInSeasons.slice(0, 3),
+        personalSetting: player.personalSettings[0],
+      })));
+
+    return await players;
+  }
+}

--- a/src/services/GlobalSearchService.ts
+++ b/src/services/GlobalSearchService.ts
@@ -6,7 +6,7 @@ export default class GlobalSearchService {
   // lastPlayerId: the last id in the currently loaded list (used for pagination)
   // pageSize: the number of players to fetch at a time
   public async search(search: string, lastPlayerId: string, pageSize: number): Promise<PlayerSearchData[]> {
-    let url = `${API_URL}api/players/global_search?search=${encodeURIComponent(search)}&pageSize=${pageSize}`;
+    let url = `${API_URL}api/players/global-search?search=${encodeURIComponent(search)}&pageSize=${pageSize}`;
     if (lastPlayerId) {
       url += `&lastObjectId=${encodeURIComponent(lastPlayerId)}`;
     }

--- a/src/store/globalSearch/index.ts
+++ b/src/store/globalSearch/index.ts
@@ -1,0 +1,37 @@
+import { moduleActionContext } from "..";
+import { GlobalSearchState, PlayerSearchData } from "./types";
+import { RootState } from "../typings";
+import { ActionContext } from "vuex";
+
+const mod = {
+  namespaced: true,
+  state: {
+    players: [],
+  } as GlobalSearchState,
+  actions: {
+    async search(
+      context: ActionContext<GlobalSearchState, RootState>,
+      searchText: string,
+    ) {
+      const { commit, rootGetters } = moduleActionContext(
+        context,
+        mod
+      );
+
+      const players = await rootGetters.globalSearchService.search(searchText);
+
+      commit.SET_PLAYERS(players);
+    },
+    async clearSearch(context: ActionContext<GlobalSearchState, RootState>) {
+      const { commit } = moduleActionContext(context, mod);
+      commit.SET_PLAYERS([]);
+    },
+  },
+  mutations: {
+    SET_PLAYERS(state: GlobalSearchState, players: PlayerSearchData[]) {
+      state.players = players;
+    },
+  },
+} as const;
+
+export default mod;

--- a/src/store/globalSearch/index.ts
+++ b/src/store/globalSearch/index.ts
@@ -3,33 +3,42 @@ import { GlobalSearchState, PlayerSearchData } from "./types";
 import { RootState } from "../typings";
 import { ActionContext } from "vuex";
 
+const PAGE_SIZE = 20;
+
 const mod = {
   namespaced: true,
   state: {
     players: [],
+    hasMore: false,
   } as GlobalSearchState,
   actions: {
     async search(
       context: ActionContext<GlobalSearchState, RootState>,
-      searchText: string,
+      search: { searchText: string; append: boolean },
     ) {
-      const { commit, rootGetters } = moduleActionContext(
+      const { state, commit, rootGetters } = moduleActionContext(
         context,
         mod
       );
 
-      const players = await rootGetters.globalSearchService.search(searchText);
+      const lastPlayerId = search.append && state.players.length > 0 ? state.players[state.players.length - 1].battleTag : '';
+      const players = await rootGetters.globalSearchService.search(search.searchText, lastPlayerId, PAGE_SIZE);
 
-      commit.SET_PLAYERS(players);
+      commit.SET_PLAYERS({ players, append: search.append });
     },
     async clearSearch(context: ActionContext<GlobalSearchState, RootState>) {
       const { commit } = moduleActionContext(context, mod);
-      commit.SET_PLAYERS([]);
+      commit.SET_PLAYERS({ players: [], append: false });
     },
   },
   mutations: {
-    SET_PLAYERS(state: GlobalSearchState, players: PlayerSearchData[]) {
-      state.players = players;
+    SET_PLAYERS(state: GlobalSearchState, payload: { players: PlayerSearchData[], append: boolean }) {
+      if (payload.append) {
+        state.players = [ ...state.players, ...payload.players ];
+      } else {
+        state.players = payload.players;
+      }
+      state.hasMore = payload.players.length === PAGE_SIZE;
     },
   },
 } as const;

--- a/src/store/globalSearch/types.ts
+++ b/src/store/globalSearch/types.ts
@@ -1,0 +1,16 @@
+import { PersonalSetting } from "@/store/personalSettings/types";
+
+export type GlobalSearchState = {
+  players: PlayerSearchData[];
+};
+
+export type PlayerSearchData = {
+  id: string;
+  name: string;
+  seasons: Season[];
+  personalSetting: PersonalSetting;
+};
+
+export type Season = {
+  id: number;
+};

--- a/src/store/globalSearch/types.ts
+++ b/src/store/globalSearch/types.ts
@@ -1,4 +1,4 @@
-import { PersonalSetting } from "@/store/personalSettings/types";
+import { ProfilePicture } from "@/store/personalSettings/types";
 
 export type GlobalSearchState = {
   players: PlayerSearchData[];
@@ -8,7 +8,7 @@ export type PlayerSearchData = {
   battleTag: string;
   name: string;
   seasons: Season[];
-  personalSetting: PersonalSetting;
+  profilePicture: ProfilePicture;
 };
 
 export type Season = {

--- a/src/store/globalSearch/types.ts
+++ b/src/store/globalSearch/types.ts
@@ -5,7 +5,7 @@ export type GlobalSearchState = {
 };
 
 export type PlayerSearchData = {
-  id: string;
+  battleTag: string;
   name: string;
   seasons: Season[];
   personalSetting: PersonalSetting;

--- a/src/store/globalSearch/types.ts
+++ b/src/store/globalSearch/types.ts
@@ -2,6 +2,8 @@ import { ProfilePicture } from "@/store/personalSettings/types";
 
 export type GlobalSearchState = {
   players: PlayerSearchData[];
+  // False if we fetched all pages of the search
+  hasMore: boolean;
 };
 
 export type PlayerSearchData = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import twitch from "./twitch/index";
 import admin from "./admin/index";
 import rankings from "./ranking/index";
 import infoMessages from "./admin/messages/index";
+import globalSearch from "./globalSearch"
 
 import RankingService from "@/services/RankingService";
 import MatchService from "@/services/MatchService";
@@ -31,6 +32,7 @@ import TournamentsService from "@/services/TournamentsService";
 import LocaleService from "@/services/LocaleService";
 import { OauthState } from "@/store/oauth/types";
 import InfoMessageService from "@/services/InfoMessageService";
+import GlobalSearchService from '@/services/GlobalSearchService';
 
 Vue.use(Vuex);
 
@@ -48,6 +50,7 @@ const services = {
   tournamentsService: new TournamentsService(),
   localeService: new LocaleService(),
   infoMessageService: new InfoMessageService(),
+  globalSearchService: new GlobalSearchService(),
 };
 
 const mod = {
@@ -63,6 +66,7 @@ const mod = {
     admin,
     tournaments,
     infoMessages,
+    globalSearch,
   },
   state: {
     darkMode: false,
@@ -138,6 +142,9 @@ const mod = {
     },
     infoMessageService() {
       return services.infoMessageService;
+    },
+    globalSearchService() {
+      return services.globalSearchService;
     },
   },
 } as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debounce@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.1.tgz#79b65710bc8b6d44094d286aecf38e44f9627852"
+  integrity sha512-epMsEE85fi4lfmJUH/89/iV/LI+F5CvNIvmgs5g5jYFPfhO2S/ae8WSsLOKWdwtoaZw9Q2IhJ4tQ5tFCcS/4HA==
+
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.29"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz#2a1795ea8e9e9c91b4a4bbe475034b20c1ec711c"
@@ -3666,6 +3671,11 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
+
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
Jira issue: https://w3champions.atlassian.net/browse/W3C-1
Github issue: https://github.com/w3champions/website/issues/493

Backend PR: https://github.com/w3champions/website-backend/pull/200

**Changes**

I added a search button on the navbar which opens a search panel that can be used to navigate to player profiles.

<img width="1422" alt="Screenshot 2022-09-01 at 21 11 46" src="https://user-images.githubusercontent.com/6545554/187983956-e3d8cf54-f55b-4ccf-973e-cf42ac76743d.png">

Demo
![w3_champs_global_search](https://user-images.githubusercontent.com/6545554/187984525-60955f11-bd64-423a-a945-4f7816ae0858.gif)

It has pagination
![w3_champs_global_search_pagination](https://user-images.githubusercontent.com/6545554/187984705-5c0fc5d7-102f-48bc-8210-6134185ed19f.gif)
