### PR TITLE
ClanOverview - move clan data fetch from onActivated to onMounted

### DIFF
--- a/src/components/clans/ClanOverview.vue
+++ b/src/components/clans/ClanOverview.vue
@@ -10,9 +10,7 @@
       </v-row>
     </div>
     <accept-invite-panel v-if="hasPendingInvite && isLoggedInPlayer" />
-    <clan-creation-panel
-      v-if="!hasPendingInvite && hasNoClan && isLoggedInPlayer"
-    />
+    <clan-creation-panel v-if="!hasPendingInvite && hasNoClan && isLoggedInPlayer" />
     <div v-if="!hasNoClan">
       <v-card-title class="justify-space-between">
         <span>{{ playersClan.clanName }} ({{ playersClan.clanId }})</span>
@@ -31,11 +29,7 @@
           ]"
           :key="mode"
         >
-          <player-league
-            :small-mode="true"
-            :show-performance="false"
-            :mode-stat="getStats(mode)"
-          />
+          <player-league :small-mode="true" :show-performance="false" :mode-stat="getStats(mode)" />
         </v-col>
       </v-row>
       <br />
@@ -52,11 +46,7 @@
                   <v-tooltip top :disabled="!getLeagueOrder(playersClan.chiefTain)">
                     <template v-slot:activator="{ on }">
                       <div v-on="on" style="display: inline">
-                        <league-icon
-                          v-on="on"
-                          class="ml-4 mb-1"
-                          :league="getLeagueOrder(playersClan.chiefTain)"
-                        />
+                        <league-icon v-on="on" class="ml-4 mb-1" :league="getLeagueOrder(playersClan.chiefTain)" />
                       </div>
                     </template>
                     <div>1 vs 1</div>
@@ -78,11 +68,7 @@
                   <v-tooltip top :disabled="!getLeagueOrder(shaman)">
                     <template v-slot:activator="{ on }">
                       <div v-on="on" style="display: inline">
-                        <league-icon
-                          v-on="on"
-                          class="ml-4 mb-1"
-                          :league="getLeagueOrder(shaman)"
-                        />
+                        <league-icon v-on="on" class="ml-4 mb-1" :league="getLeagueOrder(shaman)" />
                       </div>
                     </template>
                     <div>1 vs 1</div>
@@ -112,11 +98,7 @@
                   <v-tooltip top :disabled="!getLeagueOrder(member)">
                     <template v-slot:activator="{ on }">
                       <div v-on="on" style="display: inline">
-                        <league-icon
-                          v-on="on"
-                          class="ml-4 mb-1"
-                          :league="getLeagueOrder(member)"
-                        />
+                        <league-icon v-on="on" class="ml-4 mb-1" :league="getLeagueOrder(member)" />
                       </div>
                     </template>
                     <div>1 vs 1</div>
@@ -137,7 +119,7 @@
       </div>
       <div v-if="!playersClan.isSuccesfullyFounded">
         <v-card-title>
-          {{ $t("components_clans_clanoverview.signeecounter") }} ({{playersClan.foundingFathers.length}} / 2):
+          {{ $t("components_clans_clanoverview.signeecounter") }} ({{ playersClan.foundingFathers.length }} / 2):
         </v-card-title>
         <table class="custom-table">
           <tr v-for="member in playersClan.foundingFathers" :key="member">
@@ -155,7 +137,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onMounted, onActivated } from "vue";
+import { computed, ComputedRef, defineComponent, onMounted } from "vue";
 import ClanCreationPanel from "@/components/clans/ClanCreationPanel.vue";
 import InvitePlayerModal from "@/components/clans/InvitePlayerModal.vue";
 import PendingInvitesPanel from "@/components/clans/PendingInvitesPanel.vue";
