### PR TITLE
Fix & update preconnect / prefetch DNS to improve pagespeed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>W3Champions</title>
-    <link rel="preconnect" href="<%= BASE_URL %>">
-    <link rel="dns-prefetch" href="<%= BASE_URL %>">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico?v=5">
+
+    <!-- Preconnect TLS and prefetch DNS to improve pagespeed. -->
+    <link rel="preconnect" href="https://w3champions.wc3.tools" crossorigin>
+    <link rel="preconnect" href="https://website-backend.w3champions.com" crossorigin>
+    <link rel="preconnect" href="https://identification-service.w3champions.com" crossorigin>
+    <link rel="dns-prefetch" href="https://api.twitch.tv" crossorigin>
+
     <script type="text/javascript" src="<%= BASE_URL %>env.js?v=4"></script>
   </head>
   <body>


### PR DESCRIPTION
## Change

* `preconnect` (DNS lookup + TLS connection) to the essential domains for a functional website.
* Use only 3 times `preconnect` because more can have negative effect and would exceed the current recommendation.
* Use `dns-prefetch` (DNS lookup) for lower prioritized APIs.
* Both techniques may shorten the delay of the loading process and thus improve the user experience.

## Reference

Fixup of #467 .