### PR TITLE
preserve page on player profile when checking match detail

### DIFF
--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -36,7 +36,7 @@ export default defineComponent({
     },
   },
   setup: (_props, context) => {
-    const search = ref<string>("");
+    const search = ref<string | null>(null);
     const isLoading = ref<boolean>(false);
     const SEARCH_DELAY = 500;
     const debouncedSearch = debounce(dispatchSearch, SEARCH_DELAY);
@@ -55,6 +55,7 @@ export default defineComponent({
     });
 
     function dispatchSearch() {
+      if (search.value === null) return;
       playerSearchStore.searchBnetTag({ searchText: search.value.toLowerCase() });
     }
 
@@ -68,6 +69,7 @@ export default defineComponent({
     watch(search, onPlayerSearchChanged);
 
     function onPlayerSearchChanged(): void {
+      if (search.value === null) return;
       if (search.value && search.value.length > 2) {
         isLoading.value = true;
         debouncedSearch();

--- a/src/components/match-details/HeroIcon.vue
+++ b/src/components/match-details/HeroIcon.vue
@@ -20,7 +20,8 @@ export default defineComponent({
   props: {
     hero: {
       type: Object as PropType<Hero>,
-      required: true,
+      required: false,
+      default: undefined,
     },
     firstHero: {
       type: Boolean,

--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onActivated, PropType, ref, watch } from "vue";
+import { computed, ComputedRef, defineComponent, PropType } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { getAsset } from "@/helpers/url-functions";
 import RaceIcon from "@/components/player/RaceIcon.vue";
@@ -53,29 +53,17 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
     const playerStore = usePlayerStore();
-    const selectedTab = ref<string>("tab-16");
 
     const selectedRace: ComputedRef<number> = computed((): number => Number(selectedTab.value.split("-")[1]));
-    const isPlayerInitialized: ComputedRef<boolean> = computed((): boolean => playerStore.isInitialized);
+
+    const selectedTab: ComputedRef<string> = computed((): string => {
+      return defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All);
+    });
 
     function getImageForTable(heroId: string): string {
       const src: string = getAsset(`heroes/${heroId}.png`);
       return `<img class="mt-1" src="${src}" height="40" width="40" />`;
     }
-
-    watch(isPlayerInitialized, onPlayerInitialized);
-    function onPlayerInitialized(): void {
-      setSelectedTab();
-    }
-
-    function setSelectedTab(): void {
-      selectedTab.value = defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All) || "tab-16";
-    }
-
-    // Use activated() instead of mounted() to trigger when navigating directly from one profile to another.
-    onActivated((): void => {
-      if (isPlayerInitialized.value) setSelectedTab();
-    });
 
     function heroUsages() {
       const heroStatsData = [];

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onActivated, PropType, ref, watch } from "vue";
+import { computed, ComputedRef, defineComponent, PropType, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { getAsset } from "@/helpers/url-functions";
 import RaceIcon from "@/components/player/RaceIcon.vue";
@@ -85,12 +85,14 @@ export default defineComponent({
     const playerStore = usePlayerStore();
     const paginationSize = 10;
     const page = ref<number>(1);
-    const selectedTab = ref<string>("tab-16");
     const selectedRace: ComputedRef<number> = computed((): number => Number(selectedTab.value.split("-")[1]));
-    const isPlayerInitialized: ComputedRef<boolean> = computed((): boolean => playerStore.isInitialized);
     const pageOffset: ComputedRef<number> = computed((): number => paginationSize * page.value);
     const pageLength: ComputedRef<number> = computed((): number => Math.ceil(heroWinRates().length / paginationSize));
     const heroStatsCurrentPage: ComputedRef<PlayerHeroWinRateForStatisticsTab[]> = computed((): PlayerHeroWinRateForStatisticsTab[] => heroWinRates().slice((pageOffset.value - paginationSize), pageOffset.value));
+
+    const selectedTab: ComputedRef<string> = computed((): string => {
+      return defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All);
+    });
 
     const headers = [
       { text: "", value: "image" },
@@ -104,20 +106,6 @@ export default defineComponent({
     ];
 
     const headersWithoutImageAndName = headers.slice(2);
-
-    watch(isPlayerInitialized, onPlayerInitialized);
-    function onPlayerInitialized(): void {
-      setSelectedTab();
-    }
-
-    function setSelectedTab(): void {
-      selectedTab.value = defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All) || "tab-16";
-    }
-
-    // Use onActivated instead of onMounted to trigger when navigating directly from one profile to another.
-    onActivated((): void => {
-      if (isPlayerInitialized.value) setSelectedTab();
-    });
 
     function getImageForTable(heroId: string): string {
       const src: string = getAsset(`heroes/${heroId}.png`);

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -24,14 +24,13 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onActivated, ref, watch } from "vue";
+import { computed, ComputedRef, defineComponent } from "vue";
 import { RaceWinsOnMap } from "@/store/player/types";
 import RaceToMapStat from "@/components/overall-statistics/RaceToMapStat.vue";
 import { ERaceEnum } from "@/store/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import isEmpty from "lodash/isEmpty";
 import { defaultStatsTab } from "@/helpers/profile";
-import { usePlayerStore } from "@/store/player/store";
 
 export default defineComponent({
   name: "PlayerStatsRaceVersusRaceOnMap",
@@ -46,27 +45,11 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const playerStore = usePlayerStore();
-    const selectedTab = ref<string>("tab-1");
-
-    const isPlayerInitialized: ComputedRef<boolean> = computed((): boolean => playerStore.isInitialized);
     const isStatsEmpty: ComputedRef<boolean> = computed((): boolean => isEmpty(props.stats));
 
-    // Use onActivated instead of onMounted to trigger when navigating directly from one profile to another.
-    onActivated((): void => {
-      if (isPlayerInitialized.value) setSelectedTab();
+    const selectedTab: ComputedRef<string> = computed((): string => {
+      return defaultStatsTab(props.stats);
     });
-
-    // When loading the statistics tab via URL directly, onMounted gets called before loading player data, which this component depends on.
-    // That's why isPlayerInitialized is watched, to set the tab once player.vue init() has finished.
-    watch(isPlayerInitialized, onPlayerInitialized);
-    function onPlayerInitialized(): void {
-      setSelectedTab();
-    }
-
-    function setSelectedTab(): void {
-      selectedTab.value = defaultStatsTab(props.stats);
-    }
 
     return {
       ERaceEnum,

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -74,12 +74,13 @@
       :always-left-name="battleTag"
       only-show-enemy
       @pageChanged="onPageChanged"
+      :is-player-profile="true"
     ></matches-grid>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onActivated, onMounted, ref, watch } from "vue";
+import { computed, ComputedRef, defineComponent, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { loadActiveGameModes, activeGameModesWithAT } from "@/mixins/GameModesMixin";
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
@@ -107,20 +108,14 @@ export default defineComponent({
     const isLoadingMatches = ref<boolean>(false);
     const filtersVisible = ref<boolean>(false);
     const foundPlayer = ref<string>("");
-    const currentPage = ref<number | undefined>(undefined);
 
     const battleTag: ComputedRef<string> = computed((): string => decodeURIComponent(props.id));
     const totalMatches: ComputedRef<number> = computed((): number => playerStore.totalMatches);
     const matches: ComputedRef<Match[]> = computed((): Match[] => playerStore.matches);
     const filterButtonText: ComputedRef<string> = computed((): string => filtersVisible.value ? "Hide Additional Filters" : "Show Additional Filters");
-    const loadingProfile: ComputedRef<boolean> = computed((): boolean => playerStore.loadingProfile);
 
     onMounted(async (): Promise<void> => {
       await loadActiveGameModes();
-    });
-
-    onActivated(async (): Promise<void> => {
-      await getMatches();
     });
 
     async function playerFound(bTag: string): Promise<void> {
@@ -218,20 +213,18 @@ export default defineComponent({
       return 0;
     });
 
-    watch(loadingProfile, getMatches);
-    async function getMatches(): Promise<void> {
+    async function getMatches(page?: number): Promise<void> {
       if (isLoadingMatches.value || !playerStore.selectedSeason.id) {
         return;
       }
 
       isLoadingMatches.value = true;
-      await playerStore.loadMatches(currentPage.value);
+      await playerStore.loadMatches(page);
       isLoadingMatches.value = false;
     }
 
     async function onPageChanged(page: number): Promise<void> {
-      currentPage.value = page;
-      await getMatches();
+      await getMatches(page);
     }
 
     return {

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -126,7 +126,7 @@ export default class ProfileService {
     gateWay: Gateways,
     season: number,
     gameMode: EGameMode
-  ): Promise<PlayerMmrRpTimeline | undefined> {
+  ): Promise<PlayerMmrRpTimeline> {
     const url = `${API_URL}api/players/${encodeURIComponent(
       battleTag
     )}/mmr-rp-timeline?race=${race}&gateWay=${gateWay}&season=${season}&gameMode=${gameMode}`;
@@ -135,7 +135,7 @@ export default class ProfileService {
     if (response.ok && response.status == 200) {
       return await response.json();
     } else {
-      return undefined;
+      return {} as PlayerMmrRpTimeline;
     }
   }
   public static async retrievePlayerGameLengthStats(

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -8,7 +8,7 @@ import { Season } from "@/store/ranking/types";
 
 export const useMatchStore = defineStore("match", {
   state: (): MatchState => ({
-    page: 0,
+    page: 1,
     totalMatches: 0,
     loadingMatchDetail: true,
     matches: [] as Match[],
@@ -23,14 +23,12 @@ export const useMatchStore = defineStore("match", {
   }),
   actions: {
     async loadMatches(page?: number) {
-      if (page != null && !isNaN(page)) {
-        this.SET_PAGE(page - 1);
-      }
+      this.SET_PAGE(page ?? 1);
       let response: { count: number; matches: Match[] };
       const rootStateStore = useRootStateStore();
       if (this.status == MatchStatus.onGoing) {
         response = await MatchService.retrieveOnGoingMatchesPaged(
-          this.page,
+          this.page - 1,
           rootStateStore.gateway,
           this.gameMode,
           this.map,

--- a/src/store/player/store.ts
+++ b/src/store/player/store.ts
@@ -18,11 +18,10 @@ import { defineStore } from "pinia";
 
 export const usePlayerStore = defineStore("player", {
   state: (): PlayerState => ({
-    isInitialized: false,
     playerStatsRaceVersusRaceOnMap: {} as PlayerStatsRaceOnMapVersusRace,
     playerStatsHeroVersusRaceOnMap: {} as PlayerStatsHeroOnMapVersusRace,
     battleTag: "",
-    page: 0,
+    page: 1,
     totalMatches: 0,
     playerProfile: {} as PlayerProfile,
     matches: [] as Match[],
@@ -31,14 +30,14 @@ export const usePlayerStore = defineStore("player", {
     loadingMmrRpTimeline: true,
     opponentTag: "",
     selectedSeason: {} as Season,
-    gameMode: 0 as EGameMode,
-    race: 0 as ERaceEnum,
-    playerRace: 16 as ERaceEnum,
-    opponentRace: 16 as ERaceEnum,
+    gameMode: EGameMode.GM_1ON1,
+    race: ERaceEnum.RANDOM,
+    playerRace: ERaceEnum.TOTAL,
+    opponentRace: ERaceEnum.TOTAL,
     ongoingMatch: {} as Match,
     gameModeStats: [] as ModeStat[],
     raceStats: [] as RaceStat[],
-    mmrRpTimeline: {} as PlayerMmrRpTimeline | undefined,
+    mmrRpTimeline: {} as PlayerMmrRpTimeline,
     playerGameLengthStats: {} as PlayerGameLengthStats | undefined,
   } as PlayerState),
   actions: {
@@ -88,13 +87,11 @@ export const usePlayerStore = defineStore("player", {
       this.SET_PLAYER_STATS_HERO_VERSUS_RACE_ON_MAP(profile);
     },
     async loadMatches(page?: number) {
-      if (page != null && !isNaN(page)) {
-        this.SET_PAGE(page - 1);
-      }
+      this.SET_PAGE(page ?? 1);
       this.SET_LOADING_RECENT_MATCHES(true);
       const rootStateStore = useRootStateStore();
       const response = await MatchService.retrievePlayerMatches(
-        this.page,
+        this.page - 1,
         this.battleTag,
         this.opponentTag,
         this.gameMode,
@@ -142,9 +139,6 @@ export const usePlayerStore = defineStore("player", {
         this.selectedSeason?.id ?? -1,
       );
       this.SET_PLAYER_GAME_LENGTH_STATS(playerGameLengthStats);
-    },
-    SET_INITIALIZED(): void {
-      this.isInitialized = true;
     },
     SET_PROFILE(profile: PlayerProfile): void {
       this.playerProfile = profile;
@@ -203,7 +197,7 @@ export const usePlayerStore = defineStore("player", {
     SET_RACE_STATS(stats: RaceStat[]): void {
       this.raceStats = stats;
     },
-    SET_MMR_RP_TIMELINE(mmrRpTimeline: PlayerMmrRpTimeline | undefined): void {
+    SET_MMR_RP_TIMELINE(mmrRpTimeline: PlayerMmrRpTimeline): void {
       this.mmrRpTimeline = mmrRpTimeline;
     },
     SET_PLAYER_GAME_LENGTH_STATS(playerGameLengthStats: PlayerGameLengthStats | undefined): void {

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -2,7 +2,6 @@ import { EGameMode, ERaceEnum, Match, timestampString } from "../types";
 import { Season, Gateways, PlayerId } from "@/store/ranking/types";
 
 export type PlayerState = {
-  isInitialized: boolean;
   playerStatsRaceVersusRaceOnMap: PlayerStatsRaceOnMapVersusRace;
   playerStatsHeroVersusRaceOnMap: PlayerStatsHeroOnMapVersusRace;
   page: number;
@@ -23,7 +22,7 @@ export type PlayerState = {
   raceStats: RaceStat[];
   ongoingMatch: Match;
   gameModeStats: ModeStat[];
-  mmrRpTimeline: PlayerMmrRpTimeline | undefined;
+  mmrRpTimeline: PlayerMmrRpTimeline;
   playerGameLengthStats: PlayerGameLengthStats | undefined;
 };
 

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -31,6 +31,7 @@
             @pageChanged="onPageChanged"
             :itemsPerPage="50"
             :unfinished="unfinished"
+            :is-player-profile="false"
           ></matches-grid>
         </v-card>
       </v-col>


### PR DESCRIPTION
This PR lets you preserve the page when you're browsing matches on a player profile, and you click on a match detail, then go back in the browser. Previously, this reset the page to 1, making it very hard to browse matches further back in a player match history.

Additionally, this PR simplifies code related to player profile statistics, and fixes a few bugs that appear when you visit a profile, navigate to another profile, then go back to the first one by using the browser history.