### PR TITLE
Refactor game duration format

### DIFF
--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -109,6 +109,7 @@ import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
 import HostIcon from "@/components/matches/HostIcon.vue";
 import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
 import MatchMixin from "@/mixins/MatchMixin";
+import { formatSecondsToDuration } from "@/helpers/date-functions";
 
 @Component({
   components: {
@@ -221,17 +222,11 @@ export default class MatchesGrid extends Mixins(MatchMixin) {
     return moment(match.startTime).format(this.$t("dateFormats.dateTime").toString());
   }
 
-  public getDuration(match: Match) {
+  public getDuration(match: Match): string {
     if (this.unfinished) {
-      return this.$t("matchStatuses.onGoing");
+      return this.$t("matchStatuses.onGoing").toString();
     }
-
-    const format = match.durationInSeconds <= 3600 ? this.$t("dateFormats.timeShort") : this.$t("dateFormats.timeLong");
-
-    return moment
-      .utc(moment.duration(match.durationInSeconds, "seconds").asMilliseconds())
-      .format(format.toString())
-      .toString();
+    return formatSecondsToDuration(match.durationInSeconds);
   }
 
   showReplayDownload(item: Match): boolean {

--- a/src/components/overall-statistics/GameLengthChart.vue
+++ b/src/components/overall-statistics/GameLengthChart.vue
@@ -9,6 +9,7 @@ import moment from "moment";
 import BarChart from "@/components/overall-statistics/BarChart.vue";
 import { ChartData } from "chart.js";
 import Vue from "vue";
+import { formatSecondsToDuration } from "@/helpers/date-functions";
 
 @Component({
   components: { BarChart },
@@ -22,12 +23,8 @@ export default class GameLengthChart extends Vue {
     return times;
   }
 
-  get passedTime() {
-    return this.getTrimmedTimes().map((g) =>
-      moment
-        .utc(moment.duration(g.passedTimeInSeconds, "seconds").asMilliseconds())
-        .format("mm:ss")
-    );
+  get passedTime(): string[] {
+    return this.getTrimmedTimes().map((g) => formatSecondsToDuration(g.passedTimeInSeconds));
   }
 
   get gamesCount() {

--- a/src/helpers/date-functions.ts
+++ b/src/helpers/date-functions.ts
@@ -1,0 +1,10 @@
+import { Duration, intervalToDuration } from "date-fns";
+
+export const formatSecondsToDuration = (seconds: number): string => {
+  const duration: Duration = intervalToDuration({ start: 0, end: seconds * 1000 });
+  let result: string = duration.minutes?.toString().padStart(2, "0") + ":" + duration.seconds?.toString().padStart(2, "0");
+  if (duration.hours !== undefined && 0 < duration.hours) {
+    result = duration.hours.toString() + ":" + result;
+  }
+  return result;
+};

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2,8 +2,6 @@ const en = {
   dateFormats: {
     date: "DD-MMM-YYYY",
     dateTime: "DD-MMM-YYYY HH:mm",
-    timeShort: "mm:ss",
-    timeLong: "H:mm:ss",
   },
 
   races: {

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -195,6 +195,7 @@ import { Gateways } from "@/store/ranking/types";
 import HostIcon from "@/components/matches/HostIcon.vue";
 import MatchMixin from "@/mixins/MatchMixin";
 import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
+import { formatSecondsToDuration } from "@/helpers/date-functions";
 
 @Component({
   components: {
@@ -235,19 +236,8 @@ export default class MatchDetailView extends Mixins(MatchMixin) {
     return [this.ffaWinner, ...this.ffaLoosers];
   }
 
-  get matchDuration() {
-    const format =
-      this.match.durationInSeconds <= 3600
-        ? this.$t("dateFormats.timeShort")
-        : this.$t("dateFormats.timeLong");
-    return moment
-      .utc(
-        moment
-          .duration(this.match.durationInSeconds, "seconds")
-          .asMilliseconds()
-      )
-      .format(format.toString())
-      .toString();
+  get matchDuration(): string {
+    return formatSecondsToDuration(this.match.durationInSeconds);
   }
 
   get playedDate() {


### PR DESCRIPTION
## Reasons

`Moment` is not required to format seconds. -> refactored
Locales do not use custom format. -> removed

## Reference

#621