### PR TITLE
feat: add tooltips to hero statistics table

### DIFF
--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -161,6 +161,32 @@ export default class PlayerHeroStatistics extends Vue {
         id: heroStat.id,
         name: heroStat.name,
         image: heroStat.image,
+        numbers_by_race: {
+          hu: {
+            total: totals[ERaceEnum.HUMAN],
+            number: heroStat.hu,
+          },
+          orc: {
+            total: totals[ERaceEnum.ORC],
+            number: heroStat.orc,
+          },
+          ud: {
+            total: totals[ERaceEnum.UNDEAD],
+            number: heroStat.ud,
+          },
+          ne: {
+            total: totals[ERaceEnum.NIGHT_ELF],
+            number: heroStat.ne,
+          },
+          rand: {
+            total: totals[ERaceEnum.RANDOM],
+            number: heroStat.rand,
+          },
+          total: {
+            total: totals[ERaceEnum.TOTAL],
+            number: heroStat.total,
+          },
+        },
         hu: totals[ERaceEnum.HUMAN] > 0 ? String((heroStat.hu * 100 / totals[ERaceEnum.HUMAN]).toFixed(2)) + "%" : "N/A",
         orc: totals[ERaceEnum.ORC] > 0 ? String((heroStat.orc * 100 / totals[ERaceEnum.ORC]).toFixed(2)) + "%" : "N/A",
         ne: totals[ERaceEnum.NIGHT_ELF] > 0 ? String((heroStat.ne * 100 / totals[ERaceEnum.NIGHT_ELF]).toFixed(2)) + "%" : "N/A",

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -11,7 +11,14 @@
         </thead>
         <tbody class="player-hero-statistics-table__body">
           <tr v-for="item in heroStatsCurrentPage" :key="item.id">
-            <td v-for="header in headers" :key="header.value" v-html="item[header.value]"></td>
+            <v-tooltip v-for="header in headers" :key="header.value" top>
+              <template v-slot:activator="{ on }">
+                <td v-on="on" v-html="item[header.value]"></td>
+              </template>
+              <div v-if="item.numbers_by_race[header.value]">
+                {{ item.numbers_by_race[header.value].number }}/{{ item.numbers_by_race[header.value].total }}
+              </div>
+            </v-tooltip>
           </tr>
         </tbody>
       </template>

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -11,7 +11,9 @@
         </thead>
         <tbody class="player-hero-statistics-table__body">
           <tr v-for="item in heroStatsCurrentPage" :key="item.id">
-            <v-tooltip v-for="header in headers" :key="header.value" top>
+            <td v-html="item.image"></td>
+            <td v-html="item.name"></td>
+            <v-tooltip v-for="header in headersWithoutImageAndName" :key="header.value" top>
               <template v-slot:activator="{ on }">
                 <td v-on="on" v-html="item[header.value]"></td>
               </template>
@@ -57,6 +59,10 @@ export default class PlayerHeroStatisticsTable extends Vue {
   }
   get heroStatsCurrentPage(): PlayerHeroStatistic[] {
     return this.heroStatistics.slice((this.pageOffset - this.paginationSize), this.pageOffset);
+  }
+
+  get headersWithoutImageAndName() {
+    return this.headers.slice(2);
   }
 
   get headers() {

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -24,7 +24,9 @@
                   </thead>
                   <tbody>
                     <tr v-for="item in heroStatsCurrentPage" :key="item.hero">
-                      <v-tooltip v-for="header in headers" :key="header.value" top>
+                      <td v-html="item.image"></td>
+                      <td v-html="item.name"></td>
+                      <v-tooltip v-for="header in headersWithoutImageAndName" :key="header.value" top>
                         <template v-slot:activator="{ on }">
                           <td v-on="on" v-html="item[header.value]"></td>
                         </template>
@@ -99,6 +101,10 @@ export default class PlayerHeroWinRate extends Vue {
     return this.player.isInitialized;
   }
 
+  get headersWithoutImageAndName() {
+    return this.headers.slice(2);
+  }
+
   get headers() {
     return [
       { text: "", value: "image" },
@@ -148,13 +154,13 @@ export default class PlayerHeroWinRate extends Vue {
         name: this.$t(`heroNames.${item.heroId}`).toString(),
         image: this.getImageForTable(item.heroId),
         numbers_by_race: {
-          [ERaceEnum.UNDEAD]: {},
-          [ERaceEnum.ORC]: {},
-          [ERaceEnum.NIGHT_ELF]: {},
-          [ERaceEnum.HUMAN]: {},
-          [ERaceEnum.RANDOM]: {},
-          [ERaceEnum.TOTAL]: {},
-          [ERaceEnum.STARTER]: {},
+          [ERaceEnum.UNDEAD]: {number: 0, total: 0},
+          [ERaceEnum.ORC]: {number: 0, total: 0},
+          [ERaceEnum.NIGHT_ELF]: {number: 0, total: 0},
+          [ERaceEnum.HUMAN]: {number: 0, total: 0},
+          [ERaceEnum.RANDOM]: {number: 0, total: 0},
+          [ERaceEnum.TOTAL]: {number: 0, total: 0},
+          [ERaceEnum.STARTER]: {number: 0, total: 0},
         },
         [ERaceEnum.TOTAL]: "",
         [ERaceEnum.UNDEAD]: "",

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -24,7 +24,14 @@
                   </thead>
                   <tbody>
                     <tr v-for="item in heroStatsCurrentPage" :key="item.hero">
-                      <td v-for="header in headers" :key="header.value" v-html="item[header.value]"></td>
+                      <v-tooltip v-for="header in headers" :key="header.value" top>
+                        <template v-slot:activator="{ on }">
+                          <td v-on="on" v-html="item[header.value]"></td>
+                        </template>
+                        <div v-if="item.numbers_by_race[header.value]">
+                          {{ item.numbers_by_race[header.value].number }}/{{ item.numbers_by_race[header.value].total }}
+                        </div>
+                      </v-tooltip>
                     </tr>
                   </tbody>
                 </template>
@@ -140,6 +147,15 @@ export default class PlayerHeroWinRate extends Vue {
         hero: item.heroId,
         name: this.$t(`heroNames.${item.heroId}`).toString(),
         image: this.getImageForTable(item.heroId),
+        numbers_by_race: {
+          [ERaceEnum.UNDEAD]: {},
+          [ERaceEnum.ORC]: {},
+          [ERaceEnum.NIGHT_ELF]: {},
+          [ERaceEnum.HUMAN]: {},
+          [ERaceEnum.RANDOM]: {},
+          [ERaceEnum.TOTAL]: {},
+          [ERaceEnum.STARTER]: {},
+        },
         [ERaceEnum.TOTAL]: "",
         [ERaceEnum.UNDEAD]: "",
         [ERaceEnum.ORC]: "",
@@ -158,6 +174,10 @@ export default class PlayerHeroWinRate extends Vue {
       filtered
         .winLosses
         .map((winLoss) => {
+          playerWinRate.numbers_by_race[winLoss.race] = {
+            number: winLoss.wins,
+            total: winLoss.games,
+          };
           playerWinRate[winLoss.race] = "-";
           if (winLoss.games > 0) {
             playerWinRate[winLoss.race] = `${(winLoss.winrate * 100).toFixed(2)}%`;
@@ -166,6 +186,10 @@ export default class PlayerHeroWinRate extends Vue {
           wins += winLoss.wins;
         });
       playerWinRate[ERaceEnum.TOTAL] = `${((wins / total) * 100).toFixed(2)}%`;
+      playerWinRate.numbers_by_race[ERaceEnum.TOTAL] = {
+        number: wins,
+        total: total,
+      };
       resp.push(playerWinRate);
     }) || [];
     return resp;

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -142,6 +142,7 @@ export type PlayerHeroWinRateForStatisticsTab = {
   hero: string;
   name: string;
   image: string;
+  numbers_by_race: Object;
   [ERaceEnum.TOTAL]: string;
   [ERaceEnum.UNDEAD]: string;
   [ERaceEnum.ORC]: string;

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -138,11 +138,25 @@ export type PlayerHeroStatistic = {
   ne: string;
 };
 
+export type FractionForTooltip = {
+  number: number,
+  total: number,
+}
+
+export type NumbersByRaceForTooltip = {
+  [ERaceEnum.HUMAN]: FractionForTooltip,
+  [ERaceEnum.NIGHT_ELF]: FractionForTooltip,
+  [ERaceEnum.ORC]: FractionForTooltip,
+  [ERaceEnum.UNDEAD]: FractionForTooltip,
+  [ERaceEnum.TOTAL]: FractionForTooltip,
+  [ERaceEnum.STARTER]: FractionForTooltip,
+}
+
 export type PlayerHeroWinRateForStatisticsTab = {
   hero: string;
   name: string;
   image: string;
-  numbers_by_race: Object;
+  numbers_by_race: NumbersByRaceForTooltip;
   [ERaceEnum.TOTAL]: string;
   [ERaceEnum.UNDEAD]: string;
   [ERaceEnum.ORC]: string;


### PR DESCRIPTION
When I added the hero statistics tables, a guy sent me DM suggesting adding tooltips for the tables, as the other statistics table. Here it goes!

![image](https://github.com/w3champions/website/assets/13929995/dc613b9b-c8a0-4c4a-b28e-0858abe7cfbb)

![image](https://github.com/w3champions/website/assets/13929995/775386d6-cfb0-4c54-9dee-3f9855b24ad0)

![image](https://github.com/w3champions/website/assets/13929995/1111687a-b077-41ba-8dfe-4105b2290515)
