### PR TITLE
Lazy load country flag module

### DIFF
--- a/src/components/common/CountryFlagExtended.vue
+++ b/src/components/common/CountryFlagExtended.vue
@@ -18,7 +18,9 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { CountriesByCode } from "@/store/countries";
-import CountryFlag from "vue-country-flag";
+
+// Lazy load.
+const CountryFlag = () => import("vue-country-flag");
 
 @Component({ components: { CountryFlag } })
 export default class CountryFlagExtended extends Vue {

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -351,10 +351,12 @@ import { Component, Prop } from "vue-property-decorator";
 import { ERaceEnum, EAvatarCategory } from "@/store/typings";
 import { ECountries } from "@/store/countries";
 import { AkaSettings, SpecialPicture } from "../../store/personalSettings/types";
-import CountryFlag from "vue-country-flag";
 import PlayerSocials from "./PlayerSocials.vue";
 import { getAvatarUrl } from "../../helpers/url-functions";
 import { enumKeys } from "../../helpers/general";
+
+// Lazy load.
+const CountryFlag = () => import("vue-country-flag");
 
 type CountryType = { country: string; countryCode: string };
 

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -123,13 +123,15 @@ import {
 } from "@/store/ranking/types";
 import { EGameMode, ERaceEnum, OngoingMatches } from "@/store/typings";
 import { Countries } from "@/store/countries";
-import CountryFlag from "vue-country-flag";
 import LeagueIcon from "@/components/ladder/LeagueIcon.vue";
 import GatewaySelect from "@/components/common/GatewaySelect.vue";
 import GameModeSelect from "@/components/common/GameModeSelect.vue";
 import CountryRankingsGrid from "@/components/ladder/CountryRankingsGrid.vue";
 import AppConstants from "../constants";
 import { getProfileUrl } from "@/helpers/url-functions";
+
+// Lazy load.
+const CountryFlag = () => import("vue-country-flag");
 
 @Component({
   components: {


### PR DESCRIPTION
## Change

Only load country images if they are used in view.

## Advantage

Reduces initial loading traffic and time. Good for low network speed.

## Disadvantage

Loaded later, delay happen later.

## Neutral

Split into an additional artifact ~200kb:
![grafik](https://user-images.githubusercontent.com/7337347/220616637-6fbb5e16-e1e6-4897-bde9-b2bf4da206b1.png)
