### PR TITLE
Fix 'Stats by mode' not displaying correctly on profile

### DIFF
--- a/src/mixins/GameModesMixin.ts
+++ b/src/mixins/GameModesMixin.ts
@@ -43,6 +43,10 @@ export default class GameModesMixin extends Vue {
     return this.getGameModes(EGameModeType.MELEE, true);
   }
 
+  public get AT_modes() {
+    return Object.values(AT_EQUIVALENT);
+  }
+
   private getGameModes(type: EGameModeType | null, withAt: boolean) {
     return _
       .chain(this.$store.direct.state.admin.mapsManagement.seasonMaps)


### PR DESCRIPTION
1. Adds missing stats on player profile.
2. No longer combines AT stats into one, but chooses the AT stat with the highest ranking points to display.
3. Sorts game modes by name for teh pleasant viewing experience.

(1) before:
![image](https://user-images.githubusercontent.com/21004208/214972525-14284f8b-7db7-4c6e-ac64-9854db55a8e4.png)

(1) after:
![image](https://user-images.githubusercontent.com/21004208/214972597-a78c506d-b393-40a0-8164-96791187d480.png)

(2) before:
![image](https://user-images.githubusercontent.com/21004208/214972714-bbd9b4fd-266c-465d-a702-788dc86f3b4a.png)

(2) after:
![image](https://user-images.githubusercontent.com/21004208/214972830-1bb5ca45-f586-48a5-9d3b-e1d046440bcc.png)

(3) before:
![image](https://user-images.githubusercontent.com/21004208/214973144-398bbf6d-e07b-4f39-8910-127c4777340f.png)

(3) after:
![image](https://user-images.githubusercontent.com/21004208/214973049-1e462582-a90d-44b5-ab01-40f88f31c114.png)
