### PR TITLE
Fix profile statistics bugs and refactor

### DIFF
--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -49,8 +49,9 @@ import Vue from "vue";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import { Component, Prop, Watch } from "vue-property-decorator";
 import { getAsset } from "@/helpers/url-functions";
-import { PlayerStatsHeroOnMapVersusRace, PlayerHeroWinRateForStatisticsTab, RaceWinsOnMap, WinLossesOnMap, RaceStat } from "@/store/player/types";
+import { PlayerStatsHeroOnMapVersusRace, PlayerHeroWinRateForStatisticsTab } from "@/store/player/types";
 import { ERaceEnum } from "@/store/typings";
+import { races, defaultStatsTab } from "@/helpers/profile";
 
 @Component({
   components: { RaceIcon },
@@ -60,6 +61,7 @@ export default class PlayerHeroWinRate extends Vue {
   public raceEnums = ERaceEnum;
   public page = 1;
   public paginationSize = 10;
+  public races = races;
   @Prop() playerStatsHeroVersusRaceOnMap!: PlayerStatsHeroOnMapVersusRace;
   @Prop() selectedMap!: string;
 
@@ -69,23 +71,12 @@ export default class PlayerHeroWinRate extends Vue {
   }
 
   setSelectedTab(): void {
-    let maxRace = ERaceEnum.RANDOM;
-    let maxGames = 0;
-    this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
-      .filter((s: RaceWinsOnMap) => s.race !== ERaceEnum.TOTAL)
-      .forEach((s: RaceWinsOnMap) =>
-        s.winLossesOnMap.forEach((w: WinLossesOnMap) => {
-          const gamesOfRace = w.winLosses
-            .map((wl: RaceStat) => wl.games)
-            .reduce((a: number, b:number) => a + b, 0);
+    this.selectedTab = defaultStatsTab(this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All) || "tab-16";
+  }
 
-          if (maxGames < gamesOfRace) {
-            maxRace = s.race;
-            maxGames = gamesOfRace;
-          }
-        })
-      );
-    this.selectedTab = `tab-${maxRace}`;
+  // Use activated() instead of mounted() to trigger when navigating directly from one profile to another.
+  activated(): void {
+    if (this.isPlayerInitialized) this.setSelectedTab();
   }
 
   get selectedRace() {
@@ -182,35 +173,6 @@ export default class PlayerHeroWinRate extends Vue {
 
   getHeroCell(name: string, heroId: string) {
     return `<span>${this.getImageForTable(heroId)}${name}</span>`;
-  }
-
-  get races() {
-    return [
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.HUMAN]}`),
-        raceId: ERaceEnum.HUMAN,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.ORC]}`),
-        raceId: ERaceEnum.ORC,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.NIGHT_ELF]}`),
-        raceId: ERaceEnum.NIGHT_ELF,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.UNDEAD]}`),
-        raceId: ERaceEnum.UNDEAD,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.RANDOM]}`),
-        raceId: ERaceEnum.RANDOM,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.TOTAL]}`),
-        raceId: ERaceEnum.TOTAL,
-      },
-    ];
   }
 }
 </script>

--- a/src/components/player/tabs/PlayerStatisticTab.vue
+++ b/src/components/player/tabs/PlayerStatisticTab.vue
@@ -48,7 +48,7 @@
           />
           <v-select
             :items="races"
-            item-text="raceName"
+            :item-text="translateRaceName"
             item-value="raceId"
             v-model="selectedRace"
             @change="setTimelineRace"
@@ -65,9 +65,7 @@
             :mmrRpTimeline="playerMmrRpTimeline"
           />
           <v-card-text v-else>
-            {{
-              $t("components_player_tabs_playerstatistictab.playerhasnomatches")
-            }}
+            {{ $t("components_player_tabs_playerstatistictab.playerhasnomatches") }}
           </v-card-text>
         </v-card-text>
       </v-col>
@@ -127,7 +125,6 @@
 <script lang="ts">
 import { Component, Watch, Mixins } from "vue-property-decorator";
 import GameModesMixin from "@/mixins/GameModesMixin";
