### PR TITLE
Cannot change gamemode on matches page

### DIFF
--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -161,7 +161,8 @@ export default class MatchesView extends Vue {
     }, AppConstants.ongoingMatchesRefreshInterval);
   }
 
-  mounted(): void {
+  async mounted() {
+    await this.$store.direct.dispatch.rankings.retrieveSeasons();
     this.getMatches(1);
     this.getMaps();
     this.refreshMatches();


### PR DESCRIPTION
After fixing some duplicate requests to backend in https://github.com/w3champions/website/pull/552, you can no longer change gamemode when visiting the recent matches page if you haven't visited the front page or the rankings before that. 

Fixed by fetching seasons on the matches view.