### PR TITLE
Refactor `TwitchService` to static service

### DIFF
--- a/src/services/TwitchService.ts
+++ b/src/services/TwitchService.ts
@@ -2,7 +2,7 @@ import { TwitchStreamResponse } from "@/store/twitch/types";
 import { TwitchToken } from "@/store/oauth/types";
 
 export default class TwitchService {
-  public async getStreamStatus(
+  public static async getStreamStatus(
     token: TwitchToken,
     twitchNames: string[]
   ): Promise<TwitchStreamResponse> {

--- a/src/store/twitch/store.ts
+++ b/src/store/twitch/store.ts
@@ -19,8 +19,7 @@ export const useTwitchStore = defineStore("twitch", {
         .map((name) => (name ? name.replace("https://twitch.tv/", "") : ""))
         .filter((name) => !!name && encodeURIComponent(name) === name);
 
-      const twitchService = new TwitchService();
-      const response = await twitchService.getStreamStatus(
+      const response = await TwitchService.getStreamStatus(
         token,
         sanitizedTwitchNames
       );


### PR DESCRIPTION
## Reason

Service is stateless and needs no instance.

## Change

Refactor service to a static service.

## Reference

#609

