### PR TITLE
W3c 188/two backend requests on ranking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -337,7 +337,6 @@ export default class App extends Vue {
     this.$store.direct.dispatch.loadLocale();
     this.$i18n.locale = this.savedLocale;
     await this.$store.direct.dispatch.oauth.loadAuthCodeToState();
-    await this.$store.direct.dispatch.rankings.retrieveSeasons();
     if (this.authCode) {
       await this.$store.direct.dispatch.oauth.loadBlizzardBtag(this.authCode);
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -82,6 +82,10 @@ const mod = {
       rootGetters.localeService.setLocale(locale);
       commit.SET_LOCALE(locale);
     },
+    setGateway(context: ActionContext<OauthState, RootState>, gateway: Gateways) {
+      const { commit } = moduleActionContext(context, mod);
+      commit.SET_GATEWAY(gateway);
+    }
   },
   mutations: {
     SET_DARK_MODE(state: RootState, darkMode: boolean) {

--- a/src/store/ranking/index.ts
+++ b/src/store/ranking/index.ts
@@ -113,7 +113,6 @@ const mod = {
       commit.SET_SELECTED_SEASON(season);
 
       await dispatch.retrieveLeagueConstellation();
-      await dispatch.retrieveRankings(undefined);
     },
     async setCountry(
       context: ActionContext<RankingState, RootState>,

--- a/src/store/ranking/index.ts
+++ b/src/store/ranking/index.ts
@@ -97,22 +97,19 @@ const mod = {
       const { commit } = moduleActionContext(context, mod);
       commit.SET_SEARCH_RANKINGS([]);
     },
-    async setLeague(
+    setLeague(
       context: ActionContext<RankingState, RootState>,
       league: number
     ) {
       const { commit, dispatch } = moduleActionContext(context, mod);
       commit.SET_LEAGUE(league);
-      await dispatch.retrieveRankings(undefined);
     },
-    async setSeason(
+    setSeason(
       context: ActionContext<RankingState, RootState>,
       season: Season
     ) {
-      const { commit, dispatch } = moduleActionContext(context, mod);
+      const { commit } = moduleActionContext(context, mod);
       commit.SET_SELECTED_SEASON(season);
-
-      await dispatch.retrieveLeagueConstellation();
     },
     async setCountry(
       context: ActionContext<RankingState, RootState>,

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -301,8 +301,7 @@ export default class CountryRankingsView extends Vue {
   }
 
   async selectSeason(season: Season) {
-    await this.$store.direct.dispatch.rankings.setSeason(season);
-    await this.$store.direct.dispatch.rankings.setLeague(0);
+    this.$store.direct.dispatch.rankings.setSeason(season);
     this.refreshRankings();
   }
 

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -353,28 +353,29 @@ export default class RankingsView extends Vue {
   async mounted() {
     this.search = "";
 
+    await this.$store.direct.dispatch.rankings.retrieveSeasons();
+
     if (this.season) {
-      this.$store.direct.commit.rankings.SET_SELECTED_SEASON({
-        id: this.season,
-      });
-    } else {
-      await this.$store.direct.dispatch.rankings.retrieveSeasons();
+      this.$store.direct.dispatch.rankings.setSeason({id: this.season} as Season);
     }
     if (this.league) {
-      await this.$store.direct.dispatch.rankings.setLeague(this.league);
+      this.$store.direct.dispatch.rankings.setLeague(this.league);
     }
     if (this.gamemode) {
-      this.$store.direct.commit.rankings.SET_GAME_MODE(this.gamemode);
+      this.$store.direct.dispatch.rankings.setGameMode(this.gamemode);
     }
     if (this.gateway) {
-      this.$store.direct.commit.SET_GATEWAY(this.gateway);
+      this.$store.direct.dispatch.setGateway(this.gateway);
     }
 
-    await this.refreshRankings();
+    await this.loadOngoingMatches();
+    await this.getLadders();
 
     if (this.ladders && !this.selectedLeague?.id) {
-      await this.$store.direct.dispatch.rankings.setLeague(this.ladders[0].id);
+      this.$store.direct.dispatch.rankings.setLeague(this.ladders[0].id);
     }
+
+    await this.getRankings();
 
     if (this.playerId) {
       const selectedPlayer = this.rankings.find(
@@ -434,12 +435,14 @@ export default class RankingsView extends Vue {
   }
 
   public async selectSeason(season: Season) {
-    await this.$store.direct.dispatch.rankings.setSeason(season);
-    await this.$store.direct.dispatch.rankings.setLeague(0);
+    this.$store.direct.dispatch.rankings.setSeason(season);
+    await this.getLadders();
+    await this.setLeague(0);
   }
 
   public async setLeague(league: number) {
-    await this.$store.direct.dispatch.rankings.setLeague(league);
+    this.$store.direct.dispatch.rankings.setLeague(league);
+    await this.getRankings();
   }
 
   public playerIsRanked(rank: Ranking): boolean {

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -352,13 +352,16 @@ export default class RankingsView extends Vue {
 
   async mounted() {
     this.search = "";
-    if (this.league) {
-      await this.$store.direct.dispatch.rankings.setLeague(this.league);
-    }
+
     if (this.season) {
       this.$store.direct.commit.rankings.SET_SELECTED_SEASON({
         id: this.season,
       });
+    } else {
+      await this.$store.direct.dispatch.rankings.retrieveSeasons();
+    }
+    if (this.league) {
+      await this.$store.direct.dispatch.rankings.setLeague(this.league);
     }
     if (this.gamemode) {
       this.$store.direct.commit.rankings.SET_GAME_MODE(this.gamemode);
@@ -367,7 +370,6 @@ export default class RankingsView extends Vue {
       this.$store.direct.commit.SET_GATEWAY(this.gateway);
     }
 
-    await this.$store.direct.dispatch.rankings.retrieveSeasons();
     await this.refreshRankings();
 
     if (this.ladders && !this.selectedLeague?.id) {


### PR DESCRIPTION
This pr fixes several issues.

1. Double requests to backend when changing seasons on Ranking page. That is now 1 request.

2. Triple requests to backend when changing seasons on CountryRankings page. 2 were sent to fetch Rankings and 1 to fetch CountryRankings. That is now only 1 to CountryRankings and 0 to Rankings.

3. Player search failing when going from a player's profile page, if that player is not ranked in the current season. Wrong season was being set. For example, go to this profile and click the 1vs1 platinum 16 badge:
 https://w3champions.com/player/Brekkie%2321685
 
4. Empty rankings page showing when doing a fresh page load on a player search. For example when going directly to this url (This bug is not visible without fixing bug number 3 first. The wrong season was being set):
https://w3champions.com/Rankings?season=12&gateway=20&gamemode=1&league=39&playerId=12_Brekkie%2321685%4020_GM_1v1_NE

5. Double requests to fetch all seasons when going to w3champions starting page. Go to w3champions.com and check network. You will see two requests to https://website-backend.w3champions.com/api/ladder/seasons. That is now 1 request.
