### PR TITLE
W3c 195/reenable finished matches

### DIFF
--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -1,13 +1,9 @@
 <template>
   <v-menu offset-x>
     <template v-slot:activator="{ on }">
-      <v-btn
-        tile
-        v-on="on"
-        class="ma-4"
-        style="background-color: transparent"
-      >
-        <h2 class="pa-0">{{ $t("components_common_seasonselect.season") }} {{ selectedSeason.id }}</h2>
+      <v-btn tile v-on="on" :class="{'ma-4': !matchesPage}" style="background-color: transparent">
+        <div v-if="matchesPage"> {{ $t("components_common_seasonselect.season") }} {{ selectedSeason.id }}</div>
+        <h2 v-else>{{ $t("components_common_seasonselect.season") }} {{ selectedSeason.id }}</h2>
         <v-icon class="ml-4">mdi-chevron-right</v-icon>
       </v-btn>
     </template>
@@ -19,11 +15,7 @@
           </v-list-item-content>
         </v-list>
         <v-list dense>
-          <v-list-item
-            v-for="season in seasons"
-            :key="season.id"
-            @click="selectSeason(season)"
-          >
+          <v-list-item v-for="season in seasons" :key="season.id" @click="selectSeason(season)">
             <v-list-item-content>
               <v-list-item-title>{{ $t("components_common_seasonselect.season") }} {{ season.id }}</v-list-item-title>
             </v-list-item-content>
@@ -41,19 +33,24 @@ import { Season } from "@/store/ranking/types";
 
 @Component({})
 export default class SeasonSelect extends Vue {
+  @Prop({default: false}) matchesPage?: boolean;
+
   get seasons() {
     return this.$store.direct.state.rankings.seasons;
   }
 
   get selectedSeason() {
-    return this.$store.direct.state.rankings.selectedSeason;
+    return this.matchesPage
+      ? this.$store.direct.state.matches.selectedSeason
+      : this.$store.direct.state.rankings.selectedSeason;
   }
 
   public selectSeason(season: Season) {
-    this.$store.direct.dispatch.rankings.setSeason(season);
+    this.matchesPage
+      ? this.$store.direct.dispatch.matches.setSeason(season)
+      : this.$store.direct.dispatch.rankings.setSeason(season);
     this.$emit("seasonSelected", season);
   }
-
 }
 </script>
 

--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -7,7 +7,7 @@
         class="ma-4"
         style="background-color: transparent"
       >
-        <h2 class="pa-0">Season {{ selectedSeason.id }}</h2>
+        <h2 class="pa-0">{{ $t("components_common_seasonselect.season") }} {{ selectedSeason.id }}</h2>
         <v-icon class="ml-4">mdi-chevron-right</v-icon>
       </v-btn>
     </template>
@@ -15,7 +15,7 @@
       <v-card-text>
         <v-list>
           <v-list-item-content>
-            <v-list-item-title>Previous seasons:</v-list-item-title>
+            <v-list-item-title>{{ $t("components_common_seasonselect.prevseasons") }}</v-list-item-title>
           </v-list-item-content>
         </v-list>
         <v-list dense>
@@ -25,7 +25,7 @@
             @click="selectSeason(season)"
           >
             <v-list-item-content>
