### PR TITLE
Minor improvements to player profile page

### DIFF
--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -11,7 +11,7 @@
     <template v-slot:body="{ items }">
       <tbody>
         <tr v-for="item in items" :key="item.id">
-          <td class="cell mode">
+          <td class="cell d-flex justify-center align-center">
             <span>{{ $t("gameModes." + EGameMode[item.gameMode]) }}</span>
             <race-icon style="display: inline; padding-left: 10px" :race="item.race" />
           </td>
@@ -175,11 +175,5 @@ export default defineComponent({
 
 .cell {
   white-space: nowrap;
-
-  &.mode {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
 }
 </style>

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -1,10 +1,5 @@
 <template>
-  <v-data-table
-    hide-default-footer
-    :headers="headers"
-    :items="gameModeStatsCombined"
-    mobile-breakpoint="400"
-  >
+  <v-data-table hide-default-footer :headers="headers" :items="gameModeStatsCombined" mobile-breakpoint="400">
     <template v-for="h in headers" v-slot:[`header.${h.text}`]="{ header }">
       <v-tooltip top v-bind:key="h.text">
         <template v-slot:activator="{ on }">
@@ -16,14 +11,11 @@
     <template v-slot:body="{ items }">
       <tbody>
         <tr v-for="item in items" :key="item.id">
-          <td>
+          <td class="cell mode">
             <span>{{ $t("gameModes." + EGameMode[item.gameMode]) }}</span>
-            <race-icon
-              style="display: inline; padding-left: 10px"
-              :race="item.race"
-            />
+            <race-icon style="display: inline; padding-left: 10px" :race="item.race" />
           </td>
-          <td class="number-text text-start">
+          <td class="number-text text-start cell">
             <div class="text-center">
               <span class="won">{{ item.wins }}</span>
               -
@@ -31,7 +23,7 @@
             </div>
             <div class="sub-value">{{ (item.winrate * 100).toFixed(1) }}%</div>
           </td>
-          <td class="number-text text-end">
+          <td class="number-text text-end cell">
             <div class="text-center">
               {{ item.rank !== 0 ? item.mmr : "-" }}
             </div>
@@ -39,7 +31,7 @@
               {{ getTopPercent(item) }}
             </div>
           </td>
-          <td class="number-text text-center" style="min-width: 100px">
+          <td class="number-text text-center cell" style="min-width: 100px">
             <level-progress v-if="item.rank !== 0" :rp="item.rankingPoints"></level-progress>
             <div v-else>-</div>
           </td>
@@ -93,8 +85,7 @@ export default defineComponent({
       const AT_arranged = AT_modes().map((AT_mode) => AT_stats.filter((modeStat) => AT_mode == modeStat.gameMode));
 
       // Filter out AT modes that haven't been played, sort by ranking points and get the stat with the highest rank.
-      const topAtStats = AT_arranged
-        .filter((modeStats) => !isEmpty(modeStats))
+      const topAtStats = AT_arranged.filter((modeStats) => !isEmpty(modeStats))
         .map((modeStats) => modeStats.sort((modeStat) => modeStat.rankingPoints))
         .map((modeStats) => modeStats.filter((modeStat, index) => index === 0))
         .flat();
@@ -111,7 +102,7 @@ export default defineComponent({
     });
 
     function sortByName(mode: ModeStat[]): ModeStat[] {
-      return mode.sort((a, b) => EGameMode[a.gameMode] < EGameMode[b.gameMode] ? -1 : 1);
+      return mode.sort((a, b) => (EGameMode[a.gameMode] < EGameMode[b.gameMode] ? -1 : 1));
     }
 
     function getTopPercent(modeStat: ModeStat): string {
@@ -180,5 +171,15 @@ export default defineComponent({
 
 .tooltip-inner {
   white-space: pre-line;
+}
+
+.cell {
+  white-space: nowrap;
+
+  &.mode {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }
 </style>

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -313,17 +313,16 @@ export default defineComponent({
 // common
 
 .LadderSummaryShowcase-card:after {
-  width: 250px;
-  height: 100px;
   -ms-flex: 0 0 100px;
   flex: 0 0 100px;
+  width: 250px;
   height: 105px;
   content: "";
   position: absolute;
-  // left: 50%;
-  transform: translateX(-50%);
   top: -50px;
-  margin-left: 163px;
+  margin-left: 49%;
+  left: 75px;
+  transform: translateX(-50%);
 }
 
 .LadderSummaryShowcase-card {

--- a/src/components/player/RecentPerformance.vue
+++ b/src/components/player/RecentPerformance.vue
@@ -5,8 +5,11 @@
     </h5>
     <ul class="recent-performance__results">
       <li v-for="(resultSymbol, index) in lastTenMatchesPerformance" :key="resultSymbol + index">
-        <span :class="resultSymbol === 'W' ? 'won' : 'lost'">{{ resultSymbol }}</span>
-        <span v-if="index < lastTenMatchesPerformance.length - 1">-</span>
+        <v-chip color="transparent" :title="resultSymbol === 'W' ? 'Win' : 'Loss'" label style="padding: 0">
+          <v-icon class="sword-icon" :color="resultSymbol === 'W' ? 'green' : 'red'">
+            {{ mdiShieldSwordOutline }}
+          </v-icon>
+        </v-chip>
       </li>
     </ul>
   </div>
@@ -14,6 +17,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { mdiShieldSwordOutline } from "@mdi/js";
 
 export default defineComponent({
   name: "RecentPerformance",
@@ -25,13 +29,19 @@ export default defineComponent({
     },
   },
   setup() {
-     // example: ['W', 'W', 'W', 'L', 'L', 'W', 'L', 'W', 'L', 'L']
-    return {};
+    // example: ['W', 'W', 'W', 'L', 'L', 'W', 'L', 'W', 'L', 'L']
+    return { mdiShieldSwordOutline };
   },
 });
 </script>
 
 <style lang="scss" scoped>
+.sword-icon {
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+}
+
 .recent-performance {
   margin-top: 0.4em;
 

--- a/src/components/player/tabs/PlayerProfileTab.vue
+++ b/src/components/player/tabs/PlayerProfileTab.vue
@@ -9,12 +9,7 @@
         </v-col>
         <v-col md="12" lg="9">
           <v-row v-if="!isBetaSeason">
-            <v-col
-              cols="12"
-              md="4"
-              v-for="gameModeStat in topGameModeStats"
-              :key="gameModeStat.gameMode"
-            >
+            <v-col cols="12" md="4" v-for="gameModeStat in topGameModeStats" :key="gameModeStat.gameMode">
               <player-league :modeStat="gameModeStat"></player-league>
             </v-col>
           </v-row>
@@ -30,11 +25,7 @@
               <h4 style="position: relative">
                 {{ $t("components_player_tabs_playerprofiletab.statsByRace") }}
               </h4>
-              <v-data-table
-                hide-default-footer
-                :headers="raceHeaders"
-                :items="selectedRaceStats"
-              >
+              <v-data-table hide-default-footer :headers="raceHeaders" :items="selectedRaceStats">
                 <template v-slot:item.race="{ item }">
                   <span><race-icon v-bind:race="item.race" /></span>
                 </template>
@@ -43,14 +34,12 @@
                     <span class="won">{{ item.wins }}</span>
                     -
                     <span class="lost">{{ item.losses }}</span>
-                    <span style="float: right">
-                      ({{ (item.winrate * 100).toFixed(1) }}%)
-                    </span>
+                    <span style="float: right">({{ (item.winrate * 100).toFixed(1) }}%)</span>
                   </span>
                 </template>
               </v-data-table>
             </v-col>
-            <v-col cols="12" md="6">
+            <v-col cols="12" md="8">
               <h4 style="position: relative">
                 {{ $t("components_player_tabs_playerprofiletab.statsByMode") }}
               </h4>
@@ -60,17 +49,8 @@
         </v-col>
       </v-row>
     </v-card-text>
-    <v-card-text
-      v-if="loadingProfile"
-      style="min-height: 500px"
-      class="text-center"
-    >
-      <v-progress-circular
-        style="margin-top: 180px"
-        :size="50"
-        color="primary"
-        indeterminate
-      ></v-progress-circular>
+    <v-card-text v-if="loadingProfile" style="min-height: 500px" class="text-center">
+      <v-progress-circular style="margin-top: 180px" :size="50" color="primary" indeterminate></v-progress-circular>
     </v-card-text>
   </div>
 </template>
@@ -134,26 +114,19 @@ export default defineComponent({
     const selectedRaceStats: ComputedRef<RaceStat[]> = computed((): RaceStat[] => {
       if (!raceStats.value) return [];
 
-      return raceStats.value.filter((r) =>
-        r.gateWay === rootStateStore.gateway &&
-        r.season === selectedSeason.value?.id
+      return raceStats.value.filter(
+        (r) => r.gateWay === rootStateStore.gateway && r.season === selectedSeason.value?.id
       );
     });
 
     const topGameModeStats: ComputedRef<ModeStat[]> = computed((): ModeStat[] => {
       if (!gameModeStats.value) return [];
 
-      const oneVOnes = gameModeStats.value.filter(
-        (g) => g.gameMode === EGameMode.GM_1ON1
-      );
+      const oneVOnes = gameModeStats.value.filter((g) => g.gameMode === EGameMode.GM_1ON1);
 
       const rankedOneVOnes = oneVOnes.filter((x) => x.rank != 0);
 
-      let bestOneVOne = sortBy(rankedOneVOnes, [
-        "leagueOrder",
-        "division",
-        "rank",
-      ])[0];
+      let bestOneVOne = sortBy(rankedOneVOnes, ["leagueOrder", "division", "rank"])[0];
 
       if (!bestOneVOne) {
         bestOneVOne = oneVOnes[0];
@@ -162,37 +135,25 @@ export default defineComponent({
       const twoV2s = gameModeStats.value.filter((g) => g.gameMode === EGameMode.GM_2ON2_AT);
       const rankedtwoV2s = twoV2s.filter((x) => x.rank != 0);
 
-      let besttwoV2s = sortBy(rankedtwoV2s, [
-        "leagueOrder",
-        "division",
-        "rank",
-      ])[0];
+      let besttwoV2s = sortBy(rankedtwoV2s, ["leagueOrder", "division", "rank"])[0];
 
       if (!besttwoV2s) {
         besttwoV2s = twoV2s[0];
       }
 
-      const otherModes = gameModeStats.value.filter((g) =>
-        g.gameMode !== EGameMode.GM_1ON1 && g.gameMode !== EGameMode.GM_2ON2_AT
+      const otherModes = gameModeStats.value.filter(
+        (g) => g.gameMode !== EGameMode.GM_1ON1 && g.gameMode !== EGameMode.GM_2ON2_AT
       );
 
       const otherModesRanked = otherModes.filter((g) => g.rank != 0);
-      const bestOtherModes = sortBy(otherModesRanked, [
-        "leagueOrder",
-        "division",
-        "rank",
-      ]);
+      const bestOtherModes = sortBy(otherModesRanked, ["leagueOrder", "division", "rank"]);
 
       const allModes = [];
       if (bestOneVOne) allModes.push(bestOneVOne);
       if (besttwoV2s) allModes.push(besttwoV2s);
       allModes.push(...bestOtherModes);
 
-      const bestAllModesSorted = sortBy(allModes, [
-        "leagueOrder",
-        "division",
-        "rank",
-      ]);
+      const bestAllModesSorted = sortBy(allModes, ["leagueOrder", "division", "rank"]);
 
       return take(
         bestAllModesSorted.filter((x) => x.rank != 0),

--- a/src/scss/shared/base.scss
+++ b/src/scss/shared/base.scss
@@ -65,13 +65,6 @@ header.v-app-bar--is-scrolled + main {
   opacity: 0.25;
 }
 
-.red {
-  background-color: red;
-  position: absolute;
-  top: 5px;
-  left: 28px;
-}
-
 .blinker {
   -webkit-animation: up-right 1s infinite;
   -moz-animation: up-right 1s infinite;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -6,17 +6,11 @@
           <v-card-title>
             <v-row no-gutters>
               <v-col :align-self="'center'">
-                <span>
-                  {{ $t("views_player.profile") }} {{ profile.battleTag }}
-                </span>
+                <span>{{ $t("views_player.profile") }} {{ profile.battleTag }}</span>
                 <span v-if="aliasName" class="ml-1">({{ aliasName }})</span>
                 <span class="mr-2" />
                 <!-- add some space between name and season badges -->
-                <div
-                  v-for="season in seasonsWithoutCurrentOne"
-                  :key="season.id"
-                  class="ml-1 d-inline-block"
-                >
+                <div v-for="season in seasonsWithoutCurrentOne" :key="season.id" class="ml-1 d-inline-block">
                   <season-badge :season="season" :on-click="selectSeason" />
                 </div>
               </v-col>
@@ -38,15 +32,9 @@
                         <v-subheader>
                           {{ $t("views_player.prevseasons") }}
                         </v-subheader>
-                        <v-list-item
-                          v-for="item in seasons"
-                          :key="item.id"
-                          @click="selectSeason(item)"
-                        >
+                        <v-list-item v-for="item in seasons" :key="item.id" @click="selectSeason(item)">
                           <v-list-item-content>
-                            <v-list-item-title>
-                              {{ $t("views_rankings.season") }} {{ item.id }}
-                            </v-list-item-title>
+                            <v-list-item-title>{{ $t("views_rankings.season") }} {{ item.id }}</v-list-item-title>
                           </v-list-item-content>
                         </v-list-item>
                       </v-list>
@@ -92,9 +80,7 @@
           <v-container style="padding-top: 6px">
             <v-row align="center" justify="center">
               <host-icon
-                v-if="
-                  ongoingMatch.serverInfo && ongoingMatch.serverInfo.provider
-                "
+                v-if="ongoingMatch.serverInfo && ongoingMatch.serverInfo.provider"
                 :host="ongoingMatch.serverInfo"
               ></host-icon>
             </v-row>
@@ -102,35 +88,19 @@
 
           <v-tabs v-model="tabsModel">
             <v-tabs-slider></v-tabs-slider>
-            <v-tab
-              exact
-              class="profileTab"
-              :to="`/player/${encodeURIComponent(battleTag)}`"
-            >
+            <v-tab exact class="profileTab" :to="`/player/${encodeURIComponent(battleTag)}`">
               {{ $t("views_player.profile") }}
             </v-tab>
-            <v-tab
-              class="profileTab"
-              :to="`/player/${encodeURIComponent(battleTag)}/matches`"
-            >
+            <v-tab class="profileTab" :to="`/player/${encodeURIComponent(battleTag)}/matches`">
               {{ $t("views_player.matchhistory") }}
             </v-tab>
-            <v-tab
-              class="profileTab"
-              :to="`/player/${encodeURIComponent(battleTag)}/at-teams`"
-            >
+            <v-tab class="profileTab" :to="`/player/${encodeURIComponent(battleTag)}/at-teams`">
               {{ $t("views_player.teams") }}
             </v-tab>
-            <v-tab
-              class="profileTab"
-              :to="`/player/${encodeURIComponent(battleTag)}/statistics`"
-            >
+            <v-tab class="profileTab" :to="`/player/${encodeURIComponent(battleTag)}/statistics`">
               {{ $t("views_player.statistics") }}
             </v-tab>
-            <v-tab
-              class="profileTab"
-              :to="`/player/${encodeURIComponent(battleTag)}/clan`"
-            >
+            <v-tab class="profileTab" :to="`/player/${encodeURIComponent(battleTag)}/clan`">
               {{ $t("views_player.clan") }}
             </v-tab>
           </v-tabs>
@@ -200,9 +170,7 @@ export default defineComponent({
 
     const seasonsWithoutCurrentOne: ComputedRef<Season[]> = computed((): Season[] => {
       if (!seasons.value) return [];
-      return seasons.value
-        .filter((s) => s.id !== rankingsStore.seasons[0]?.id)
-        .reverse();
+      return seasons.value.filter((s) => s.id !== rankingsStore.seasons[0]?.id).reverse();
     });
 
     const ongoingMatchGameModeClass: ComputedRef<string> = computed((): string => {
@@ -230,8 +198,7 @@ export default defineComponent({
 
     function getDuration(match: Match): number {
       const today = new Date();
-      const diffMs =
-        today.getTime() - new Date(match.startTime.toString()).getTime(); // milliseconds between now & Christmas
+      const diffMs = today.getTime() - new Date(match.startTime.toString()).getTime(); // milliseconds between now & Christmas
       const diffMins = Math.round(((diffMs % 86400000) % 3600000) / 60000); // minutes
 
       return diffMins;
@@ -243,9 +210,7 @@ export default defineComponent({
       }
 
       return match.teams.find((team: Team) =>
-        team.players.some(
-          (player: PlayerInTeam) => player.battleTag === battleTag.value
-        )
+        team.players.some((player: PlayerInTeam) => player.battleTag === battleTag.value)
       );
     }
 
@@ -254,10 +219,8 @@ export default defineComponent({
         return {} as Team;
       }
 
-      return match.teams.find((team: Team) =>
-          !team.players.some(
-            (player: PlayerInTeam) => player.battleTag === battleTag.value
-          )
+      return match.teams.find(
+        (team: Team) => !team.players.some((player: PlayerInTeam) => player.battleTag === battleTag.value)
       );
     }
 
@@ -352,6 +315,13 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.red {
+  background-color: red;
+  position: absolute;
+  top: 5px;
+  left: 28px;
+}
+
 .profileTab {
   background-color: #f5f5f5;
 }


### PR DESCRIPTION
- Re-align the league banner and center stats by mode (as well as using the entire column space available)
- Use icons instead of using `W/L` for recent performance

Current:
![image](https://github.com/user-attachments/assets/52960a38-16d5-49da-a23f-2a2948504d0a)

New:
![image](https://github.com/user-attachments/assets/3ff68f74-6b36-4644-ba89-5820d5e82bf1)
![image](https://github.com/user-attachments/assets/e2b6b3ba-99f0-47ee-8ac5-783b5f32ff68)
![image](https://github.com/user-attachments/assets/64dd0f01-6656-4c6b-ba65-30bb7c850f15)


