### PR TITLE
[W3C-119] Improve hero usage chart

### DIFF
--- a/src/components/overall-statistics/PlayedHeroesChart.vue
+++ b/src/components/overall-statistics/PlayedHeroesChart.vue
@@ -1,13 +1,29 @@
 <template>
-  <bar-chart :chart-data="gameHourChartData" />
+  <bar-chart :chart-data="chartData" :chart-options="chartOptions" />
 </template>
 <script lang="ts">
+import Vue from "vue";
+import _ from "lodash";
+import { ChartData } from "chart.js";
 import { Component, Prop } from "vue-property-decorator";
-
 import { PlayedHero } from "@/store/overallStats/types";
 import BarChart from "@/components/overall-statistics/BarChart.vue";
-import { ChartData } from "chart.js";
-import Vue from "vue";
+import { HERO_DATA } from "@/store/heroes";
+import { ERaceEnum } from "@/store/typings";
+
+type PlayedHeroExtra = PlayedHero & {
+  race: ERaceEnum,
+  color: string,
+}
+
+const FILL_OPACITY = "0.5";
+const RACE_COLORS: { [key: string]: string } = {
+  [ERaceEnum.RANDOM]: `rgba(66, 62, 64, ${FILL_OPACITY})`,
+  [ERaceEnum.HUMAN]: `rgba(54, 162, 235, ${FILL_OPACITY})`,
+  [ERaceEnum.ORC]: `rgba(255, 0, 0, ${FILL_OPACITY})`,
+  [ERaceEnum.UNDEAD]: `rgba(151, 0, 165, ${FILL_OPACITY})`,
+  [ERaceEnum.NIGHT_ELF]: `rgba(0, 161, 3, ${FILL_OPACITY})`,
+}
 
 @Component({
   components: { BarChart },
@@ -15,39 +31,82 @@ import Vue from "vue";
 export default class PlayedHeroesChart extends Vue {
   @Prop() public playedHeroes!: PlayedHero[];
 
-  get orderedHeroes(): PlayedHero[] {
-    return this.playedHeroes
-      .map((h) => ({
-        icon: this.$t("heroNames." + h.icon).toString(),
-        count: h.count,
-      }))
-      .sort(this.compare);
+  get orderedHeroes(): PlayedHeroExtra[] {
+    return _
+      .chain(this.playedHeroes)
+      .map(hero => {
+        const race = HERO_DATA[hero.icon].race;
+        const color = RACE_COLORS[race];
+        return {
+          ...hero,
+          race,
+          color,
+        }
+      })
+      .orderBy([ "race", "count", "icon" ], [ "asc", "desc", "asc" ])
+      .groupBy('race')
+      .mapValues((heroes, race) => {
+        // Compute percentages within the race
+        const groupTotalCount = _.sumBy(heroes, 'count');
+        const newHeroesData: PlayedHeroExtra[] = _.map(heroes, hero => ({
+          ...hero,
+          icon: this.$t("heroNames." + hero.icon).toString(),
+          count: _.round(hero.count / groupTotalCount * 100, 1),
+        }));
+
+        // Add empty data point between races
+        if (+race !== ERaceEnum.RANDOM) {
+          newHeroesData.unshift({ icon: '', count: 0, race: ERaceEnum.RANDOM, color: "" });
+        }
+
+        return newHeroesData;
+      })
+      .toArray()
+      .flatten()
+      .value();
   }
 
-  private compare(a: PlayedHero, b: PlayedHero) {
-    if (a.icon < b.icon) {
-      return -1;
-    }
-    return 1;
-  }
-
-  get gameHourChartData(): ChartData {
+  get chartData(): ChartData {
     return {
-      labels: this.orderedHeroes.map((p) => p.icon),
+      labels: this.orderedHeroes.map((p: PlayedHero) => p.icon),
       datasets: [
         {
-          label: String(
-            this.$t(
-              "components_overall-statistics_playedheroeschart.playedheroes"
-            )
-          ),
-          data: this.orderedHeroes.map((p) => p.count),
-          backgroundColor: "rgba(54, 162, 235, 0.2)",
-          borderColor: "rgba(54, 162, 235, 1)",
+          data: this.orderedHeroes.map((p: PlayedHero) => p.count),
+          backgroundColor: this.orderedHeroes.map(p => p.color),
           borderWidth: 1,
         },
       ],
     };
+  }
+
+  get chartOptions() {
+    return {
+      legend: {
+        display: false,
+      },
+      tooltips: {
+        displayColors: false,
+        callbacks: {
+          label: (tooltipItem: { xLabel: string; yLabel: string }) => (
+            `${tooltipItem.xLabel} - ${tooltipItem.yLabel}%`
+          ),
+          title: () => "",
+        },
+      },
+      maintainAspectRatio: false,
+      scales: {
+        yAxes: [
+          {
+            ticks: {
+              beginAtZero: true,
+              callback: function (value: number) {
+                return value + '%';
+              },
+            },
+          },
+        ],
+      },
+    }
   }
 }
 </script>

--- a/src/store/heroes.ts
+++ b/src/store/heroes.ts
@@ -1,0 +1,113 @@
+import { ERaceEnum } from './typings'
+
+export enum EHeroes {
+  ARCHMAGE = 'archmage',
+  ALCHEMIST = 'alchemist',
+  FIRELORD = 'avatarofflame',
+  DARK_RANGER = 'bansheeranger',
+  BEASTMASTER = 'beastmaster',
+  BLADEMASTER = 'blademaster',
+  CRYPT_LORD = 'cryptlord',
+  DEATH_KNIGHT = 'deathknight',
+  DEMON_HUNTER = 'demonhunter',
+  DREAD_LORD = 'dreadlord',
+  FARSEER = 'farseer',
+  KEEPER_OF_THE_GROVE = 'keeperofthegrove',
+  LICH = 'lich',
+  MOUNTAIN_KING = 'mountainking',
+  PALADIN = 'paladin',
+  PANDAREN_BREWMASTER = 'pandarenbrewmaster',
+  PIT_LORD = 'pitlord',
+  PRIESTESS_OF_THE_MOON = 'priestessofthemoon',
+  NAGA_SEA_WITCH = 'seawitch',
+  SHADOW_HUNTER = 'shadowhunter',
+  BLOODMAGE = 'sorceror',
+  TAUREN_CHEFTAIN = 'taurenchieftain',
+  TINKER = 'tinker',
+  WARDEN = 'warden',
+}
+
+export type HeroData = {
+  [key: string]: {
+    race: ERaceEnum
+  };
+}
+
+export const HERO_DATA: HeroData = {
+  [EHeroes.ARCHMAGE]: {
+    race: ERaceEnum.HUMAN,
+  },
+  [EHeroes.BLOODMAGE]: {
+    race: ERaceEnum.HUMAN,
+  },
+  [EHeroes.MOUNTAIN_KING]: {
+    race: ERaceEnum.HUMAN,
+  },
+  [EHeroes.PALADIN]: {
+    race: ERaceEnum.HUMAN,
+  },
+
+  [EHeroes.BLADEMASTER]: {
+    race: ERaceEnum.ORC,
+  },
+  [EHeroes.FARSEER]: {
+    race: ERaceEnum.ORC,
+  },
+  [EHeroes.SHADOW_HUNTER]: {
+    race: ERaceEnum.ORC,
+  },
+  [EHeroes.TAUREN_CHEFTAIN]: {
+    race: ERaceEnum.ORC,
+  },
+
+  [EHeroes.CRYPT_LORD]: {
+    race: ERaceEnum.UNDEAD,
+  },
+  [EHeroes.DEATH_KNIGHT]: {
+    race: ERaceEnum.UNDEAD,
+  },
+  [EHeroes.DREAD_LORD]: {
+    race: ERaceEnum.UNDEAD,
+  },
+  [EHeroes.LICH]: {
+    race: ERaceEnum.UNDEAD,
+  },
+
+  [EHeroes.DEMON_HUNTER]: {
+    race: ERaceEnum.NIGHT_ELF,
+  },
+  [EHeroes.KEEPER_OF_THE_GROVE]: {
+    race: ERaceEnum.NIGHT_ELF,
+  },
+  [EHeroes.PRIESTESS_OF_THE_MOON]: {
+    race: ERaceEnum.NIGHT_ELF,
+  },
+  [EHeroes.WARDEN]: {
+    race: ERaceEnum.NIGHT_ELF,
+  },
+
+  [EHeroes.ALCHEMIST]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.FIRELORD]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.DARK_RANGER]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.BEASTMASTER]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.PANDAREN_BREWMASTER]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.PIT_LORD]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.NAGA_SEA_WITCH]: {
+    race: ERaceEnum.RANDOM,
+  },
+  [EHeroes.TINKER]: {
+    race: ERaceEnum.RANDOM,
+  },
+}


### PR DESCRIPTION
Jira issue: https://w3champions.atlassian.net/browse/W3C-119
Github issue: https://github.com/w3champions/website/issues/216

**Changes**
* Grouped heroes by races
* Assigned colors by races

**Before**
<img width="1142" alt="Screenshot 2022-09-03 at 14 55 44" src="https://user-images.githubusercontent.com/6545554/188269403-1f16903a-bfb3-4b5e-9201-0e0bac3428df.png">

**After**
<img width="1147" alt="Screenshot 2022-09-03 at 14 53 14" src="https://user-images.githubusercontent.com/6545554/188269407-a2df1b85-51db-4806-be8a-234bf6938732.png">
<img width="1142" alt="Screenshot 2022-09-03 at 14 53 52" src="https://user-images.githubusercontent.com/6545554/188269412-f1d4441d-617a-4092-b1b5-b666281f6fe8.png">
