### PR TITLE
Attempt to use system package manager for python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,11 @@ RUN apk add --no-cache bash
 RUN chmod +x env.sh
 
 RUN apk add --no-cache \
-python3 py3-pip \
+python3 py3-pip python3-dateutil python3-magic s3cmd \
 curl \
 which \
 bash
 
-RUN pip install python-dateutil python-magic s3cmd --break-system-packages
 COPY s3config /etc/s3config
 RUN chmod +x /etc/s3config/sync_assets.sh
 


### PR DESCRIPTION
--break-system-packages is not recommended, so ideally the package manager for the whole container would manage the packages. If the packages don't exist, --break-system-packages will do 😄 