### PR TITLE
Round ranking points to 3 decimals

### DIFF
--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -125,7 +125,7 @@
           <td class="number-text text-end">{{ item.player.games }}</td>
           <td class="number-text text-end">{{ (item.player.winrate * 100).toFixed(1) }}%</td>
           <td class="number-text text-end">{{ item.player.mmr }}</td>
-          <td class="number-text text-end">{{ item.rankingPoints }}</td>
+          <td class="number-text text-end">{{ Math.round(item.rankingPoints * 1000) / 1000 }}</td>
         </tr>
       </tbody>
     </table>

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -42,7 +42,7 @@
           </td>
           <td class="number-text text-center">
             <span v-if="is2v2(item) && item.rank !== 0"></span>
-            {{ item.rank !== 0 ? item.rankingPoints : "-" }}
+            {{ item.rank !== 0 ? Math.round(item.rankingPoints * 1000) / 1000 : "-" }}
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Temporary fix for Ranking Points until a component showing the level in a nicer way.

Before:
![image](https://user-images.githubusercontent.com/21004208/197245074-73b949e7-3f7e-4ed7-b549-1037c3a8fd8c.png)

After:
![image](https://user-images.githubusercontent.com/21004208/197245164-43f36568-f965-4680-bf31-c9ba23e2c805.png)