-
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
 import { EGameMode, ERaceEnum } from "@/store/typings";
 import {
@@ -140,6 +137,8 @@ import PlayerStatsRaceVersusRaceOnMap from "@/components/player/PlayerStatsRaceV
 import PlayerMmrRpTimelineChart from "@/components/player/PlayerMmrRpTimelineChart.vue";
 import PlayerHeroStatistics from "@/components/player/PlayerHeroStatistics.vue";
 import PlayerHeroWinRate from "@/components/player/PlayerHeroWinRate.vue";
+import { races } from "@/helpers/profile";
+import { TranslateResult } from "vue-i18n";
 
 @Component({
   components: {
@@ -157,6 +156,7 @@ export default class PlayerStatisticTab extends Mixins(GameModesMixin) {
   public updatePlayerHeroStatsKey = 0;
   public selectedMap = "Overall";
   public selectedMapHeroWinRate = "Overall";
+  public races = races;
 
   get selectedSeason() {
     return this.$store.direct.state.player.selectedSeason;
@@ -188,10 +188,14 @@ export default class PlayerStatisticTab extends Mixins(GameModesMixin) {
 
   async mounted(): Promise<void> {
     this.getMaps();
+    await this.loadActiveGameModes();
+  }
+
+  // Use activated() instead of mounted() to trigger when navigating directly from one profile to another.
+  activated(): void {
     if (this.isPlayerInitialized) {
       this.initMmrRpTimeline();
     }
-    await this.loadActiveGameModes();
   }
 
   // When loading the statistics tab via URL directly, due to Lifecycle Hooks the mounted() here
@@ -205,10 +209,10 @@ export default class PlayerStatisticTab extends Mixins(GameModesMixin) {
   private async initMmrRpTimeline() {
     const raceStats = this.$store.direct.state.player.raceStats;
     let maxRace = ERaceEnum.HUMAN;
-    let maxWins = 0;
+    let maxGames = 0;
     raceStats.forEach((r) => {
-      if (r.wins > maxWins) {
-        maxWins = r.wins;
+      if (r.games > maxGames) {
+        maxGames = r.wins;
         maxRace = r.race;
       }
     });
@@ -265,33 +269,8 @@ export default class PlayerStatisticTab extends Mixins(GameModesMixin) {
     ].filter((r: { race: ERaceEnum }) => r.race !== ERaceEnum.RANDOM);
   }
 
-  get races() {
-    return [
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.HUMAN]}`),
-        raceId: ERaceEnum.HUMAN,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.ORC]}`),
-        raceId: ERaceEnum.ORC,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.NIGHT_ELF]}`),
-        raceId: ERaceEnum.NIGHT_ELF,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.UNDEAD]}`),
-        raceId: ERaceEnum.UNDEAD,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.RANDOM]}`),
-        raceId: ERaceEnum.RANDOM,
-      },
-      {
-        raceName: this.$t(`races.${ERaceEnum[ERaceEnum.TOTAL]}`),
-        raceId: ERaceEnum.TOTAL,
-      },
-    ];
+  public translateRaceName(race: any): TranslateResult {
+    return this.$t(`races.${race.raceName}`);
   }
 
   public getMaps(): void {

--- a/src/helpers/profile.ts
+++ b/src/helpers/profile.ts
@@ -1,0 +1,52 @@
+import { ERaceEnum } from "@/store/typings";
+import { RaceWinsOnMap, WinLossesOnMap, RaceStat } from "@/store/player/types";
+
+export const races = [
+  {
+    raceId: ERaceEnum.HUMAN,
+    raceName: ERaceEnum[ERaceEnum.HUMAN]
+  },
+  {
+    raceId: ERaceEnum.ORC,
+    raceName: ERaceEnum[ERaceEnum.ORC]
+  },
+  {
+    raceId: ERaceEnum.NIGHT_ELF,
+    raceName: ERaceEnum[ERaceEnum.NIGHT_ELF]
+  },
+  {
+    raceId: ERaceEnum.UNDEAD,
+    raceName: ERaceEnum[ERaceEnum.UNDEAD]
+  },
+  {
+    raceId: ERaceEnum.RANDOM,
+    raceName: ERaceEnum[ERaceEnum.RANDOM]
+  },
+  {
+    raceId: ERaceEnum.TOTAL,
+    raceName: ERaceEnum[ERaceEnum.TOTAL]
+  },
+];
+
+export function defaultStatsTab(raceWinsOnMap: RaceWinsOnMap[]): string {
+  let maxRace = ERaceEnum.TOTAL;
+  let maxGames = 0;
+
+  if (!raceWinsOnMap) return `tab-${maxRace}`;
+
+  raceWinsOnMap
+    .filter((s: RaceWinsOnMap) => s.race !== ERaceEnum.TOTAL)
+    .forEach((s: RaceWinsOnMap) =>
+      s.winLossesOnMap.forEach((w: WinLossesOnMap) => {
+        const gamesOfRace = w.winLosses
+          .map((wl: RaceStat) => wl.games)
+          .reduce((a: number, b:number) => a + b, 0);
+
+        if (maxGames < gamesOfRace) {
+          maxRace = s.race;
+          maxGames = gamesOfRace;
+        }
+      })
+    );
+  return `tab-${maxRace}`;
+}


### PR DESCRIPTION
This PR fixes a few bugs on the statistics page on player profiles, and moves some repeated code from components to a new file helper/profile.ts.

I was deep down the rabbit hole when I realized I fixes several bugs, so unfortunately there's no individual commit messages for each bugfix, but here's a summary.

1. Fixed a display bug when no 1v1 games had been played.
Before:
![image](https://user-images.githubusercontent.com/21004208/215267922-6434d82f-2cca-40f8-a2d9-c0984c5924e2.png)
![image](https://user-images.githubusercontent.com/21004208/215267988-f997b7ec-4f50-458d-951f-4256e5d823da.png)

After:
![image](https://user-images.githubusercontent.com/21004208/215267959-a3e6d919-3917-4bd5-8ee6-674df2ee6c21.png)
![image](https://user-images.githubusercontent.com/21004208/215268012-abbc5330-8502-496a-a8b2-0a71024552f9.png)

2. MMR timeline default race picker now looks at amount of games, not amount of wins.

3. Fixed a bug where MMR timeline and hero stats were wrong when moving from one profile to another. Screenshot shows Happy's stats on my profile.
![image](https://user-images.githubusercontent.com/21004208/215268183-e0355bd9-ad02-4282-a572-e921b87fda9d.png)

4. Fixed correct race tab not being chosen for hero stats.
Before:
![image](https://user-images.githubusercontent.com/21004208/215268519-06e46fec-cbdb-43e8-a0d0-b57a11e77ec7.png)

After:
![image](https://user-images.githubusercontent.com/21004208/215268493-d585f44b-cfc8-44c2-b959-250192247ef9.png)
 