### PR TITLE
Fix mmr distribution requests

### DIFF
--- a/src/components/common/MapSelect.vue
+++ b/src/components/common/MapSelect.vue
@@ -33,8 +33,8 @@ import { Component, Prop } from "vue-property-decorator";
 
 @Component({})
 export default class MapSelect extends Vue {
-  @Prop() map = "Overall";
-  @Prop() mapKeys = [];
+  @Prop({default: "Overall"}) map?: string;
+  @Prop({default: []}) mapKeys!: Array<string>;
 
   get selected(): string | TranslateResult {
     const match = this.maps.find((m) => m.key === this.map);

--- a/src/components/overall-statistics/tabs/MmrDistributionTab.vue
+++ b/src/components/overall-statistics/tabs/MmrDistributionTab.vue
@@ -206,7 +206,6 @@ export default class PlayerActivityTab extends Vue {
   private async init() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
     await this.setSelectedSeason(this.seasons[0]);
-    this.updateMMRDistribution();
   }
 
   get verifiedBtag() {

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -183,6 +183,7 @@ export default class PlayerMatchesTab extends Vue {
 
   public async activated() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
+    this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
     setTimeout(async () => await this.getMatches(), 500);
   }
 

--- a/src/components/player/tabs/PlayerStatisticTab.vue
+++ b/src/components/player/tabs/PlayerStatisticTab.vue
@@ -60,10 +60,11 @@
       <v-col cols="12" md="10">
         <v-card-text v-if="!loadingMmrRpTimeline">
           <player-mmr-rp-timeline-chart
+            v-if="!isPlayerMmrRpTimelineEmpty"
             style="position: relative"
             :mmrRpTimeline="playerMmrRpTimeline"
           />
-          <v-card-text v-if="isPlayerMmrRpTimelineEmpty">
+          <v-card-text v-else>
             {{
               $t("components_player_tabs_playerstatistictab.playerhasnomatches")
             }}

--- a/src/components/tournaments/TournamentMatchUpdate.vue
+++ b/src/components/tournaments/TournamentMatchUpdate.vue
@@ -171,7 +171,7 @@ interface DateTimePickerProps extends Element {
 
 @Component({ components: { CountryFlag } })
 export default class PlayerAvatar extends Vue {
-  @Prop() isModalOpened = false;
+  @Prop({default: false}) isModalOpened?: boolean;
   @Prop() tournamentMatch?: ITournamentMatch;
 
   public countries: { country: string; countryCode: string }[] = [];

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -232,6 +232,10 @@ const data = {
       invitespending: "Invites Pending:",
       nonepending: "None pending",
     },
+    components_common_copybutton: {
+      tooltip: "Copy to clipboard",
+      maptooltip: "Copy maps to clipboard",
+    },
     components_common_gamemodeselect: {
       selectgamemode: "Select a gamemode:",
     },
@@ -293,6 +297,11 @@ const data = {
     components_matches_matchesstatusselect: {
       selectstatus: "Select a status:",
     },
+    components_matches_sortselect: {
+      sortmatchesby: "Sort matches by:",
+      mmrdescending: "MMR",
+      starttimedescending: "Start time",
+    },
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Top live 1v1 matches",
     },
@@ -319,6 +328,7 @@ const data = {
       playedmaps: "Played Maps",
       popularhours: "Popular Hours",
       gamelengths: "Game Lengths",
+      selectseason: "Select Season"
     },
     "components_overall-statistics_tabs_winratestab": {
       selectmap: "Select Map",

--- a/src/store/player/index.ts
+++ b/src/store/player/index.ts
@@ -25,7 +25,7 @@ const mod = {
     matches: [] as Match[],
     loadingProfile: false,
     loadingRecentMatches: false,
-    loadingMmrRpTimeline: false,
+    loadingMmrRpTimeline: true,
     opponentTag: "",
     selectedSeason: {} as Season,
     gameMode: 0 as EGameMode,

--- a/src/store/ranking/index.ts
+++ b/src/store/ranking/index.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { moduleActionContext } from "..";
 import { CountryRanking, Ladder, Ranking, RankingState, Season } from "./types";
 import { DataTableOptions, EGameMode, RootState } from "../typings";
@@ -101,7 +102,7 @@ const mod = {
       context: ActionContext<RankingState, RootState>,
       league: number
     ) {
-      const { commit, dispatch } = moduleActionContext(context, mod);
+      const { commit } = moduleActionContext(context, mod);
       commit.SET_LEAGUE(league);
     },
     setSeason(
@@ -139,12 +140,15 @@ const mod = {
       commit.SET_LEAGUE_CONSTELLATION(ladders);
     },
     async retrieveSeasons(context: ActionContext<RankingState, RootState>) {
-      const { commit, rootGetters } = moduleActionContext(context, mod);
+      const { commit, rootGetters, state } = moduleActionContext(context, mod);
+
+      // Seasons already fetched, skip
+      if (!_.isEmpty(state.seasons)) {
+        return;
+      }
 
       const seasons = await rootGetters.rankingService.retrieveSeasons();
-
       commit.SET_SEASONS(seasons);
-      commit.SET_SELECTED_SEASON(seasons[0]);
     },
   },
   mutations: {

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -230,12 +230,12 @@ export default class CountryRankingsView extends Vue {
 
   async mounted() {
     window.scrollTo(0, 0);
+    await this.$store.direct.dispatch.rankings.retrieveSeasons();
 
-    if (this.season) {
-      this.$store.direct.commit.rankings.SET_SELECTED_SEASON({
-        id: this.season,
-      });
-    }
+    this.season
+      ? this.$store.direct.dispatch.rankings.setSeason({id: this.season})
+      : this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
+
     if (this.gateway) {
       this.$store.direct.commit.SET_GATEWAY(this.gateway);
     }
@@ -243,7 +243,6 @@ export default class CountryRankingsView extends Vue {
     let country =
       this.country || this.selectedCountryCode || this.countries[0].countryCode;
 
-    await this.$store.direct.dispatch.rankings.retrieveSeasons();
     await this.getLadders();
     await this.$store.direct.dispatch.rankings.setCountry(country);
     this.initialized = true;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -161,7 +161,7 @@ import SupportBox from "@/components/common/SupportBox.vue";
 import PartnerBox from "@/components/common/PartnerBox.vue";
 import TopOngoingMatchesWithStreams from "@/components/matches/TopOngoingMatchesWithStreams.vue";
 import { NewsMessage } from "@/store/admin/messages/types";
-import { Map } from "@/store/admin/maps/types"
+import { Map } from "@/store/admin/maps/types";
 import CopyButton from "@/components/common/CopyButton.vue";
 
 @Component({
@@ -190,6 +190,7 @@ export default class HomeView extends Vue {
 
   async mounted(): Promise<void> {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
+    this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
     await this.$store.direct.dispatch.rankings.getTopFive();
     await this.$store.direct.dispatch.infoMessages.loadNews();
     await this.$store.direct.dispatch.admin.mapsManagement.loadMapsForCurrentSeason();

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -163,6 +163,7 @@ export default class MatchesView extends Vue {
 
   async mounted() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
+    this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
     this.getMatches(1);
     this.getMaps();
     this.refreshMatches();

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -43,6 +43,7 @@ import { Component } from "vue-property-decorator";
 
 import { Match, EGameMode } from "@/store/typings";
 import { MatchStatus } from "@/store/match/types";
+import { Season } from "@/store/ranking/types";
 
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
 import MatchesStatusSelect from "@/components/matches/MatchesStatusSelect.vue";
@@ -88,8 +89,8 @@ export default class MatchesView extends Vue {
     return this.$store.direct.state.matches.matches;
   }
 
-  get currentSeason(): number {
-    return this.$store.direct.state.rankings.seasons[0].id;
+  get currentSeason(): Season {
+    return this.$store.direct.state.rankings.seasons[0];
   }
 
   get maps() {
@@ -98,10 +99,14 @@ export default class MatchesView extends Vue {
   }
 
   get mapsByGameMode() {
+    if (!this.currentSeason) {
+      return [];
+    }
+
     const filterSeasons =
       this.$store.direct.state.matches.status == MatchStatus.onGoing
         ? (matchesOnMapPerSeason: MatchesOnMapPerSeason) =>
-            matchesOnMapPerSeason.season === this.currentSeason
+            matchesOnMapPerSeason.season === this.currentSeason.id
         : (matchesOnMapPerSeason: MatchesOnMapPerSeason) =>
             matchesOnMapPerSeason.season >= 0;
 

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -54,7 +54,6 @@ import PopularGameTimeChart from "@/components/overall-statistics/PopularGameTim
 import PlayedHeroesChart from "@/components/overall-statistics/PlayedHeroesChart.vue";
 import HeroWinrate from "@/components/overall-statistics/HeroWinrate.vue";
 import MmrDistributionChart from "@/components/overall-statistics/MmrDistributionChart.vue";
-import { SeasonGameModeGateWayForMMR } from "@/store/overallStats/types";
 import { Season } from "@/store/ranking/types";
 
 @Component({
@@ -93,14 +92,6 @@ export default class OverallStatisticsView extends Vue {
         freshLogin: false,
       });
     }
-    const mMRDistributionPayload: SeasonGameModeGateWayForMMR = {
-      season: this.$store.direct.state.rankings.selectedSeason.id,
-      gameMode: this.$store.direct.state.matches.gameMode,
-      gateWay: this.$store.direct.state.gateway,
-    };
-    await this.$store.direct.dispatch.overallStatistics.loadMmrDistribution(
-      mMRDistributionPayload
-    );
   }
 }
 </script>

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -355,9 +355,10 @@ export default class RankingsView extends Vue {
 
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
 
-    if (this.season) {
-      this.$store.direct.dispatch.rankings.setSeason({id: this.season} as Season);
-    }
+    this.season
+      ? this.$store.direct.dispatch.rankings.setSeason({ id: this.season })
+      : this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
+
     if (this.league) {
       this.$store.direct.dispatch.rankings.setLeague(this.league);
     }


### PR DESCRIPTION
Fetch mmr distribution once instead of 3 times.

Fetch seasons only once per browsing session instead of multiple times.

Fix issue of matches not showing when starting a browser session on Statistics tab, then going to Matches.

Set some locales for local development (they are already in the excel doc since some time ago).
