### PR TITLE
Use mapname in global stats

### DIFF
--- a/src/components/overall-statistics/MapsPerSeasonChart.vue
+++ b/src/components/overall-statistics/MapsPerSeasonChart.vue
@@ -17,7 +17,7 @@ export default class MapsPerSeasonChart extends Vue {
 
   get mapNames() {
     return this.mapsPerSeason.map((m) =>
-      this.$t(`mapNames.${m.map}`).toString()
+      m.mapName ?? m.map
     );
   }
 

--- a/src/store/overallStats/types.ts
+++ b/src/store/overallStats/types.ts
@@ -121,6 +121,7 @@ export interface PopularGameHour {
 
 export interface MapCount {
   map: string;
+  mapName : string;
   count: number;
 }
 


### PR DESCRIPTION
https://w3champions.atlassian.net/browse/W3C-86
Small fix to use property from back instead of translation.