### PR TITLE
Use gameModes mixin for BannedPlayers

### DIFF
--- a/src/components/admin/AdminBannedPlayers.vue
+++ b/src/components/admin/AdminBannedPlayers.vue
@@ -222,7 +222,7 @@ export default class AdminBannedPlayers extends Mixins(GameModesMixin) {
     { text: "Actions", value: "actions", sortable: false, filterable: false },
   ];
 
-  getGameModeName(id: EGameMode): TranslateResult | undefined {
+  getGameModeName(id: EGameMode) {
     return this.activeGameModesWithAT.find((mode) => mode.id === id)?.name ?? this.$t(`gameModes.${EGameMode[id]}`);
   }
 
@@ -230,7 +230,7 @@ export default class AdminBannedPlayers extends Mixins(GameModesMixin) {
   // If you're editing a ban, and they are banned from an inactive game mode, add those the list, to allow deselecting them.
   get selectableGameModes() {
     const bannedModesForEditedItem = this.editedItem.gameModes;
-    const activeModeIds = this.activeGameModesWithAT.map((mode) => mode.id);
+    const activeModeIds = this.activeGameModes.map((mode) => mode.id);
     const bannedInactiveModesForEditedItem = bannedModesForEditedItem
       .filter((mode) => !activeModeIds.includes(mode))
       .map((id) => {
@@ -239,7 +239,7 @@ export default class AdminBannedPlayers extends Mixins(GameModesMixin) {
           name: this.$t(`gameModes.${EGameMode[id]}`)
         };
       });
-    const activeModes = this.activeGameModesWithAT;
+    const activeModes = this.activeGameModes;
 
     return activeModes.concat(bannedInactiveModesForEditedItem);
   }


### PR DESCRIPTION
Removes inactive game modes from the list of bannable modes when you add/edit a ban.

If you edit a ban, and the player is banned from an inactive mode, that game is added to the list, so that you can deselect it.

AT modes are also removed from the list of bannable modes, since banning from an AT mode had no effect.

Before:
![image](https://user-images.githubusercontent.com/21004208/235473393-2e7da7c4-f4c9-4b0e-a042-ddc8187de396.png)

After:
![image](https://user-images.githubusercontent.com/21004208/235939339-2f105bd3-17ae-42dd-9e95-e20b804e6996.png)

