### PR TITLE
Update `chart.js` from v2 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@mdi/font": "^6.9.96",
-    "chart.js": "^2.9.4",
+    "chart.js": "^4.2.1",
     "chartjs-adapter-date-fns": "^3.0.0",
-    "chartjs-plugin-annotation": "^0.5.7",
+    "chartjs-plugin-annotation": "^2.1.2",
     "core-js": "^3.27.1",
     "date-fns": "^2.29.3",
     "date-fns-tz": "^2.0.0",
@@ -28,7 +28,7 @@
     "tiptap": "^1.32.2",
     "tiptap-extensions": "^1.35.2",
     "vue": "^2.7.14",
-    "vue-chartjs": "^3.5.1",
+    "vue-chartjs": "^5.2.0",
     "vue-class-component": "^7.2.6",
     "vue-cookies-ts": "^1.5.19",
     "vue-country-flag": "^2.3.2",
@@ -40,8 +40,6 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
-    "@types/chart.js": "^2.9.37",
-    "@types/chartjs-plugin-annotation": "^0.5.2",
     "@types/debounce": "^1.2.1",
     "@types/google-spreadsheet": "^3.3.0",
     "@types/lodash": "^4.14.191",

--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -25,7 +25,7 @@ export default class ActivityPerDayChart extends Vue {
     return this.gameDays.filter((g) => g.gameMode == EGameMode.GM_1ON1)[0];
   }
 
-  get gameHourChartData(): ChartData {
+  get gameHourChartData(): ChartData<"line", unknown> {
     return {
       labels: this.gameDayDates,
       datasets: this.gameDays
@@ -54,9 +54,11 @@ export default class ActivityPerDayChart extends Vue {
                 };
               })
               .splice(0, c.gameDays.length - 1),
+            fill: true,
             backgroundColor: "rgba(126,126,126,0.08)",
             borderColor: this.mapColor(c.gameMode),
             borderWidth: 1.5,
+            tension: 0.4, // Smooth line.
           };
         }),
     };

--- a/src/components/overall-statistics/AmountPerDayChart.vue
+++ b/src/components/overall-statistics/AmountPerDayChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <line-chart :chart-data="gameHourChartData" />
+  <line-chart :chart-data="chartData" />
 </template>
 <script lang="ts">
 import { Component, Prop } from "vue-property-decorator";
@@ -23,16 +23,18 @@ export default class AmountPerDayChart extends Vue {
     return this.gameDays.map((g) => g.gamesPlayed);
   }
 
