### PR TITLE
[W3C-27] Add Random to win rates table

### DIFF
--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -74,6 +74,12 @@
                     :winThreshold="0.51"
                     :lossThreshold="0.49"
                   />
+                  <player-stats-race-versus-race-on-map-table-cell
+                    :stats="item.winLosses[0]"
+                    :compareRace="item.race"
+                    :winThreshold="0.51"
+                    :lossThreshold="0.49"
+                  />
                 </tr>
               </tbody>
             </template>
@@ -132,6 +138,11 @@ export default class WinratesTab extends Vue {
         align: "start",
         sortable: false,
       },
+      {
+        text: this.$t("components_overall-statistics_tabs_winratestab.vsrdm"),
+        align: "start",
+        sortable: false,
+      },
     ];
   }
 
@@ -172,7 +183,7 @@ export default class WinratesTab extends Vue {
     if (!statsPerMapAndRace) {
       return [];
     }
-    return statsPerMapAndRace.ratio.slice(1, 5);
+    return statsPerMapAndRace.ratio.slice(1, 5).concat(statsPerMapAndRace.ratio[0]);
   }
 
   public setSelectedMap(map: string) {

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -43,7 +43,7 @@
           <v-data-table
             hide-default-footer
             :headers="headers"
-            :items="raceWinrateWithoutRandom"
+            :items="raceWinrate"
             :mobile-breakpoint="400"
           >
             <template v-slot:body="{ items }">
@@ -166,7 +166,7 @@ export default class WinratesTab extends Vue {
     });
   }
 
-  get raceWinrateWithoutRandom(): Ratio[] {
+  get raceWinrate(): Ratio[] {
     if (
       !this.statsPerRaceAndMap ||
       !this.statsPerRaceAndMap[0] ||

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -13,6 +13,7 @@
 
 <script lang="ts">
 import Vue from "vue";
+import _ from "lodash";
 import { Component, Prop } from "vue-property-decorator";
 import { RaceWinLoss } from "@/store/overallStats/types";
 import { ERaceEnum } from "@/store/typings";
@@ -57,7 +58,7 @@ export default class PlayerStatsRaceVersusRaceOnMapTableCell extends Vue {
   }
 
   get isComparingSameRace() {
-    if (!this.compareRace || !this.stats) {
+    if (_.isNil(this.compareRace) || !this.stats) {
       return false;
     }
 

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -58,6 +58,7 @@ export default class PlayerStatsRaceVersusRaceOnMapTableCell extends Vue {
   }
 
   get isComparingSameRace() {
+    // We must explicitly check nil here because compareRace could be RANDOM and !0 is true
     if (_.isNil(this.compareRace) || !this.stats) {
       return false;
     }

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -326,6 +326,7 @@ const data = {
       vsorc: "vs Orc",
       vsud: "vs Undead",
       vsne: "vs Night Elf",
+      vsrdm: "vs Random",
     },
     "components_overall-statistics_gamelengthchart": {
       amountofgames: "amount of games",

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -53,7 +53,6 @@ import GameLengthChart from "@/components/overall-statistics/GameLengthChart.vue
 import PopularGameTimeChart from "@/components/overall-statistics/PopularGameTimeChart.vue";
 import PlayedHeroesChart from "@/components/overall-statistics/PlayedHeroesChart.vue";
 import HeroWinrate from "@/components/overall-statistics/HeroWinrate.vue";
-import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
 import MmrDistributionChart from "@/components/overall-statistics/MmrDistributionChart.vue";
 import { SeasonGameModeGateWayForMMR } from "@/store/overallStats/types";
 import { Season } from "@/store/ranking/types";
@@ -66,7 +65,6 @@ import { Season } from "@/store/ranking/types";
     PopularGameTimeChart,
     AmountPerDayChart,
     GameLengthChart,
-    PlayerStatsRaceVersusRaceOnMapTableCell,
   },
 })
 export default class OverallStatisticsView extends Vue {


### PR DESCRIPTION
Jira issue: https://w3champions.atlassian.net/browse/W3C-27

**Changes**

We now also display the win rates with and against random.

I added a new string in the localization document. I only added the English version.
<img width="1371" alt="Screenshot 2022-09-05 at 11 25 19" src="https://user-images.githubusercontent.com/6545554/188407060-f791a311-d583-4837-a24f-462199bbe126.png">

**Before**
<img width="1143" alt="Screenshot 2022-09-05 at 00 31 53" src="https://user-images.githubusercontent.com/6545554/188406592-4a96face-ac7d-452a-b37c-a6bd8f30864d.png">

**After**
<img width="1140" alt="Screenshot 2022-09-05 at 00 35 29" src="https://user-images.githubusercontent.com/6545554/188406618-5f67025d-4a36-400b-a811-e5aac9b6ecd2.png">
