### PR TITLE
[W3C-194] Replace RH Ladder with ATR

### DIFF
--- a/src/components/admin/AdminQueueData.vue
+++ b/src/components/admin/AdminQueueData.vue
@@ -164,8 +164,8 @@ export default class AdminQueueData extends Vue {
         modeId: EGameMode.GM_ROC_1ON1,
       },
       {
-        text: this.$t(`gameModes.${EGameMode[EGameMode.GM_RH_1ON1]}`),
-        gameMode: EGameMode.GM_RH_1ON1,
+        text: this.$t(`gameModes.${EGameMode[EGameMode.GM_ATR_1ON1]}`),
+        gameMode: EGameMode.GM_ATR_1ON1,
       },
       {
         text: this.$t(`gameModes.${EGameMode[EGameMode.GM_BANJOBALL_4ON4]}`),

--- a/src/components/common/GameModeSelect.vue
+++ b/src/components/common/GameModeSelect.vue
@@ -99,8 +99,8 @@ export default class GameModeSelect extends Vue {
         gameMode: EGameMode.GM_ROC_1ON1,
       },
       {
-        modeName: this.$t(`gameModes.${EGameMode[EGameMode.GM_RH_1ON1]}`),
-        gameMode: EGameMode.GM_RH_1ON1,
+        modeName: this.$t(`gameModes.${EGameMode[EGameMode.GM_ATR_1ON1]}`),
+        gameMode: EGameMode.GM_ATR_1ON1,
       },
       {
         modeName: this.$t(

--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -101,7 +101,7 @@ export default class ActivityPerDayChart extends Vue {
       case EGameMode.GM_ROC_1ON1:
         return "rgb(120, 0, 4)";
 
-      case EGameMode.GM_RH_1ON1:
+      case EGameMode.GM_ATR_1ON1:
         return "rgb(21, 189, 124)";
 
       case EGameMode.GM_BANJOBALL_4ON4:
@@ -141,7 +141,7 @@ export default class ActivityPerDayChart extends Vue {
       case EGameMode.GM_ROC_1ON1:
         return 1;
 
-      case EGameMode.GM_RH_1ON1:
+      case EGameMode.GM_ATR_1ON1:
         return 1;
 
       case EGameMode.GM_BANJOBALL_4ON4:

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -254,8 +254,8 @@ export default class PlayerMatchesTab extends Vue {
         modeId: EGameMode.GM_ROC_1ON1,
       },
       {
-        modeName: this.$t(`gameModes.${EGameMode[EGameMode.GM_RH_1ON1]}`),
-        modeId: EGameMode.GM_RH_1ON1,
+        modeName: this.$t(`gameModes.${EGameMode[EGameMode.GM_ATR_1ON1]}`),
+        modeId: EGameMode.GM_ATR_1ON1,
       },
       {
         modeName: this.$t(

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -39,6 +39,7 @@ const en = {
     GM_LTW_1ON1: "Line Tower Wars 1vs1",
     GM_FROSTCRAFT_4ON4: "Frostcraft 4v4",
     GM_RH_1ON1: "Random Hero 1vs1",
+    GM_ATR_1ON1: "All The Randoms 1vs1",
     GM_BANJOBALL_4ON4: "Banjoball 4v4",
   },
 

--- a/src/store/typings.ts
+++ b/src/store/typings.ts
@@ -139,7 +139,7 @@ export enum EGameMode {
 
   GM_FROSTCRAFT_4ON4 = 501,
 
-  GM_RH_1ON1 = 601,
+  GM_ATR_1ON1 = 601,
 
   GM_BANJOBALL_4ON4 = 701,
 }


### PR DESCRIPTION
Replace Random Hero Ladder with All The Randoms. Maps are already uploaded through Admin -> Manage Maps.

This replaces RH with ATR, without creating a new GameMode ID for ATR, so mmr and overall statistics will carry over. If this is not desirable, we could create a new GameMode Enum for ATR.

Jira issue:
https://w3champions.atlassian.net/browse/W3C-194

Backend PR:
https://github.com/w3champions/website-backend/pull/218

Matchmaking PR:
https://github.com/w3champions/matchmaking-service/pull/262