-  get gameHourChartData(): ChartData {
+  get chartData(): ChartData {
     return {
       labels: this.gameDayDates,
       datasets: [
         {
           label: this.$t("components_overall-statistics_tabs_playeractivitytab.playersperday").toString(),
           data: this.gameDayCounts,
+          fill: true,
           backgroundColor: "rgba(54, 162, 235, 0.2)",
           borderColor: "rgba(54, 162, 235, 1)",
-          borderWidth: 1,
+          borderWidth: 1.5,
+          tension: 0.4, // Smooth line.
         },
       ],
     };

--- a/src/components/overall-statistics/BarChart.vue
+++ b/src/components/overall-statistics/BarChart.vue
@@ -1,69 +1,59 @@
+<template>
+  <bar-chart-generic
+      :data="chartData"
+      :options="chartOptions"
+  />
+</template>
+
 <script lang="ts">
-import { Component, Prop, Mixins, Watch } from "vue-property-decorator";
-import { Bar, mixins } from "vue-chartjs";
-import { ChartData, ChartOptions } from "chart.js";
-import chartjsPluginAnnotation from "chartjs-plugin-annotation";
+import { Chart as ChartJS, ChartOptions } from "chart.js/auto";
+import chartJSPluginAnnotation from "chartjs-plugin-annotation";
+import { Bar as BarChartGeneric } from "vue-chartjs";
 
-@Component({
-  mixins: [mixins.reactiveProp],
-})
-export default class BarChart extends Mixins(Bar) {
-  @Prop() public chartOptions: ChartOptions | undefined;
-  @Prop() public chartData!: ChartData;
+ChartJS.register(chartJSPluginAnnotation);
 
-  get options() {
-    return this.chartOptions ?? this.defaultOptions;
-  }
-
-  //default options
-  private defaultOptions: ChartOptions = {
-    legend: {
-      display: true,
-    },
-    tooltips: {
-      bodyAlign: "center",
-      custom: function (tooltip: { displayColors: boolean }) {
-        if (!tooltip) return;
-        tooltip.displayColors = false;
+const defaultOptions = (): ChartOptions => {
+  return {
+    plugins: {
+      legend: {
+        display: true,
       },
-      callbacks: {
-        label: function (tooltipItem: { xLabel: string; yLabel: string }) {
-          return `${tooltipItem.xLabel} - ${tooltipItem.yLabel}`;
-        },
-        title: function () {
-          return "";
+      tooltip: {
+        bodyAlign: "center",
+        displayColors: false,
+        callbacks: {
+          label: (tooltipItem: { label: string; formattedValue: string }) => {
+            return `${tooltipItem.label} - ${tooltipItem.formattedValue}`;
+          },
+          title: () => {
+            return "";
+          },
         },
       },
     },
-    maintainAspectRatio: false,
+    maintainAspectRatio: true,
     scales: {
-      yAxes: [
-        {
-          ticks: {
-            beginAtZero: true,
-          },
-        },
-      ],
-      xAxes: [
-        {
-          ticks: {
-            reverse: false,
-          },
-        },
-      ],
+      y: { beginAtZero: true },
+      x: { reverse: false },
     },
   };
+};
 
-  mounted() {
-    if (this.chartData) {
-      this.addPlugin([chartjsPluginAnnotation]);
-      this.renderChart(this.chartData, this.options);
-    }
-  }
-
-  @Watch("chartOptions", { deep: true })
-  onOptionsChanged(newOptions: ChartOptions) {
-    if (this.chartData) this.renderChart(this.chartData, newOptions);
-  }
-}
+export default {
+  name: "BarChart",
+  components: { BarChartGeneric },
+  props: {
+    chartData: {
+      type: Object,
+    },
+    chartOptions: {
+      type: Object,
+      default: defaultOptions,
+    },
+    // datasetIdKey: {
+    //   type: String,
+    //   default: "label",
+    // },
+  },
+};
 </script>

--- a/src/components/overall-statistics/BarChart.vue
+++ b/src/components/overall-statistics/BarChart.vue
@@ -6,10 +6,16 @@
 </template>
 
 <script lang="ts">
-import { Chart as ChartJS, ChartOptions } from "chart.js/auto";
+import { BarController, BarElement, CategoryScale, Chart as ChartJS, ChartOptions, Filler, LinearScale, Tooltip } from "chart.js";
 import chartJSPluginAnnotation from "chartjs-plugin-annotation";
 import { Bar as BarChartGeneric } from "vue-chartjs";
 
+ChartJS.register(BarController);
+ChartJS.register(BarElement);
+ChartJS.register(CategoryScale);
+ChartJS.register(LinearScale);
+ChartJS.register(Filler);
+ChartJS.register(Tooltip);
 ChartJS.register(chartJSPluginAnnotation);
 
 const defaultOptions = (): ChartOptions => {

--- a/src/components/overall-statistics/LineChart.vue
+++ b/src/components/overall-statistics/LineChart.vue
@@ -1,95 +1,75 @@
+<template>
+  <line-chart-generic
+      :data="chartData"
+      :options="chartOptions"
+  />
+</template>
+
 <script lang="ts">
-import { Component, Prop, Mixins } from "vue-property-decorator";
-import { Line, mixins } from "vue-chartjs";
-import { ChartData, TimeUnit } from "chart.js";
+import { Chart as ChartJS, ChartOptions } from "chart.js/auto";
+import chartJSPluginAnnotation from "chartjs-plugin-annotation";
+import { Line as LineChartGeneric } from "vue-chartjs";
 import "chartjs-adapter-date-fns";
 
-@Component({
-  mixins: [mixins.reactiveProp],
-})
-export default class LineChart extends Mixins(Line) {
-  @Prop() public chartData!: ChartData;
-  @Prop() public customYAxes?: {
-    ticks: {
-      beginAtZero: true;
-    };
-  }[];
+ChartJS.register(chartJSPluginAnnotation);
 
-  private options = {
-    legend: {
-      display: true,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const defaultOptionsXAxis: any = {
+  type: "time",
+  time: {
+    unit: "day",
+    tooltipFormat: "MMM dd, yyyy",
+    displayFormats: {
+      day: "MMM dd, yyyy",
     },
-    tooltips: {
-      custom: function (tooltip: { displayColors: boolean }) {
-        if (!tooltip) return;
-        tooltip.displayColors = false;
+  },
+};
+
+export const defaultOptions = (): ChartOptions => {
+  return {
+    plugins: {
+      legend: {
+        display: true,
       },
-      callbacks: {
-        label: function (tooltipItem: { xLabel: string; yLabel: string }) {
-          return `${tooltipItem.xLabel} - ${tooltipItem.yLabel}`;
-        },
-        title: function () {
-          return "";
+      tooltip: {
+        bodyAlign: "center",
+        displayColors: false,
+        // mode: "index",
+        position: "nearest",
+        callbacks: {
+          label: (tooltipItem: { label: string; formattedValue: string }) => {
+            return `${tooltipItem.label} - ${tooltipItem.formattedValue}`;
+          },
+          title: () => {
+            return "";
+          },
         },
       },
     },
-    maintainAspectRatio: false,
+    maintainAspectRatio: true,
     scales: {
-      yAxes: [
-        {
-          ticks: {
-            beginAtZero: true,
-          },
-        },
-      ],
-      xAxes: [
-        {
-          type: "time",
-          time: {
-            // Cast prevents a bug
-            unit: "day" as TimeUnit,
-            displayFormats: {
-              day: "MMM dd, yyyy",
-            },
-          },
-        },
-      ],
+      y: { beginAtZero: true },
+      x: defaultOptionsXAxis,
     },
     elements: {
       point: {
-        radius: 1,
+        radius: 2,
       },
     },
   };
+};
 
-  mounted() {
-    // For each line in graph, create gradient backgroundColor
-    if (this.chartData.datasets) {
-      const canv = document.getElementById("line-chart") as HTMLCanvasElement;
-      for (let _i = 0; _i < this.chartData.datasets.length; _i++) {
-        const color = this.chartData.datasets[_i]?.borderColor as string;
-        if (color) {
-          const gradient = canv
-            .getContext("2d")
-            ?.createLinearGradient(0, 0, 0, canv.height);
-          // regex takes "(X,X,X" from color string
-          // e.g. "rgb(23, 21, 42)" -> "(23, 21, 42"
-          // this will be assembled to full string e.g. "rgba(23, 21, 42, 0.5)"
-          const regex = /\((\d*,\s?){2}\d*/g;
-          gradient?.addColorStop(0.1, "rgba" + color.match(regex) + ", 0.75)");
-          gradient?.addColorStop(0.3, "rgba" + color.match(regex) + ", 0.50)");
-          gradient?.addColorStop(0.6, "rgba" + color.match(regex) + ", 0.25)");
-          gradient?.addColorStop(0.85, "rgba" + color.match(regex) + ", 0.0)");
-          this.chartData.datasets[_i].backgroundColor = gradient;
-        }
-      }
-    }
-    if (this.customYAxes !== undefined) {
-      this.options.scales.yAxes = this.customYAxes;
-    }
-    if (this.chartData) {
-      this.renderChart(this.chartData, this.options);
-    }
+export default {
+  name: "LineChart",
+  components: { LineChartGeneric },
+  props: {
+    chartData: {
+      type: Object,
+    },
+    chartOptions: {
+      type: Object,
+      default: defaultOptions,
+    },
   }
-}
+};
 </script>

--- a/src/components/overall-statistics/LineChart.vue
+++ b/src/components/overall-statistics/LineChart.vue
@@ -6,15 +6,33 @@
 </template>
 
 <script lang="ts">
-import { Chart as ChartJS, ChartOptions } from "chart.js/auto";
+import {
+  Chart as ChartJS,
+  ChartOptions,
+  Filler,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  ScaleOptions,
+  TimeScale,
+  Tooltip,
+} from "chart.js";
+import "chartjs-adapter-date-fns";
 import chartJSPluginAnnotation from "chartjs-plugin-annotation";
 import { Line as LineChartGeneric } from "vue-chartjs";
-import "chartjs-adapter-date-fns";
 
+ChartJS.register(LineController);
+ChartJS.register(LineElement);
+ChartJS.register(PointElement);
+ChartJS.register(TimeScale);
+ChartJS.register(LinearScale);
+ChartJS.register(Filler);
+ChartJS.register(Tooltip);
 ChartJS.register(chartJSPluginAnnotation);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const defaultOptionsXAxis: any = {
+export const defaultOptionsXAxis: ScaleOptions<"time"> = {
   type: "time",
   time: {
     unit: "day",

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -9,8 +9,7 @@
 </template>
 <script lang="ts">
 import { PlayerMmrRpTimeline } from "@/store/player/types";
-import { ChartData } from "chart.js";
-import { ChartOptions } from "chart.js/auto";
+import { ChartData , ChartOptions } from "chart.js";
 import { parseJSON, startOfDay } from "date-fns";
 import { utcToZonedTime } from "date-fns-tz";
 import { Component, Prop } from "vue-property-decorator";

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -3,17 +3,18 @@
     <line-chart
       ref="chart"
       :chart-data="mmrRpChartData"
-      :custom-y-axes="YAxesSettings"
+      :chart-options="chartOptions"
     />
   </div>
 </template>
 <script lang="ts">
 import { PlayerMmrRpTimeline } from "@/store/player/types";
 import { ChartData } from "chart.js";
+import { ChartOptions } from "chart.js/auto";
 import { parseJSON, startOfDay } from "date-fns";
 import { utcToZonedTime } from "date-fns-tz";
 import { Component, Prop } from "vue-property-decorator";
-import LineChart from "@/components/overall-statistics/LineChart.vue";
+import LineChart, { defaultOptions, defaultOptionsXAxis } from "@/components/overall-statistics/LineChart.vue";
 import Vue from "vue";
 
 @Component({
@@ -35,30 +36,28 @@ export default class PlayerMmrRpTimelineChart extends Vue {
     return this.mmrRpTimeline.mmrRpAtDates.map((m) => startOfDay(utcToZonedTime(parseJSON(m.date), "UTC")));
   }
 
-  get YAxesSettings() {
-    return [
-      {
-        id: "y-axis-0",
-        ticks: {
+  get chartOptions(): ChartOptions {
+    const options: ChartOptions = {
+      scales: {
+        x: defaultOptionsXAxis,
+        y: {
           beginAtZero: false,
+          title: {
+            display: true,
+            text: "MMR",
+          },
         },
-        scaleLabel: {
-          display: true,
-          labelString: "MMR",
+        y1: {
+          position: "right",
+          beginAtZero: false,
+          title: {
+            display: true,
+            text: "RP",
+          },
         },
       },
-      {
-        id: "y-axis-1",
-        position: "right",
-        ticks: {
-          beginAtZero: false,
-        },
-        scaleLabel: {
-          display: true,
-          labelString: "RP",
-        },
-      },
-    ];
+    };
+    return { ...defaultOptions(), ...options };
   }
 
   get mmrRpChartData(): ChartData {
@@ -66,24 +65,30 @@ export default class PlayerMmrRpTimelineChart extends Vue {
       labels: this.Dates,
       datasets: [
         {
+          yAxisID: "y",
           label: "MMR",
           data: this.mmrValues,
           borderColor: "rgba(54, 162, 235, 1)",
+          fill: true,
+          backgroundColor: "rgba(54, 162, 235, 0.2)",
           borderWidth: 1.0,
           pointStyle: "circle",
           pointRadius: 1.2,
           pointBorderWidth: 1.8,
+          tension: 0.4, // Smooth line.
         },
         {
+          yAxisID: "y1",
           label: "RP",
           data: this.rpValues,
           borderColor: "rgba(150, 80, 100, 1)",
-          backgroundColor: "rgba(126,126,126,0.08)",
+          fill: true,
+          backgroundColor: "rgba(150, 80, 100, 0.2)",
           borderWidth: 1.0,
           pointStyle: "circle",
           pointRadius: 1.2,
           pointBorderWidth: 1.8,
-          yAxisID: "y-axis-1",
+          tension: 0.4, // Smooth line.
         },
       ],
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,6 +1059,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
+  integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -1173,21 +1178,6 @@
   integrity sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
   dependencies:
     "@types/node" "*"
-
-"@types/chart.js@*", "@types/chart.js@^2.7.55", "@types/chart.js@^2.9.37":
-  version "2.9.37"
-  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.37.tgz#8af70862b154fedf938b5b87debdb3a70f6e3208"
-  integrity sha512-9bosRfHhkXxKYfrw94EmyDQcdjMaQPkU1fH2tDxu8DWXxf1mjzWQAV4laJF51ZbC2ycYwNDvIm1rGez8Bug0vg==
-  dependencies:
-    moment "^2.10.2"
-
-"@types/chartjs-plugin-annotation@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.2.tgz#559447274c3c7b1fdbde343babf9d5767001b409"
-  integrity sha512-dg7v6xQyi6T0/lmgRqIlJGc4Y52MvYYrqDAQgNu6nD2G/3VXfAV0TSFIbs7VbqINmnxZSWIYbHz7rzemRM/TeQ==
-  dependencies:
-    "@types/chart.js" "*"
-    moment "^2.10.2"
 
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
@@ -2364,40 +2354,22 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chart.js@^2.4.0, chart.js@^2.9.4:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
-  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
+chart.js@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.2.1.tgz#d2bd5c98e9a0ae35408975b638f40513b067ba1d"
+  integrity sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==
   dependencies:
-    chartjs-color "^2.1.0"
-    moment "^2.10.2"
+    "@kurkle/color" "^0.3.0"
 
 chartjs-adapter-date-fns@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
   integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
 
-chartjs-color-string@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
-  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
-  dependencies:
-    color-name "^1.0.0"
-
-chartjs-color@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
-  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
-  dependencies:
-    chartjs-color-string "^0.6.0"
-    color-convert "^1.9.3"
-
-chartjs-plugin-annotation@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.7.tgz#1bf0e30199a6a9ff9889ce0f37a1e755a80d10bf"
-  integrity sha512-tKN5KLc69unyZGTvSdhVQEyAOhVNnSkFCCgefZhO4UaqFfABZGFU/d9p6WM2KB0eXFs/rR3Jayh7dvyASC7K0A==
-  dependencies:
-    chart.js "^2.4.0"
+chartjs-plugin-annotation@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-annotation/-/chartjs-plugin-annotation-2.1.2.tgz#8c307c931fda735a1acf1b606ad0e3fd7d96299b"
+  integrity sha512-kmEp2WtpogwnKKnDPO3iO3mVwvVGtmG5BkZVtAEZm5YzJ9CYxojjYEgk7OTrFbJ5vU098b84UeJRe8kRfNcq5g==
 
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.5.3"
@@ -2494,7 +2466,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-color-convert@^1.9.0, color-convert@^1.9.3:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -2513,7 +2485,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4639,11 +4611,6 @@ module-alias@^2.2.2:
   resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
   integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
 
-moment@^2.10.2:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 mrmime@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
@@ -6542,12 +6509,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vue-chartjs@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.5.1.tgz#d25e845708f7744ae51bed9d23a975f5f8fc6529"
-  integrity sha512-foocQbJ7FtveICxb4EV5QuVpo6d8CmZFmAopBppDIGKY+esJV8IJgwmEW0RexQhxqXaL/E1xNURsgFFYyKzS/g==
-  dependencies:
-    "@types/chart.js" "^2.7.55"
+vue-chartjs@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-5.2.0.tgz#3d0076ccf8016d1bf8fab5ccd837e7fb81005ded"
+  integrity sha512-d3zpKmGZr2OWHQ1xmxBcAn5ShTG917+/UCLaSpaCDDqT0U7DBsvFzTs69ZnHCgKoXT55GZDW8YEj9Av+dlONLA==
 
 vue-class-component@^7.2.6:
   version "7.2.6"


### PR DESCRIPTION
* Update dependency `chart.js`
* Update dependency `vue-chartjs`
* Update dependency `chartjs-plugin-annotation`
* No `moment` dependency by `chart.js`
* Tree-shaking support (not used yet)
* Fixed tooltip bug introduced with migration to date-fns-adapter
* Removed gradient color fill

## Reference

Closes #621