### PR TITLE
Use direct import for `lodash` to reduce build size

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     // "@vue/prettier/@typescript-eslint"
     // "@vue/typescript/recommended",
     // "@vue/prettier/@typescript-eslint",
+    "plugin:lodash/recommended",
   ],
   parser: "vue-eslint-parser",
   parserOptions: {
@@ -48,5 +49,11 @@ module.exports = {
     "vue/valid-v-slot": ["error", {
       allowModifiers: true,
     }],
+    "lodash/import-scope": ["error", "method"],
+    "lodash/prefer-constant": "off",
+    "lodash/prefer-lodash-method": "off",
+    "lodash/prefer-lodash-typecheck": "off",
+    "lodash/prefer-matches": "off",
+    "lodash/prop-shorthand": "off",
   },
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dotenv": "^16.0.3",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-vue": "^9.8.0",
     "eslint-plugin-vuetify": "^1.1.0",

--- a/src/components/admin/AdminMaps.vue
+++ b/src/components/admin/AdminMaps.vue
@@ -36,7 +36,7 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import EditMap from "./maps/EditMap.vue";
 import EditMapFiles from "./maps/EditMapFiles.vue";
-import _ from "lodash";
+import isUndefined from "lodash/isUndefined";
 
 @Component({ components: { EditMap, EditMapFiles } })
 export default class AdminMaps extends Vue {
@@ -68,7 +68,7 @@ export default class AdminMaps extends Vue {
   }
 
   public get maps() {
-    return _.isUndefined(this.search)
+    return isUndefined(this.search)
       ? this.$store.direct.state.admin.mapsManagement.maps
       : this.$store.direct.state.admin.mapsManagement.maps.filter((m) => {
         return m.category?.toLowerCase().includes(this.search!.toLowerCase()) ||

--- a/src/components/admin/AdminTournaments.vue
+++ b/src/components/admin/AdminTournaments.vue
@@ -61,7 +61,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import _ from "lodash";
+import throttle from "lodash/throttle";
 import { Component } from "vue-property-decorator";
 import { ITournament, ITournamentPlayer, ETournamentState } from "@/store/tournaments/types";
 import Tournament from "../tournaments/Tournament.vue";
@@ -85,7 +85,7 @@ export default class AdminTournaments extends Vue {
   public isCreateTournamentOpen = false;
   public isEditTournamentOpen = false;
 
-  private throttledInit = _.throttle(this.init, 2000, { leading: true });
+  private throttledInit = throttle(this.init, 2000, { leading: true });
 
   async mounted(): Promise<void> {
     this.throttledInit();

--- a/src/components/admin/tournaments/AddPlayerModal.vue
+++ b/src/components/admin/tournaments/AddPlayerModal.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-import _ from "lodash";
+import map from "lodash/map";
 import { ITournament } from "@/store/tournaments/types";
 import { ERaceEnum } from "@/store/typings";
 import Vue from "vue";
@@ -53,7 +53,7 @@ export default class AddPlayerModal extends Vue {
   public race: string = ERaceEnum.RANDOM.toString();
 
   get races() {
-    return _.map(ERaceEnumLabel, (raceName, raceId) => ({
+    return map(ERaceEnumLabel, (raceName, raceId) => ({
       raceId,
       raceName,
     }));

--- a/src/components/admin/tournaments/EditTournamentModal.vue
+++ b/src/components/admin/tournaments/EditTournamentModal.vue
@@ -138,7 +138,9 @@
 
 <script lang="ts">
 import { addDays, setHours, startOfHour } from "date-fns";
-import _ from "lodash";
+import map from "lodash/map";
+import pick from "lodash/pick";
+import pickBy from "lodash/pickBy";
 import { ETournamentFormat, ETournamentState, ITournament } from "@/store/tournaments/types";
 import { EGameMode } from "@/store/typings";
 import Vue from "vue";
@@ -212,7 +214,7 @@ export default class AddPlayerModal extends Vue {
       "registrationTimeMinutes", "readyTimeSeconds", "vetoTimeSeconds",
       "showWinnerTimeHours", "matcherinoUrl",
     ];
-    const tournamentData = _.pick(this, fieldNames);
+    const tournamentData = pick(this, fieldNames);
     this.$emit("save", tournamentData);
   }
 
@@ -221,7 +223,7 @@ export default class AddPlayerModal extends Vue {
   }
 
   get states() {
-    const validStates = _.pickBy(ETournamentState, (_value, key) => {
+    const validStates = pickBy(ETournamentState, (_value, key) => {
       return !isNaN(key as any);
     }) as { [key: number]: string };
     return this.getSelectOptions(validStates);
@@ -240,7 +242,7 @@ export default class AddPlayerModal extends Vue {
   }
 
   private getSelectOptions(labelMap: { [key: number]: string }) {
-    return _.map(labelMap, (name, id) => ({
+    return map(labelMap, (name, id) => ({
       id: +id,
       name,
     }));

--- a/src/components/ladder/CountryRankingsGrid.vue
+++ b/src/components/ladder/CountryRankingsGrid.vue
@@ -190,7 +190,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import * as _ from "lodash";
+import flatMap from "lodash/flatMap";
 import { Component, Prop, Watch } from "vue-property-decorator";
 import { Ranking, PlayerId, PlayerInfo, CountryRanking, League } from "@/store/ranking/types";
 import { EAvatarCategory, ERaceEnum, OngoingMatches } from "@/store/typings";
@@ -352,7 +352,7 @@ export default class CountryRankingsGrid extends Vue {
   }
 
   async getStreamStatus(): Promise<void> {
-    const twitchNames = _.flatMap(this.rankings, (cr) => cr.ranks).map(
+    const twitchNames = flatMap(this.rankings, (cr) => cr.ranks).map(
       (r) => r.playersInfo[0].twitchName
     );
 

--- a/src/components/ladder/RankingsRaceDistribution.vue
+++ b/src/components/ladder/RankingsRaceDistribution.vue
@@ -38,7 +38,8 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import { Ranking } from "@/store/ranking/types";
-import * as _ from "lodash";
+import groupBy from "lodash/groupBy";
+import orderBy from "lodash/orderBy";
 import { ERaceEnum } from "@/store/typings";
 
 @Component({
@@ -56,7 +57,7 @@ export default class RankingsRaceDistribution extends Vue {
 
     const result: { race: number; total: number; percent: number }[] = [];
 
-    const groupedByRace = _.groupBy(this.rankings, (x) => {
+    const groupedByRace = groupBy(this.rankings, (x) => {
       return x.race;
     });
 
@@ -78,7 +79,7 @@ export default class RankingsRaceDistribution extends Vue {
       }
     }
 
-    return _.orderBy(result, (x) => x.percent, "desc");
+    return orderBy(result, (x) => x.percent, "desc");
   }
 
   public getRaceName(race: number) {

--- a/src/components/overall-statistics/PlayedHeroesChart.vue
+++ b/src/components/overall-statistics/PlayedHeroesChart.vue
@@ -3,7 +3,10 @@
 </template>
 <script lang="ts">
 import Vue from "vue";
-import _ from "lodash";
+import chain from "lodash/chain";
+import map from "lodash/map";
+import round from "lodash/round";
+import sumBy from "lodash/sumBy";
 import { ChartData, ChartOptions } from "chart.js";
 import { Component, Prop } from "vue-property-decorator";
 import { PlayedHero } from "@/store/overallStats/types";
@@ -32,8 +35,7 @@ export default class PlayedHeroesChart extends Vue {
   @Prop() public playedHeroes!: PlayedHero[];
 
   get orderedHeroes(): PlayedHeroExtra[] {
-    return _
-        .chain(this.playedHeroes)
+    return chain(this.playedHeroes)
         .map((hero) => {
           const race = HERO_DATA[hero.icon].race;
           const color = RACE_COLORS[race];
@@ -47,11 +49,11 @@ export default class PlayedHeroesChart extends Vue {
         .groupBy("race")
         .mapValues((heroes, race) => {
           // Compute percentages within the race
-          const groupTotalCount = _.sumBy(heroes, "count");
-          const newHeroesData: PlayedHeroExtra[] = _.map(heroes, (hero) => ({
+          const groupTotalCount = sumBy(heroes, "count");
+          const newHeroesData: PlayedHeroExtra[] = map(heroes, (hero) => ({
             ...hero,
             icon: this.$t("heroNames." + hero.icon).toString(),
-            count: _.round(hero.count / groupTotalCount * 100, 1),
+            count: round(hero.count / groupTotalCount * 100, 1),
           }));
 
           // Add empty data point between races

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -56,7 +56,7 @@ import { EGameMode } from "@/store/typings";
 import { ModeStat } from "@/store/player/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 
 @Component({
   components: { RaceIcon, LevelProgress },
@@ -76,7 +76,7 @@ export default class ModeStatsGrid extends Mixins(GameModesMixin) {
 
     // Filter out AT modes that haven't been played, sort by ranking points and get the stat with the highest rank.
     const topAtStats = AT_arranged
-      .filter((modeStats) => !_.isEmpty(modeStats))
+      .filter((modeStats) => !isEmpty(modeStats))
       .map((modeStats) => modeStats.sort((modeStat) => modeStat.rankingPoints))
       .map((modeStats) => modeStats.filter((modeStat, index) => index === 0))
       .flat();

--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -29,7 +29,7 @@ import { getAsset } from "@/helpers/url-functions";
 import { PlayerStatsHeroOnMapVersusRace, RaceWinsOnMap, WinLossesOnMap, RaceStat } from "@/store/player/types";
 import { ERaceEnum } from "@/store/typings";
 import { races, defaultStatsTab } from "@/helpers/profile";
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 
 @Component({
   components: { RaceIcon, PlayerHeroStatisticsTable },
@@ -134,7 +134,7 @@ export default class PlayerHeroStatistics extends Vue {
       [ERaceEnum.TOTAL]: 0,
     };
 
-    if (_.isEmpty(heroStatsData)) return;
+    if (isEmpty(heroStatsData)) return;
 
     const winLossesOnMap = this.$store.direct.state.player.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
       .filter((obj: RaceWinsOnMap) => obj.race == this.selectedRace)[0]

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -34,7 +34,7 @@ import { RaceWinsOnMap } from "@/store/player/types";
 import RaceToMapStat from "@/components/overall-statistics/RaceToMapStat.vue";
 import { ERaceEnum } from "@/store/typings";
 import RaceIcon from "@/components/player/RaceIcon.vue";
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { defaultStatsTab } from "@/helpers/profile";
 
 @Component({
@@ -56,7 +56,7 @@ export default class PlayerStatsRaceVersusRaceOnMap extends Vue {
   }
 
   get isEmpty(): boolean {
-    return _.isEmpty(this.stats);
+    return isEmpty(this.stats);
   }
 
   // When loading the statistics tab via URL directly, due to Lifecycle Hooks the mounted() here

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import _ from "lodash";
+import isNil from "lodash/isNil";
 import { Component, Prop } from "vue-property-decorator";
 import { RaceWinLoss } from "@/store/overallStats/types";
 import { ERaceEnum } from "@/store/typings";
@@ -59,7 +59,7 @@ export default class PlayerStatsRaceVersusRaceOnMapTableCell extends Vue {
 
   get isComparingSameRace() {
     // We must explicitly check nil here because compareRace could be RANDOM and !0 is true
-    if (_.isNil(this.compareRace) || !this.stats) {
+    if (isNil(this.compareRace) || !this.stats) {
       return false;
     }
 

--- a/src/components/player/tabs/PlayerProfileTab.vue
+++ b/src/components/player/tabs/PlayerProfileTab.vue
@@ -78,7 +78,8 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import * as _ from "lodash";
+import sortBy from "lodash/sortBy";
+import take from "lodash/take";
 import PlayerLeague from "@/components/player/PlayerLeague.vue";
 import PlayerAvatar from "@/components/player/PlayerAvatar.vue";
 import ModeStatsGrid from "@/components/player/ModeStatsGrid.vue";
@@ -164,7 +165,7 @@ export default class PlayerProfileTab extends Vue {
 
     const rankedOneVOnes = oneVOnes.filter((x) => x.rank != 0);
 
-    let bestOneVOne = _.sortBy(rankedOneVOnes, [
+    let bestOneVOne = sortBy(rankedOneVOnes, [
       "leagueOrder",
       "division",
       "rank",
@@ -180,7 +181,7 @@ export default class PlayerProfileTab extends Vue {
 
     const rankedtwoV2s = twoV2s.filter((x) => x.rank != 0);
 
-    let besttwoV2s = _.sortBy(rankedtwoV2s, [
+    let besttwoV2s = sortBy(rankedtwoV2s, [
       "leagueOrder",
       "division",
       "rank",
@@ -196,7 +197,7 @@ export default class PlayerProfileTab extends Vue {
     );
 
     const otherModesRanked = otherModes.filter((g) => g.rank != 0);
-    const bestOtherModes = _.sortBy(otherModesRanked, [
+    const bestOtherModes = sortBy(otherModesRanked, [
       "leagueOrder",
       "division",
       "rank",
@@ -207,13 +208,13 @@ export default class PlayerProfileTab extends Vue {
     if (besttwoV2s) allModes.push(besttwoV2s);
     allModes.push(...bestOtherModes);
 
-    const bestAllModesSorted = _.sortBy(allModes, [
+    const bestAllModesSorted = sortBy(allModes, [
       "leagueOrder",
       "division",
       "rank",
     ]);
 
-    return _.take(
+    return take(
       bestAllModesSorted.filter((x) => x.rank != 0),
       3
     );

--- a/src/components/tournaments/TournamentBracket.vue
+++ b/src/components/tournaments/TournamentBracket.vue
@@ -28,7 +28,10 @@
 </template>
 
 <script lang="ts">
-import _ from "lodash";
+import assign from "lodash/assign";
+import fromPairs from "lodash/fromPairs";
+import pick from "lodash/pick";
+import times from "lodash/times";
 import { ETournamentState, ITournament, ITournamentRound, BracketDimensions } from "@/store/tournaments/types";
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
@@ -57,10 +60,10 @@ export default class TournamentBracket extends Vue {
   }
 
   get rounds(): ITournamentRound[] {
-    const playerExtraData = _.fromPairs(
+    const playerExtraData = fromPairs(
       this.tournament.players.map((p) => [
         p.battleTag,
-        _.pick(p, [ "countryCode", "race" ]),
+        pick(p, [ "countryCode", "race" ]),
       ])
     );
     for (const round of this.tournament.rounds) {
@@ -69,7 +72,7 @@ export default class TournamentBracket extends Vue {
           continue;
         }
         for (const player of series.players) {
-          _.assign(player, playerExtraData[player.battleTag]);
+          assign(player, playerExtraData[player.battleTag]);
         }
       }
     }
@@ -81,7 +84,7 @@ export default class TournamentBracket extends Vue {
     let verticalSpace = this.verticalSpace;
     let marginTop = 0;
     const dimensions: BracketDimensions[] = [];
-    _.times(this.rounds.length, () => {
+    times(this.rounds.length, () => {
       dimensions.push({
         verticalSpace,
         marginTop,

--- a/src/components/tournaments/TournamentSeriesPlayer.vue
+++ b/src/components/tournaments/TournamentSeriesPlayer.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import _ from "lodash";
+import isNil from "lodash/isNil";
 import { ISeriesPlayer } from "@/store/tournaments/types";
 import { Component, Prop } from "vue-property-decorator";
 import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
@@ -58,15 +58,15 @@ export default class TournamentSeriesPlayer extends Vue {
     if (!this.seriesFinished) {
       return "";
     }
-    if (_.isNil(this.player)) {
+    if (isNil(this.player)) {
       return "";
     }
 
     let score = "";
-    if (!_.isNil(this.player.score)) {
+    if (!isNil(this.player.score)) {
       score = this.player.score.toString();
     }
-    if (!_.isNil(this.player) && !this.seriesCanceled) {
+    if (!isNil(this.player) && !this.seriesCanceled) {
       score = this.player.won ? "1" : "0";
     }
     if (this.seriesSpecial) {
@@ -77,7 +77,7 @@ export default class TournamentSeriesPlayer extends Vue {
   }
 
   get raceClass() {
-    if (_.isNil(this.player)) {
+    if (isNil(this.player)) {
       return "";
     }
     const race = this.player.race;

--- a/src/mixins/GameModesMixin.ts
+++ b/src/mixins/GameModesMixin.ts
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import { EGameMode, EGameModeType } from "@/store/typings";
-import _ from "lodash";
+import chain from "lodash/chain";
 import { SeasonMap } from "@/store/admin/maps/types";
 
 const AT_EQUIVALENT: { [key: number]: EGameMode } = {
@@ -48,8 +48,7 @@ export default class GameModesMixin extends Vue {
   }
 
   private getGameModes(type: EGameModeType | null, withAt: boolean) {
-    return _
-      .chain(this.$store.direct.state.admin.mapsManagement.seasonMaps)
+    return chain(this.$store.direct.state.admin.mapsManagement.seasonMaps)
       .reduce((result: SeasonMap[], seasonMap: SeasonMap) => {
         result.push(seasonMap);
         if (withAt && AT_EQUIVALENT[seasonMap.id]) {

--- a/src/services/TournamentsService.ts
+++ b/src/services/TournamentsService.ts
@@ -1,4 +1,5 @@
-import _ from "lodash";
+import pickBy from "lodash/pickBy";
+import isUndefined from "lodash/isUndefined";
 import { ITournament, ITournamentPlayer } from "@/store/tournaments/types";
 import { API_URL } from "@/main";
 
@@ -117,9 +118,9 @@ export default class TournamentsService {
       "registrationTimeMinutes", "readyTimeSeconds", "vetoTimeSeconds",
       "showWinnerTimeHours", "matcherinoUrl",
     ];
-    const body = _.pickBy(
+    const body = pickBy(
       tournament,
-      (value, key) => fieldNames.includes(key) && !_.isUndefined(value)
+      (value, key) => fieldNames.includes(key) && !isUndefined(value)
     );
     body.registrationTimeMinutes = +body.registrationTimeMinutes!;
     body.readyTimeSeconds = +body.readyTimeSeconds!;

--- a/src/store/admin/maps/index.ts
+++ b/src/store/admin/maps/index.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { moduleActionContext } from "../..";
 import { RootState } from "../../typings";
 import { ActionContext } from "vuex";
@@ -50,7 +50,7 @@ const mod = {
       const { commit, rootGetters, state } = moduleActionContext(context, mod);
 
       // Season maps already fetched, skip
-      if (!_.isEmpty(state.seasonMaps)) {
+      if (!isEmpty(state.seasonMaps)) {
         return;
       }
 

--- a/src/store/ranking/index.ts
+++ b/src/store/ranking/index.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { moduleActionContext } from "..";
 import { CountryRanking, Ladder, Ranking, RankingState, Season } from "./types";
 import { DataTableOptions, EGameMode, RootState } from "../typings";
@@ -131,7 +131,7 @@ const mod = {
       const { commit, rootGetters, state } = moduleActionContext(context, mod);
 
       // Seasons already fetched, skip
-      if (!_.isEmpty(state.seasons)) {
+      if (!isEmpty(state.seasons)) {
         return;
       }
 

--- a/src/views/Tournaments.vue
+++ b/src/views/Tournaments.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import _ from "lodash";
+import difference from "lodash/difference";
 import { isFuture } from "date-fns";
 import TournamentsTable from "@/components/tournaments/TournamentsTable.vue";
 import { ITournament } from "@/store/tournaments/types";
@@ -44,7 +44,7 @@ export default class TournamentsView extends Vue {
   }
 
   get pastTournaments() {
-    return _.difference(this.tournaments, this.upcomingTournaments);
+    return difference(this.tournaments, this.upcomingTournaments);
   }
 
   public onRowClick(item: ITournament) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,6 +3122,13 @@ eslint-config-prettier@^8.3.0, eslint-config-prettier@^8.6.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
   integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
 
+eslint-plugin-lodash@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.4.0.tgz#14a761547f126c92ff56789662a20a44f8bb6290"
+  integrity sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==
+  dependencies:
+    lodash "^4.17.21"
+
 eslint-plugin-prettier@^4.0.0, eslint-plugin-prettier@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
## Changes

* Use direct import for `lodash` to reduce build size
* Add eslint plugin to ensure this for new code

## Test by compiling

### Difference

Size: -60 KiB
Gzipped: -20 KiB

### Current build

```txt
File                                   Size        Gzipped

dist\js\chunk-vendors.23b7ce38.js      977.84 KiB  281.33 KiB
dist\js\app.24457c62.js                778.11 KiB  296.48 KiB
dist\js\admin-view.d8e430e8.js         368.43 KiB  105.71 KiB
dist\js\840.c7ea0ea6.js                298.85 KiB  216.59 KiB
dist\env.js                            0.98 KiB    0.40 KiB
dist\css\chunk-vendors.01cf3aae.css    746.54 KiB  104.36 KiB
dist\css\app.755083fb.css              26.02 KiB   5.92 KiB
dist\css\admin-view.2e25e0f9.css       5.71 KiB    1.13 KiB
```

### Lodash optimized

```txt
File                                   Size        Gzipped

dist\js\chunk-vendors.f5f0c372.js      916.08 KiB  260.09 KiB
dist\js\app.e5b6a122.js                778.27 KiB  296.64 KiB
dist\js\admin-view.244bfdc7.js         369.80 KiB  106.26 KiB
dist\js\840.c7ea0ea6.js                298.85 KiB  216.59 KiB
dist\env.js                            0.98 KiB    0.40 KiB
dist\css\chunk-vendors.2a195454.css    746.55 KiB  104.36 KiB
dist\css\app.b65f6c24.css              26.10 KiB   5.92 KiB
dist\css\admin-view.2e25e0f9.css       5.71 KiB    1.13 KiB
```
