### PR TITLE
Matches - use internal page state when polling for matches to prevent page resetting

### DIFF
--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -34,6 +34,14 @@ export const useMatchStore = defineStore("match", {
           this.mmr,
           this.sort
         );
+
+        // Handle edge case when loading ongoing matches, if the number of matches are reduced
+        // so that the current page no longer exists, we decrement the current page by 1 and retry.
+        if (!response.matches.length && this.page > 1) {
+          this.SET_PAGE(this.page - 1);
+          await this.loadMatches();
+          return;
+        }
       } else {
         response = await MatchService.retrieveMatches(
           this.page - 1,

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -22,8 +22,7 @@ export const useMatchStore = defineStore("match", {
     selectedSeason: {} as Season,
   }),
   actions: {
-    async loadMatches(page?: number) {
-      this.SET_PAGE(page ?? 1);
+    async loadMatches() {
       let response: { count: number; matches: Match[] };
       const rootStateStore = useRootStateStore();
       if (this.status == MatchStatus.onGoing) {
@@ -33,7 +32,7 @@ export const useMatchStore = defineStore("match", {
           this.gameMode,
           this.map,
           this.mmr,
-          this.sort,
+          this.sort
         );
       } else {
         response = await MatchService.retrieveMatches(
@@ -42,7 +41,7 @@ export const useMatchStore = defineStore("match", {
           this.gameMode,
           this.map,
           this.mmr,
-          this.selectedSeason.id,
+          this.selectedSeason.id
         );
       }
       this.SET_TOTAL_MATCHES(response.count);
@@ -57,7 +56,7 @@ export const useMatchStore = defineStore("match", {
         gameMode || this.gameMode,
         map || this.map,
         this.mmr,
-        this.sort,
+        this.sort
       );
       this.SET_ALL_ONGOING_MATCHES(response.matches);
     },
@@ -70,34 +69,34 @@ export const useMatchStore = defineStore("match", {
     },
     async setStatus(matchStatus: MatchStatus) {
       this.SET_STATUS(matchStatus);
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setGameMode(gameMode: EGameMode) {
       this.SET_GAME_MODE(gameMode);
       this.SET_MAP("Overall");
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setMap(map: string) {
       this.SET_MAP(map);
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setMmr(mmr: Mmr) {
       this.SET_MMR(mmr);
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setSort(sort: string) {
       this.SET_SORT(sort);
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setSeason(season: Season) {
       this.SET_SEASON(season);
-      this.SET_PAGE(0);
-      await this.loadMatches(undefined);
+      this.SET_PAGE(1);
+      await this.loadMatches();
     },
     async setPlayerScores(playerScores: PlayerScore[]) {
       this.SET_PLAYER_SCORES(playerScores);
@@ -138,9 +137,8 @@ export const useMatchStore = defineStore("match", {
     SET_PLAYER_SCORES(playerScores: PlayerScore[]): void {
       this.matchDetail.playerScores = playerScores;
     },
-    SET_SEASON(season: Season):void {
+    SET_SEASON(season: Season): void {
       this.selectedSeason = season;
     },
   },
 });
-

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -147,7 +147,6 @@ export default defineComponent({
       await rankingsStore.retrieveSeasons();
       rankingsStore.setSeason(rankingsStore.seasons[0]);
       await matchStore.setSeason(rankingsStore.seasons[0]);
-      await getMatches();
       getMaps();
       refreshMatches();
     });


### PR DESCRIPTION
The refresh interval was setting the page to 1, and the page was also updated if undefined when getting matches.
Now always uses the internal state directly, and the page has to be updated using the setter (e.g when changing filters)

Also add retry logic if the last page of ongoing matches is selected, but the number of matches are reduced  on update, removing the current page.