-              <v-list-item-title>Season {{ season.id }}</v-list-item-title>
+              <v-list-item-title>{{ $t("components_common_seasonselect.season") }} {{ season.id }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
         </v-list>

--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-menu offset-x>
+    <template v-slot:activator="{ on }">
+      <v-btn
+        tile
+        v-on="on"
+        class="ma-4"
+        style="background-color: transparent"
+      >
+        <h2 class="pa-0">Season {{ selectedSeason.id }}</h2>
+        <v-icon class="ml-4">mdi-chevron-right</v-icon>
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-list>
+          <v-list-item-content>
+            <v-list-item-title>Previous seasons:</v-list-item-title>
+          </v-list-item-content>
+        </v-list>
+        <v-list dense>
+          <v-list-item
+            v-for="season in seasons"
+            :key="season.id"
+            @click="selectSeason(season)"
+          >
+            <v-list-item-content>
+              <v-list-item-title>Season {{ season.id }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import { Season } from "@/store/ranking/types";
+
+@Component({})
+export default class SeasonSelect extends Vue {
+  get seasons() {
+    return this.$store.direct.state.rankings.seasons;
+  }
+
+  get selectedSeason() {
+    return this.$store.direct.state.rankings.selectedSeason;
+  }
+
+  public selectSeason(season: Season) {
+    this.$store.direct.dispatch.rankings.setSeason(season);
+    this.$emit("seasonSelected", season);
+  }
+
+}
+</script>
+
+<style></style>

--- a/src/components/matches/MatchesStatusSelect.vue
+++ b/src/components/matches/MatchesStatusSelect.vue
@@ -60,6 +60,7 @@ export default class MatchesStatusSelect extends Vue {
 
   public setStatus(status: MatchStatus) {
     this.$store.direct.dispatch.matches.setStatus(status);
+    this.$emit("statusChanged", status);
   }
 }
 </script>

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -245,6 +245,10 @@ const data = {
     components_common_mmrselect: {
       selectmmr: "Select MMR range"
     },
+    components_common_seasonselect: {
+      season: "Season",
+      prevseasons: "Previous seasons:"
+    },
     components_ladder_countryrankingsgrid: {
       noplayerfound: "No players found for this country",
     },

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -15,12 +15,13 @@ export default class MatchService {
     gateway: number,
     gameMode: EGameMode,
     map: string,
-    mmr: Mmr
+    mmr: Mmr,
+    season: number
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
     const minMmr = mmr.min === 0 ? "" : `&minMmr=${mmr.min}`
     const maxMmr = mmr.max === 3000 ? "" : `&maxMmr=${mmr.max}`
-    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}`;
+    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}`;
 
     const response = await fetch(url);
     return await response.json();

--- a/src/store/match/index.ts
+++ b/src/store/match/index.ts
@@ -1,6 +1,6 @@
 import { EGameMode } from "@/store/typings";
 import { moduleActionContext } from "..";
-import { MatchState, MatchStatus, Mmr } from "./types";
+import { MatchState, MatchStatus, Mmr, Season } from "./types";
 import { Match, MatchDetail, RootState } from "../typings";
 import { ActionContext } from "vuex";
 
@@ -18,6 +18,7 @@ const mod = {
     map: "Overall",
     mmr: {min: 0, max: 3000} as Mmr,
     sort: "startTimeDescending",
+    selectedSeason: {} as Season,
   } as MatchState,
   actions: {
     async loadMatches(
@@ -50,7 +51,8 @@ const mod = {
           rootState.gateway,
           state.gameMode,
           state.map,
-          state.mmr
+          state.mmr,
+          state.selectedSeason.id
         );
       }
 
@@ -134,6 +136,13 @@ const mod = {
       commit.SET_PAGE(0);
       await dispatch.loadMatches(undefined);
     },
+    setSeason(
+      context: ActionContext<MatchState, RootState>,
+      season: Season
+    ) {
+      const { commit } = moduleActionContext(context, mod);
+      commit.SET_SELECTED_SEASON(season);
+    },
   },
   mutations: {
     SET_PAGE(state: MatchState, page: number) {
@@ -168,6 +177,9 @@ const mod = {
     },
     SET_SORT(state: MatchState, sort: string) {
       state.sort = sort;
+    },
+    SET_SELECTED_SEASON(state: MatchState, season: Season) {
+      state.selectedSeason = season;
     },
   },
 } as const;

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -13,6 +13,7 @@ export type MatchState = {
   map: string;
   mmr: Mmr;
   sort: string;
+  selectedSeason: Season;
 };
 
 export enum MatchStatus {
@@ -28,4 +29,8 @@ export enum SortMode {
 export type Mmr = {
     min: number;
     max: number;
+};
+
+export type Season = {
+  id: number;
 };

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -58,39 +58,7 @@
           </v-card>
         </v-menu>
         <v-spacer></v-spacer>
-        <v-menu offset-x>
-          <template v-slot:activator="{ on }">
-            <v-btn
-              tile
-              v-on="on"
-              class="ma-4"
-              style="background-color: transparent"
-            >
-              <h2 class="pa-0">Season {{ selectedSeason.id }}</h2>
-              <v-icon class="ml-4">mdi-chevron-right</v-icon>
-            </v-btn>
-          </template>
-          <v-card>
-            <v-card-text>
-              <v-list>
-                <v-list-item-content>
-                  <v-list-item-title>Previous seasons:</v-list-item-title>
-                </v-list-item-content>
-              </v-list>
-              <v-list dense>
-                <v-list-item
-                  v-for="item in seasons"
-                  :key="item.id"
-                  @click="selectSeason(item)"
-                >
-                  <v-list-item-content>
-                    <v-list-item-title>Season {{ item.id }}</v-list-item-title>
-                  </v-list-item-content>
-                </v-list-item>
-              </v-list>
-            </v-card-text>
-          </v-card>
-        </v-menu>
+        <season-select @seasonSelected="seasonSelected"></season-select>
       </v-card-title>
       <v-card-text>
         <country-rankings-grid
@@ -130,6 +98,7 @@ import GameModeSelect from "@/components/common/GameModeSelect.vue";
 import CountryRankingsGrid from "@/components/ladder/CountryRankingsGrid.vue";
 import AppConstants from "../constants";
 import { getProfileUrl } from "@/helpers/url-functions";
+import SeasonSelect from "@/components/common/SeasonSelect.vue";
 
 @Component({
   components: {
@@ -138,6 +107,7 @@ import { getProfileUrl } from "@/helpers/url-functions";
     GameModeSelect,
     CountryRankingsGrid,
     CountryFlag,
+    SeasonSelect,
   },
 })
 export default class CountryRankingsView extends Vue {
@@ -190,10 +160,6 @@ export default class CountryRankingsView extends Vue {
 
   get selectedSeason() {
     return this.$store.direct.state.rankings.selectedSeason;
-  }
-
-  get seasons() {
-    return this.$store.direct.state.rankings.seasons;
   }
 
   get rankings(): CountryRanking[] {
@@ -299,11 +265,6 @@ export default class CountryRankingsView extends Vue {
     });
   }
 
-  async selectSeason(season: Season) {
-    this.$store.direct.dispatch.rankings.setSeason(season);
-    this.refreshRankings();
-  }
-
   async setCountry(countryCode: string) {
     await this.$store.direct.dispatch.rankings.setCountry(countryCode);
   }
@@ -316,6 +277,10 @@ export default class CountryRankingsView extends Vue {
     this.$router.push({
       path: getProfileUrl(playerId),
     });
+  }
+
+  seasonSelected(season: Season): void {
+    this.refreshRankings();
   }
 }
 </script>

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -7,7 +7,7 @@
             {{ $t("views_app.matches") }}
           </v-card-title>
           <v-card-text>
-            <matches-status-select />
+            <matches-status-select @statusChanged="statusChanged"/>
             <game-mode-select
               :disabledModes="disabledGameModes"
               :gameMode="gameMode"
@@ -161,9 +161,11 @@ export default class MatchesView extends Vue {
   _intervalRefreshHandle?: number = undefined;
 
   private refreshMatches(): void {
-    this._intervalRefreshHandle = setInterval(async () => {
-      await this.getMatches();
-    }, AppConstants.ongoingMatchesRefreshInterval);
+    if (this.$store.direct.state.matches.status == MatchStatus.onGoing) {
+      this._intervalRefreshHandle = setInterval(async () => {
+        await this.getMatches();
+      }, AppConstants.ongoingMatchesRefreshInterval);
+    }
   }
 
   async mounted() {
@@ -201,6 +203,16 @@ export default class MatchesView extends Vue {
 
   seasonSelected(season: Season): void {
     this.getMatches(1);
+  }
+
+  statusChanged(status: MatchStatus) {
+    if (status == MatchStatus.onGoing) {
+      this._intervalRefreshHandle = setInterval(async () => {
+        await this.getMatches();
+      }, AppConstants.ongoingMatchesRefreshInterval);
+    } else {
+      clearInterval(this._intervalRefreshHandle);
+    }
   }
 }
 </script>

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -18,10 +18,6 @@
               :mapKeys="maps"
               :map="map"
             ></map-select>
-            <mmr-select
-              @mmrChanged="mmrChanged"
-              :mmr="mmr"
-            ></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" matchesPage="true" @seasonSelected="seasonSelected"></season-select>
           </v-card-text>

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -23,6 +23,7 @@
               :mmr="mmr"
             ></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
+            <season-select v-if="!unfinished" matchesPage="true" @seasonSelected="seasonSelected"></season-select>
           </v-card-text>
           <matches-grid
             v-model="matches"
@@ -53,6 +54,8 @@ import MmrSelect from "@/components/common/MmrSelect.vue";
 import SortSelect from "@/components/matches/SortSelect.vue";
 import { MatchesOnMapPerSeason } from "@/store/overallStats/types";
 import AppConstants from "@/constants";
+import SeasonSelect from '@/components/common/SeasonSelect.vue'
+import _ from "lodash";
 
 @Component({
   components: {
@@ -62,6 +65,7 @@ import AppConstants from "@/constants";
     MapSelect,
     MmrSelect,
     SortSelect,
+    SeasonSelect,
   },
 })
 export default class MatchesView extends Vue {
@@ -169,6 +173,11 @@ export default class MatchesView extends Vue {
   async mounted() {
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
     this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
+
+    if (_.isEmpty(this.$store.direct.state.matches.selectedSeason)) {
+      this.$store.direct.dispatch.matches.setSeason(this.$store.direct.state.rankings.seasons[0]);
+    }
+
     this.getMatches(1);
     this.getMaps();
     this.refreshMatches();
@@ -192,6 +201,10 @@ export default class MatchesView extends Vue {
 
   mmrChanged(mmr: Mmr): void {
     this.$store.direct.dispatch.matches.setMmr(mmr);
+  }
+
+  seasonSelected(season: Season): void {
+    this.getMatches(1);
   }
 }
 </script>

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -105,40 +105,7 @@
           </template>
         </v-autocomplete>
       </v-card-title>
-      <v-menu offset-x>
-        <template v-slot:activator="{ on }">
-          <v-btn tile v-on="on" class="ma-4 transparent">
-            <h2 class="pa-0">
-              {{ $t("views_rankings.season") }} {{ selectedSeason.id }}
-            </h2>
-            <v-icon class="ml-4">mdi-chevron-right</v-icon>
-          </v-btn>
-        </template>
-        <v-card>
-          <v-card-text>
-            <v-list>
-              <v-list-item-content>
-                <v-list-item-title>
-                  {{ $t("views_rankings.prevseasons") }}
-                </v-list-item-title>
-              </v-list-item-content>
-            </v-list>
-            <v-list dense>
-              <v-list-item
-                v-for="item in seasons"
-                :key="item.id"
-                @click="selectSeason(item)"
-              >
-                <v-list-item-content>
-                  <v-list-item-title>
-                    {{ $t("views_rankings.season") }} {{ item.id }}
-                  </v-list-item-title>
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
-          </v-card-text>
-        </v-card>
-      </v-menu>
+      <season-select @seasonSelected="seasonSelected"></season-select>
       <v-card-text>
         <rankings-grid
           :rankings="rankings"
@@ -187,6 +154,7 @@ import RankingsGrid from "@/components/ladder/RankingsGrid.vue";
 import RankingsRaceDistribution from "@/components/ladder/RankingsRaceDistribution.vue";
 import AppConstants from "../constants";
 import { getProfileUrl } from "@/helpers/url-functions";
+import SeasonSelect from "@/components/common/SeasonSelect.vue";
 
 @Component({
   components: {
@@ -195,6 +163,7 @@ import { getProfileUrl } from "@/helpers/url-functions";
     GameModeSelect,
     RankingsGrid,
     RankingsRaceDistribution,
+    SeasonSelect,
   },
 })
 export default class RankingsView extends Vue {
@@ -262,10 +231,6 @@ export default class RankingsView extends Vue {
 
   get selectedSeason() {
     return this.$store.direct.state.rankings.selectedSeason;
-  }
-
-  get seasons() {
-    return this.$store.direct.state.rankings.seasons;
   }
 
   get selectedGameMode() {
@@ -354,7 +319,6 @@ export default class RankingsView extends Vue {
     this.search = "";
 
     await this.$store.direct.dispatch.rankings.retrieveSeasons();
-
     this.season
       ? this.$store.direct.dispatch.rankings.setSeason({ id: this.season })
       : this.$store.direct.dispatch.rankings.setSeason(this.$store.direct.state.rankings.seasons[0]);
@@ -435,12 +399,6 @@ export default class RankingsView extends Vue {
     });
   }
 
-  public async selectSeason(season: Season) {
-    this.$store.direct.dispatch.rankings.setSeason(season);
-    await this.getLadders();
-    await this.setLeague(0);
-  }
-
   public async setLeague(league: number) {
     this.$store.direct.dispatch.rankings.setLeague(league);
     await this.getRankings();
@@ -454,6 +412,11 @@ export default class RankingsView extends Vue {
     this.$router.push({
       path: getProfileUrl(playerId),
     });
+  }
+
+  async seasonSelected(): Promise<void> {
+    await this.getLadders();
+    await this.setLeague(0);
   }
 }
 </script>


### PR DESCRIPTION
Backend PR:
https://github.com/w3champions/website-backend/pull/219

**Summary of changes**
- Creates a select-season component, and then uses that component in Rankings, CountryRankings and Matches.
- Removes the mmr filter temporarily to not overload the db.
- Removes the refresh interval for finished matches to not overload the db.

I want to push this to Test to see what kind of response times we're getting. It looks OK (not great) on my local machine, but my RAM is maxed out so I'm not sure how representative it is.

**Indexes**
We also need to take a look at the indexes, and perhaps create a new index.

There's an index right now that looks like this:
```
  {
    v: 2,
    key: { EndTime: -1, GameMode: 1, GateWay: 1, Map: 1 },
    name: 'end_games'
  }
```
But that doesn't seem to apply the ESR (Equality, Sort, Range) Rule which is recommended by MongoDB, so I'm not sure how well it performs. I would like to see how that index is performing on Test.

Perhaps one of these (or both) indexes is better suited for the finished matches:
```
  {
    v: 2,
    key: { GateWay: 1, GameMode: 1, Season: 1, EndTime: -1 },
    name: 'end_games2'
  },
  {
    v: 2,
    key: { GateWay: 1, GameMode: 1, Season: 1, Map: 1, EndTime: -1 },
    name: 'end_games3'
  }
```