### PR TITLE
[W3C-193] Fix pagination on admin maps

### DIFF
--- a/src/components/admin/AdminMaps.vue
+++ b/src/components/admin/AdminMaps.vue
@@ -10,7 +10,7 @@
         <edit-map-files :map="editedMap" @cancel="closeEditFiles" @selected="mapFileSelected"></edit-map-files>
       </v-dialog>
 
-      <v-text-field label="Search" v-model="search" @input="onSearchChange"></v-text-field>
+      <v-text-field label="Search" v-model="search"></v-text-field>
       <v-data-table
         :headers="headers"
         :items="maps"
@@ -36,6 +36,7 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import EditMap from "./maps/EditMap.vue";
 import EditMapFiles from "./maps/EditMapFiles.vue";
+import _ from "lodash";
 
 @Component({ components: { EditMap, EditMapFiles } })
 export default class AdminMaps extends Vue {
@@ -62,15 +63,16 @@ export default class AdminMaps extends Vue {
   }
 
   public get maps() {
-    return this.$store.direct.state.admin.mapsManagement.maps;
+    return _.isUndefined(this.search) ?
+      this.$store.direct.state.admin.mapsManagement.maps :
+      this.$store.direct.state.admin.mapsManagement.maps.filter(m => {
+        return m.category?.toLowerCase().includes(this.search!.toLowerCase()) ||
+               m.name.toLowerCase().includes(this.search!.toLowerCase());
+      })
   }
 
   public get totalMaps() {
     return this.$store.direct.state.admin.mapsManagement.totalMaps;
-  }
-
-  public onSearchChange() {
-    this.$store.direct.dispatch.admin.mapsManagement.loadMaps(this.search);
   }
 
   public getMapPath(map: Map) {

--- a/src/components/admin/AdminMaps.vue
+++ b/src/components/admin/AdminMaps.vue
@@ -15,7 +15,7 @@
         :headers="headers"
         :items="maps"
         :items-per-page="10"
-        :server-items-length="totalMaps"
+        :footer-props="{ itemsPerPageOptions: [10, 25, 50, -1] }"
         class="elevation-1"
       >
         <template #[`item.path`]="{ item }">


### PR DESCRIPTION
In the `Manage Maps` tab in the Admin panel, pagination and the `rows per page` setting don't work, making it difficult to browse maps. Instead of fetching only a subset of the maps from backend, these PRs fetch all maps, then implements the search function in frontend instead. You would make a bigger request once, but then you wouldn't have to make another request, which is good. Since there aren't very many maps (around 250 at the moment), this should be perfectly fine.

By removing the pagination and offset request parameters from backend and matchmaking, we fetch all maps to frontend in one request.

JIRA issue: https://w3champions.atlassian.net/browse/W3C-193
Backend PR: https://github.com/w3champions/website-backend/pull/216
Matchmaking PR: https://github.com/w3champions/matchmaking-service/pull/260