@@ -208,7 +190,9 @@ export default defineComponent({
     const currentSeason: ComputedRef<number> = computed((): number => rankingsStore.seasons[0].id);
     const clanIsFunded: ComputedRef<boolean> = computed((): boolean => playersClan.value.isSuccesfullyFounded);
     const roleEnums: ComputedRef<typeof EClanRole> = computed((): typeof EClanRole => EClanRole);
-    const hasPendingInvite: ComputedRef<boolean> = computed((): boolean => !!clanStore.selectedMemberShip?.pendingInviteFromClan);
+    const hasPendingInvite: ComputedRef<boolean> = computed(
+      (): boolean => !!clanStore.selectedMemberShip?.pendingInviteFromClan
+    );
     const verifiedBtag: ComputedRef<string> = computed((): string => oauthStore.blizzardVerifiedBtag);
     const selectedPlayer: ComputedRef<string> = computed((): string => playerStore.battleTag);
     const hasNoClan: ComputedRef<boolean> = computed((): boolean => !playersClan?.value.clanId);
@@ -216,22 +200,18 @@ export default defineComponent({
     const shamans: ComputedRef<string[]> = computed((): string[] => clanStore.playersClan.shamans);
     const members: ComputedRef<string[]> = computed((): string[] => clanStore.playersClan.members);
     const loggedInRole: ComputedRef<EClanRole> = computed((): EClanRole => defineRole(verifiedBtag.value));
-    const loggedInPlayerIsChiefTain: ComputedRef<boolean> = computed((): boolean => playersClan.value.chiefTain === verifiedBtag.value);
+    const loggedInPlayerIsChiefTain: ComputedRef<boolean> = computed(
+      (): boolean => playersClan.value.chiefTain === verifiedBtag.value
+    );
 
     const loggedInPlayerIsShaman: ComputedRef<boolean> = computed((): boolean => {
-      return !!(
-        playersClan.value.shamans.find((s) => s === verifiedBtag.value) ||
-        loggedInPlayerIsChiefTain.value
-      );
+      return !!(playersClan.value.shamans.find((s) => s === verifiedBtag.value) || loggedInPlayerIsChiefTain.value);
     });
 
     function getLeagueOrder(battleTag: string): number {
       return playersClan.value.ranks
         ?.filter(
-          (r) =>
-            r.season === currentSeason.value &&
-            r.gameMode === EGameMode.GM_1ON1 &&
-            r.id.includes(battleTag)
+          (r) => r.season === currentSeason.value && r.gameMode === EGameMode.GM_1ON1 && r.id.includes(battleTag)
         )
         .sort((a, b) => a.leagueOrder - b.leagueOrder)[0]?.leagueOrder;
     }
@@ -253,20 +233,13 @@ export default defineComponent({
         battleTag: battleTag.value,
         freshLogin: false,
       });
-    });
 
-    // Load clans on activate instead of mount,
-    // because component is already mounted when going from a profile to another profile, leading to wrong clan being displayed
-    onActivated(async (): Promise<void> => {
-      playerStore.SET_BATTLE_TAG(battleTag.value);
       await clanStore.retrievePlayersMembership();
       await clanStore.retrievePlayersClan();
     });
 
     function getStats(mode: EGameMode): ModeStat {
-      const modeRankings = playersClan.value.ranks?.filter(
-        (r) => r.gameMode === mode && r.leagueName != null
-      );
+      const modeRankings = playersClan.value.ranks?.filter((r) => r.gameMode === mode && r.leagueName != null);
       const players = modeRankings.map((rankings) => rankings.player);
       if (players.length === 0) return { games: 0, gameMode: mode } as ModeStat;
 
@@ -289,13 +262,8 @@ export default defineComponent({
         }
       );
 
-      const allRanks = playersClan.value.ranks.filter(
-        (r) => r.rankNumber != 0 && r.gameMode === mode
-      );
-      const order = allRanks.reduce(
-        (a, b) => ({ leagueOrder: a.leagueOrder + b.leagueOrder }),
-        { leagueOrder: 0 }
-      );
+      const allRanks = playersClan.value.ranks.filter((r) => r.rankNumber != 0 && r.gameMode === mode);
+      const order = allRanks.reduce((a, b) => ({ leagueOrder: a.leagueOrder + b.leagueOrder }), { leagueOrder: 0 });
       reduced.leagueOrder = Math.round(order.leagueOrder / allRanks.length);
       reduced.rank = allRanks.reduce((a, b) => a + b.rankNumber, 0);
 

--- a/src/components/ladder/LevelProgress.vue
+++ b/src/components/ladder/LevelProgress.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { ref, defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
 
 export default defineComponent({
   name: "LevelProgress",
@@ -17,8 +17,8 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const progressToNextLevel = ref<number>((props.rp % 1) * 100);
-    const levelNumber = ref<number>(Math.floor(props.rp));
+    const progressToNextLevel = computed<number>(() => (props.rp % 1) * 100);
+    const levelNumber = computed<number>(() => Math.floor(props.rp));
 
     return {
       progressToNextLevel,

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -11,10 +11,7 @@
     </h2>
     <div class="LadderSummaryShowcase-subtitle">
       <div v-if="showAtPartner">
-        <span
-          class="text-center pointer"
-          @click="navigateToPartner()"
-        >
+        <span class="text-center pointer" @click="navigateToPartner()">
           {{ atPartner.name }}
         </span>
         <br v-if="showAtPartner" />
@@ -26,15 +23,12 @@
         -
         <span class="lost">{{ modeStat.losses }}</span>
       </span>
-      <span v-if="!isRanked">
+      <span v-else>
         <span class="number-text">{{ modeStat.games }} / 5</span>
       </span>
     </div>
     <div>
-      <img
-        class="LadderSummaryShowcase-divider"
-        src="/assets/profiles/profile-ladders-divider.png"
-      />
+      <img class="LadderSummaryShowcase-divider" src="/assets/profiles/profile-ladders-divider.png" />
       <div class="text-center" v-if="isRanked && !smallMode">
         <span>
           MMR:
@@ -50,10 +44,7 @@
         <span>{{ $t("components_player_playerleague.placementsplayed") }}</span>
       </div>
     </div>
-    <recent-performance
-      v-if="isRecentPerformanceVisible"
-      :last-ten-matches-performance="lastTenMatchesPerformance"
-    />
+    <recent-performance v-if="isRecentPerformanceVisible" :last-ten-matches-performance="lastTenMatchesPerformance" />
   </div>
 </template>
 
@@ -106,21 +97,21 @@ export default defineComponent({
     const rootStateStore = useRootStateStore();
 
     const matches = ref<Match[]>([]);
-    const playerId = ref<string>(props.modeStat.id);
-    const leagueMode = ref<TranslateResult>(t(`gameModes.${EGameMode[props.modeStat.gameMode]}`));
-    const gameMode = ref<EGameMode>(props.modeStat.gameMode);
-    const league = ref<number>(props.modeStat.leagueId);
-    const isRanked = ref<boolean>(props.modeStat.rank > 0);
+    const playerId = computed<string>(() => props.modeStat.id);
+    const leagueMode = computed<TranslateResult>(() => t(`gameModes.${EGameMode[props.modeStat.gameMode]}`));
+    const gameMode = computed<EGameMode>(() => props.modeStat.gameMode);
+    const league = computed<number>(() => props.modeStat.leagueId);
+    const isRanked = computed<boolean>(() => props.modeStat.rank > 0);
 
     const gateWay: ComputedRef<Gateways> = computed((): Gateways => rootStateStore.gateway);
     const selectedSeason: ComputedRef<Season> = computed((): Season => playerStore.selectedSeason);
     const battleTag: ComputedRef<string> = computed((): string => playerStore.battleTag);
-    const seasonAndGameModeAndGateway: ComputedRef<string> = computed((): string => `${selectedSeason.value.id}${gameMode.value}${gateWay.value}`);
+    const seasonAndGameModeAndGateway: ComputedRef<string> = computed(
+      (): string => `${selectedSeason.value.id}${gameMode.value}${gateWay.value}`
+    );
 
     const atPartner: ComputedRef<PlayerId> = computed((): PlayerId => {
-      return props.modeStat.playerIds.filter(
-        (id) => battleTag.value !== id.battleTag
-      )[0];
+      return props.modeStat.playerIds.filter((id) => battleTag.value !== id.battleTag)[0];
     });
 
     watch(seasonAndGameModeAndGateway, init, { immediate: true });
@@ -150,9 +141,7 @@ export default defineComponent({
 
     function navigateToLeague(): void {
       router.push({
-        path: `/Rankings?season=${selectedSeason.value.id}&gateway=${
-          gateWay.value
-        }&gamemode=${gameMode.value}&league=${
+        path: `/Rankings?season=${selectedSeason.value.id}&gateway=${gateWay.value}&gamemode=${gameMode.value}&league=${
           league.value
         }&playerId=${encodeURIComponent(playerId.value)}`,
       });
@@ -189,20 +178,14 @@ export default defineComponent({
     const lastTenMatchesPerformance: ComputedRef<string[]> = computed((): string[] => {
       return matches.value
         .slice(0, 10)
-        .map((match) =>
-          match.teams.find((team) =>
-            team.players.find((player) => player.battleTag === battleTag.value)
-          )
-        )
+        .map((match) => match.teams.find((team) => team.players.find((player) => player.battleTag === battleTag.value)))
         .filter(Boolean)
         .map((team) => (team?.won ? "W" : "L"));
     });
 
     const isRecentPerformanceVisible: ComputedRef<boolean> = computed((): boolean => {
       return (
-        props.showPerformance &&
-        gameMode.value !== EGameMode.GM_2ON2_AT &&
-        lastTenMatchesPerformance.value.length > 0
+        props.showPerformance && gameMode.value !== EGameMode.GM_2ON2_AT && lastTenMatchesPerformance.value.length > 0
       );
     });
 


### PR DESCRIPTION
It looks like the clan data fetch was inside a lifecycle hook that no longer triggers.

![image](https://github.com/user-attachments/assets/6b14afb1-3d56-401d-a406-90d5e08debe2)

This only triggers on keep-alive, but this was removed it seems in PR #817 

I moved the logic into the onMounted hook instead, and it seems to work.
Since the player profile is loaded on mount I don't think we need to set the battleTag explicitly? - but could be wrong here.

Also there was a comment regarding the use of the onActivated hook
```
 // Load clans on activate instead of mount,
 // because component is already mounted when going from a profile to another profile, leading to wrong clan being displayed
```

Not sure how to test or re-create this edge case. It seems to work as intended when I navigate through clan users and profiles.

Also prettier did it's thing on the file 🙈 