### PR TITLE
add query-parameters for player profile matches

### DIFF
--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -127,9 +127,12 @@ export default class MatchesGrid extends Mixins(MatchMixin) {
   @Prop() public itemsPerPage!: number;
   @Prop() public alwaysLeftName!: string;
   @Prop() public unfinished!: boolean;
-
-  public page = 1;
-
+  
+  public page = 1
+  mounted(){
+    this.page = Number.parseInt(this.$router.currentRoute.query.page as string ?? 1);
+    this.$emit("pageChanged", this.page);
+  }
   destroyed() {
     this.$emit("pageChanged", 1);
   }
@@ -162,6 +165,12 @@ export default class MatchesGrid extends Mixins(MatchMixin) {
   }
 
   public onPageChanged(page: number) {
+    this.$router.push({
+      query: {
+        ...this.$router.currentRoute.query,
+        page: this.page.toString()
+      }
+    });
     this.$emit("pageChanged", page);
   }
 
@@ -181,10 +190,6 @@ export default class MatchesGrid extends Mixins(MatchMixin) {
     if (this.unfinished) {
       return true;
     }
-
-    this.$router.push({
-      path: `/match/${match.id}`,
-    });
   }
 
   public getLoser(match: Match) {

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -98,12 +98,36 @@ export default class PlayerMatchesTab extends Mixins(GameModesMixin) {
   private player = usePlayerStore();
 
   async mounted(): Promise<void> {
+    const gameMode = this.$router.currentRoute.query.gameMode;
+    if (gameMode && typeof gameMode === "string"){
+      this.player.SET_GAMEMODE(Number.parseInt(gameMode));
+    }
+    const playerRace = this.$router.currentRoute.query.playerRace;
+    if (playerRace && typeof playerRace === "string"){
+      this.player.SET_RACE(Number.parseInt(playerRace));
+    }
+    const opponentRace = this.$router.currentRoute.query.opponentRace;
+    if (opponentRace && typeof opponentRace === "string"){
+      this.player.SET_OPPONENT_RACE(Number.parseInt(opponentRace));
+    }
+    const opponentTag = this.$router.currentRoute.query.opponentTag;
+    if (opponentTag && typeof opponentTag === "string"){
+      this.foundPlayer = decodeURIComponent(opponentTag)
+      this.player.SET_OPPONENT_TAG(decodeURIComponent(opponentTag));
+      console.log("SET OPPONENT NAME: ",opponentTag)
+    }
     await this.loadActiveGameModes();
   }
 
   async playerFound(bTag: string): Promise<void> {
     this.foundPlayer = bTag;
     this.player.SET_OPPONENT_TAG(bTag);
+    this.$router.push({
+      query: {
+        ...this.$router.currentRoute.query,
+        opponentTag: bTag.toString()
+      }
+    });    
     await this.getMatches();
   }
 
@@ -182,17 +206,35 @@ export default class PlayerMatchesTab extends Mixins(GameModesMixin) {
   }
 
   public setSelectedGameModeForSearch(gameMode: EGameMode) {
+    this.$router.push({
+      query: {
+        ...this.$router.currentRoute.query,
+        gameMode: gameMode.toString()
+      }
+    });
     this.player.SET_GAMEMODE(gameMode);
     this.getMatches();
   }
 
   public setPlayerRaceForSearch(race: ERaceEnum) {
     this.player.SET_PLAYER_RACE(race);
+    this.$router.push({
+      query: {
+        ...this.$router.currentRoute.query,
+        playerRace: race.toString()
+      }
+    });
     this.getMatches();
   }
 
   public setOpponentRaceForSearch(race: ERaceEnum) {
     this.player.SET_OPPONENT_RACE(race);
+    this.$router.push({
+      query: {
+        ...this.$router.currentRoute.query,
+        opponentRace: race.toString()
+      }
+    });
     this.getMatches();
   }
 


### PR DESCRIPTION
Adds query parameters to player profile matches so you can explore individual matches and still retain your filter after you use the back button of your browser.