### PR TITLE
Allow moderation of unranked players

### DIFF
--- a/src/components/admin/AdminAlts.vue
+++ b/src/components/admin/AdminAlts.vue
@@ -4,17 +4,18 @@
       <!-- Autocomplete Btag search -->
       <v-autocomplete
         class="ml-5 mr-5"
-        v-model="searchPlayerAltsModel"
+        v-model="searchPlayerModel"
         append-icon="mdi-magnify"
         label="Search BattleNet Tag"
         clearable
         placeholder=" "
         :items="searchedPlayers"
         :search-input.sync="search"
-        item-text="player.playerIds[0].battleTag"
-        item-value="player.playerIds[0].id"
+        item-text="battleTag"
+        item-value="battleTag"
         return-object
         @click:clear="revertToDefault"
+        autofocus
       ></v-autocomplete>
     </v-row>
 
@@ -34,11 +35,11 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Watch } from "vue-property-decorator";
-import { SearchedPlayer } from "@/store/admin/types";
+import { PlayerProfile } from "@/store/player/types";
 
 @Component({})
 export default class AdminAlts extends Vue {
-  public searchPlayerAltsModel = {} as SearchedPlayer;
+  public searchPlayerModel = {} as PlayerProfile;
   public search = "";
   public showAlts = false;
   public oldSearchTerm = "";
@@ -51,18 +52,16 @@ export default class AdminAlts extends Vue {
     this.alts = [];
   }
 
-  @Watch("searchPlayerAltsModel")
+  @Watch("searchPlayerModel")
   public async onSearchStringChanged(
-    searchedPlayer: SearchedPlayer
+    searchedPlayer: PlayerProfile
   ): Promise<void> {
     if (!searchedPlayer) return;
 
     if (searchedPlayer) {
-      const btag = searchedPlayer.player.playerIds[0].battleTag;
+      const btag = searchedPlayer.battleTag;
 
-      this.alts = await this.$store.direct.dispatch.admin.getAltsForPlayer(
-        btag
-      );
+      this.alts = await this.$store.direct.dispatch.admin.getAltsForPlayer(btag);
 
       if ((this.alts != null || undefined) && this.alts.length > 0) {
         this.showAlts = true;
@@ -74,7 +73,7 @@ export default class AdminAlts extends Vue {
 
   @Watch("search")
   public onSearchChanged(newValue: string): void {
-    if (newValue && newValue.length > 2 && newValue >= this.oldSearchTerm) {
+    if (newValue && newValue.length > 2 && newValue !== this.oldSearchTerm) {
       this.$store.direct.dispatch.admin.searchBnetTag({
         searchText: newValue.toLowerCase(),
       });
@@ -84,7 +83,7 @@ export default class AdminAlts extends Vue {
     }
   }
 
-  get searchedPlayers(): SearchedPlayer[] {
+  get searchedPlayers(): PlayerProfile[] {
     return this.$store.direct.state.admin.searchedPlayers;
   }
 }

--- a/src/components/admin/AdminGlobalMute.vue
+++ b/src/components/admin/AdminGlobalMute.vue
@@ -37,10 +37,11 @@
                       placeholder=" "
                       :items="searchedPlayers"
                       :search-input.sync="search"
-                      item-text="player.playerIds[0].battleTag"
-                      item-value="player.playerIds[0].id"
+                      item-text="battleTag"
+                      item-value="battleTag"
                       return-object
                       @click:clear="revertToDefault"
+                      autofocus
                     ></v-autocomplete>
                   </v-row>
                   <v-row v-if="showConfirmation" class="ma-2">
@@ -126,11 +127,8 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Watch } from "vue-property-decorator";
-import {
-  GloballyMutedPlayer,
-  GlobalMute,
-  SearchedPlayer,
-} from "@/store/admin/types";
+import { GloballyMutedPlayer, GlobalMute } from "@/store/admin/types";
+import { PlayerProfile } from "@/store/player/types";
 
 @Component({})
 export default class AdminGlobalMute extends Vue {
@@ -178,7 +176,7 @@ export default class AdminGlobalMute extends Vue {
   public banExpiry = "";
   public dateMenu = false;
   public dialog = false;
-  public searchPlayerModel = {} as SearchedPlayer;
+  public searchPlayerModel = {} as PlayerProfile;
   public search = "";
   public showConfirmation = false;
   public oldSearchTerm = "";
@@ -193,12 +191,12 @@ export default class AdminGlobalMute extends Vue {
 
   @Watch("searchPlayerModel")
   public async onSearchStringChanged(
-    searchedPlayer: SearchedPlayer
+    searchedPlayer: PlayerProfile
   ): Promise<string> {
     if (!searchedPlayer) return "";
 
     if (searchedPlayer) {
-      this.player = searchedPlayer.player.playerIds[0].battleTag;
+      this.player = searchedPlayer.battleTag;
 
       await this.$store.direct.dispatch.admin.searchBnetTag({
         searchText: this.player.toLowerCase(),
@@ -211,14 +209,14 @@ export default class AdminGlobalMute extends Vue {
       }
     }
 
-    this.player = searchedPlayer.player.playerIds[0].battleTag;
+    this.player = searchedPlayer.battleTag;
     this.showConfirmation = true;
     return this.player;
   }
 
   @Watch("search")
   public onSearchChanged(newValue: string): void {
-    if (newValue && newValue.length > 2 && newValue >= this.oldSearchTerm) {
+    if (newValue && newValue.length > 2 && newValue !== this.oldSearchTerm) {
       this.$store.direct.dispatch.admin.searchBnetTag({
         searchText: newValue.toLowerCase(),
       });
@@ -228,7 +226,7 @@ export default class AdminGlobalMute extends Vue {
     }
   }
 
-  get searchedPlayers(): SearchedPlayer[] {
+  get searchedPlayers(): PlayerProfile[] {
     return this.$store.direct.state.admin.searchedPlayers;
   }
 

--- a/src/components/admin/AdminProxies.vue
+++ b/src/components/admin/AdminProxies.vue
@@ -4,17 +4,18 @@
       <!-- Autocomplete Btag search -->
       <v-autocomplete
         class="ml-5 mr-5"
-        v-model="searchPlayerProxiesModel"
+        v-model="searchPlayerModel"
         append-icon="mdi-magnify"
         label="Search BattleNet Tag"
         clearable
         placeholder=" "
         :items="searchedPlayers"
         :search-input.sync="search"
-        item-text="player.playerIds[0].battleTag"
-        item-value="player.playerIds[0].id"
+        item-text="battleTag"
+        item-value="battleTag"
         return-object
         @click:clear="revertToDefault"
+        autofocus
       ></v-autocomplete>
     </v-row>
 
@@ -30,11 +31,12 @@ import Vue from "vue";
 import { Component, Watch } from "vue-property-decorator";
 import nodeOverridesCard from "@/components/admin/proxies/nodeOverridesCard.vue";
 import reviewProxies from "@/components/admin/proxies/reviewProxies.vue";
-import { Proxy, ProxySettings, SearchedPlayer } from "@/store/admin/types";
+import { Proxy, ProxySettings } from "@/store/admin/types";
+import { PlayerProfile } from "@/store/player/types";
 
 @Component({ components: { nodeOverridesCard, reviewProxies } })
 export default class AdminProxies extends Vue {
-  public searchPlayerProxiesModel = {} as SearchedPlayer;
+  public searchPlayerModel = {} as PlayerProfile;
   public search = "";
   public showProxyOptions = false;
   public oldSearchTerm = "";
@@ -45,18 +47,16 @@ export default class AdminProxies extends Vue {
     this.$store.direct.dispatch.admin.clearSearch();
   }
 
-  @Watch("searchPlayerProxiesModel")
+  @Watch("searchPlayerModel")
   public async onSearchStringChanged(
-    searchedPlayer: SearchedPlayer
+    searchedPlayer: PlayerProfile
   ): Promise<void> {
     if (!searchedPlayer) return;
 
     if (searchedPlayer) {
-      const bTag = searchedPlayer.player.playerIds[0].battleTag;
+      const bTag = searchedPlayer.battleTag;
 
-      const proxies = await this.$store.direct.dispatch.admin.getProxiesForPlayer(
-        bTag
-      );
+      const proxies = await this.$store.direct.dispatch.admin.getProxiesForPlayer(bTag);
       await this.setPlayerProxies(proxies);
 
       if (proxies._id != null || undefined) {
@@ -84,7 +84,7 @@ export default class AdminProxies extends Vue {
 
   @Watch("search")
   public onSearchChanged(newValue: string): void {
-    if (newValue && newValue.length > 2 && newValue >= this.oldSearchTerm) {
+    if (newValue && newValue.length > 2 && newValue !== this.oldSearchTerm) {
       this.$store.direct.dispatch.admin.searchBnetTag({
         searchText: newValue.toLowerCase(),
       });
@@ -94,7 +94,7 @@ export default class AdminProxies extends Vue {
     }
   }
 
-  get searchedPlayers(): SearchedPlayer[] {
+  get searchedPlayers(): PlayerProfile[] {
     return this.$store.direct.state.admin.searchedPlayers;
   }
 

--- a/src/store/admin/index.ts
+++ b/src/store/admin/index.ts
@@ -6,13 +6,13 @@ import mapsManagementModule from "./maps/index";
 import infoMessageManagementModule from "./messages/index";
 import tournamentsManagementModule from "./tournaments";
 import replayManagementModule from "./replays/index";
+import { PlayerProfile } from "@/store/player/types";
 
 import {
   AdminState,
   BannedPlayer,
   Proxy,
   QueueData,
-  SearchedPlayer,
   ProxySettings,
   OverridesList,
   GloballyMutedPlayer,
@@ -120,13 +120,9 @@ const mod = {
       context: ActionContext<AdminState, RootState>,
       search: { searchText: string }
     ) {
-      const { commit, rootGetters, rootState } = moduleActionContext(context, mod);
+      const { commit, rootGetters } = moduleActionContext(context, mod);
 
-      const searchedPlayers = await rootGetters.adminService.searchByTag(
-        search.searchText,
-        rootState.oauth.token
-      );
-
+      const searchedPlayers = await rootGetters.profileService.searchPlayer(search.searchText);
       commit.SET_SEARCH_FOR_BNET_TAG(searchedPlayers);
     },
 
@@ -254,7 +250,7 @@ const mod = {
     SET_AVAILABLEPROXIES(state: AdminState, availableProxies: Proxy[]) {
       state.availableProxies = availableProxies;
     },
-    SET_SEARCH_FOR_BNET_TAG(state: AdminState, searchedPlayers: SearchedPlayer[]) {
+    SET_SEARCH_FOR_BNET_TAG(state: AdminState, searchedPlayers: PlayerProfile[]) {
       state.searchedPlayers = searchedPlayers;
     },
     SET_SEARCHED_PROXIES_FOR_BATTLETAG(state: AdminState, proxies: ProxySettings) {

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -1,13 +1,14 @@
 import { PlayerOverview } from "@/store/ranking/types";
 import { EChatScope } from "../common/typings";
 import { EColors } from "../typings";
+import { PlayerProfile } from "@/store/player/types";
 
 export type AdminState = {
   total: number;
   players: BannedPlayer[];
   queuedata: QueueData[];
   availableProxies: Proxy[];
-  searchedPlayers: SearchedPlayer[];
+  searchedPlayers: PlayerProfile[];
   proxiesSetForSearchedPlayer: ProxySettings;
   searchedBattletag: string;
   modifiedProxies: ProxySettings;


### PR DESCRIPTION
Lets you do the following actions, which previously only were available on ranked users:

1. Global mute
2. Smurf checker
3. Proxy settings
4. Assign portraits

Also some QoL like automatic keyboard focus on input element.