### PR TITLE
refactor(Rankings): add loading status on search request

### DIFF
--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -315,6 +315,9 @@ export default class RankingsView extends Vue {
     if (!this.search || this.search.length < 3) {
       return "Type at least 3 letters";
     }
+    if (this.isLoading) {
+      return "Loading...";
+    }
 
     return "No player found";
   }


### PR DESCRIPTION
Expected behavior: while making a request after typing 3+ chars in `/rankings` search bar, dropdown placeholder text should change to `Loading...`

Actual behavior: dropdown placeholder text stays `No player found` while make a request after typing 3+ chars


Header search bar working as expected so I've used its [code style](https://github.com/w3champions/website/blob/47e97565a72d3091ad73447609a6cd54cffbc02f/src/components/common/GlobalSearch.vue#L136-L145)