### PR TITLE
:bug: left side of playerInfo was not clickable in playerView

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -56,22 +56,16 @@
               </v-col>
             </v-row>
           </v-card-title>
-          <div
-            class="live-match__container"
-            v-if="ongoingMatch.id"
-            :class="ongoingMatchGameModeClass"
-          >
+          <div class="live-match__container" v-if="ongoingMatch.id" :class="ongoingMatchGameModeClass">
             <div class="live-match__indicator">
               Live
               <span class="circle red blinker"></span>
-              <span class="live-match__duration">
-                {{ getDuration(ongoingMatch) }}'
-              </span>
+              <span class="live-match__duration">{{ getDuration(ongoingMatch) }}'</span>
             </div>
             <div v-if="!isOngoingMatchFFA">
               <div class="live-match__team1">
                 <team-match-info
-                  :not-clickable="true"
+                  :not-clickable="isOngoingMatchFFA"
                   :team="getPlayerTeam(ongoingMatch)"
                   :unfinishedMatch="true"
                   left="true"
@@ -80,7 +74,7 @@
               <div class="live-match__vstext">VS</div>
               <div class="live-match__team2">
                 <team-match-info
-                  :not-clickable="false"
+                  :not-clickable="isOngoingMatchFFA"
                   :team="getOpponentTeam(ongoingMatch)"
                   :unfinishedMatch="true"
                   right="true"


### PR DESCRIPTION
Kovax reported this as a good first issue
Adressing leftside of playerInfo is not clickable in playerView:

To be tested: 

- [ ] It seems this clickbehavior was set up static before because players were able to see FFA playerInfo? We need to test if click is disable left and right on FFA - Currently I have no FFA Matches on livedata.

Question: This was because you should not be able to check other players in ffa right?

![image](https://user-images.githubusercontent.com/18357175/226171202-cff1f41b-9676-41af-a59e-4b4301a8d61e.png)
