### PR TITLE
Clean up games per day graph

### DIFF
--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -10,6 +10,7 @@ import LineChart, { getBackgroundColor } from "@/components/overall-statistics/L
 import { ChartData, ScriptableContext } from "chart.js";
 import { EGameMode } from "@/store/types";
 import { parseJSON } from "date-fns";
+import { utcToZonedTime } from "date-fns-tz";
 
 export default defineComponent({
   name: "ActivityPerDayChart",
@@ -23,6 +24,10 @@ export default defineComponent({
     },
     selectedGameMode: {
       type: Number as PropType<EGameMode>,
+      required: true,
+    },
+    normalized: {
+      type: Boolean,
       required: true,
     },
   },
@@ -55,8 +60,8 @@ export default defineComponent({
               data: c.gameDays
                 .map((g) => {
                   return {
-                    x: parseJSON(g.date),
-                    y: g.gamesPlayed * multiplier(c.gameMode),
+                    x: utcToZonedTime(parseJSON(g.date), "UTC"),
+                    y: g.gamesPlayed * (props.normalized ? multiplier(c.gameMode) : 1),
                   };
                 })
                 .splice(0, c.gameDays.length - 1),
@@ -114,7 +119,7 @@ export default defineComponent({
         case EGameMode.GM_DS:
           return "rgb(150, 150, 20)";
 
-          case EGameMode.GM_WARHAMMER_1ON1:
+        case EGameMode.GM_WARHAMMER_1ON1:
           return "rgb(255, 0, 192)";
 
         default:

--- a/src/components/overall-statistics/tabs/PlayerActivityTab.vue
+++ b/src/components/overall-statistics/tabs/PlayerActivityTab.vue
@@ -1,35 +1,42 @@
 <template>
   <div>
-    <v-card-title>Games per Day</v-card-title>
-    <v-card-text v-if="!loadingGamesPerDayStats">
-      <v-row>
-        <v-col cols="12" md="2">
-          <v-card-text>
-            <v-select
-              v-model="selectedGamesPerDayMode"
-              :items="activeGameModesWithAll()"
-              item-text="name"
-              item-value="id"
-              @change="setSelectedGamesPerDayMode"
-              :label="$t(`components_overall-statistics_tabs_playeractivitytab.selectmode`)"
-              outlined
-            />
-          </v-card-text>
+    <v-card-title>
+      {{ $t("components_overall-statistics_tabs_playeractivitytab.gamesperday") }}
+    </v-card-title>
+    <v-row v-if="!loadingGamesPerDayStats">
+      <v-col cols="12" md="2">
+        <v-card-text>
+          <v-select
+            v-model="selectedGamesPerDayMode"
+            :items="activeGameModesWithAll()"
+            item-text="name"
+            item-value="id"
+            @change="setSelectedGamesPerDayMode"
+            :label="$t(`components_overall-statistics_tabs_playeractivitytab.selectmode`)"
+            outlined
+            hide-details
+          />
+          <v-switch
+            v-model="normalizedGamesPerDay"
+            @change="setNormalizedGamesPerDay"
+            :label="$t(`components_overall-statistics_tabs_playeractivitytab.normalized`)"
+          ></v-switch>
           <div v-if="isAllMode">
             {{ $t("components_overall-statistics_tabs_playeractivitytab.gamemodedesc1") }}
             <br />
             {{ $t("components_overall-statistics_tabs_playeractivitytab.gamemodedesc2") }}
           </div>
-        </v-col>
-        <v-col cols="12" md="10">
-          <activity-per-day-chart
-            style="position: relative"
-            :selectedGameMode="selectedGamesPerDayMode"
-            :game-days="gameDays"
-          />
-        </v-col>
-      </v-row>
-    </v-card-text>
+        </v-card-text>
+      </v-col>
+      <v-col cols="12" md="10">
+        <activity-per-day-chart
+          style="position: relative"
+          :selectedGameMode="selectedGamesPerDayMode"
+          :game-days="gameDays"
+          :normalized="normalizedGamesPerDay"
+        />
+      </v-col>
+    </v-row>
     <v-card-title>
       {{ $t("components_overall-statistics_tabs_playeractivitytab.playersperday") }}
     </v-card-title>
@@ -219,17 +226,18 @@ export default defineComponent({
     const selectedMatchupRace2 = ref<ERaceEnum>(ERaceEnum.HUMAN);
     const selectedMatchupMmr = ref<string>("all");
     const selectedMatchupSeason = ref<string>("all");
+    const normalizedGamesPerDay = ref<boolean>(true);
     const selectedSeasonForMapsInitial: ComputedRef<string> = computed((): string => rankingsStore.seasons[0]?.id?.toString() ?? "");
     const isAllMode: ComputedRef<boolean> = computed((): boolean => selectedGamesPerDayMode.value === EGameMode.UNDEFINED);
     const race1String: ComputedRef<string> = computed((): string => raceOptions.filter((r) => r.id == selectedMatchupRace1.value)[0].name);
     const race2String: ComputedRef<string> = computed((): string => raceOptions.filter((r) => r.id == selectedMatchupRace2.value)[0].name);
     let overWrittenOnce = false;
 
-     onMounted(async (): Promise<void> => {
+    onMounted(async (): Promise<void> => {
       await loadActiveGameModes();
       await rankingsStore.retrieveSeasons();
       setMatchupLengthSeason("all");
-     });
+    });
 
     function setSelectedLengthMode(mode: EGameMode) {
       selectedLengthMode.value = mode;
@@ -271,6 +279,10 @@ export default defineComponent({
       overallStatsStore.loadMatchupLengthStatistics(selectedMatchupRace1.value, selectedMatchupRace2.value, selectedMatchupSeason.value);
     }
 
+    function setNormalizedGamesPerDay(normalized: boolean) {
+      normalizedGamesPerDay.value = normalized;
+    }
+
     const seasons: ComputedRef<string[]> = computed((): string[] => ["All", ...rankingsStore.seasons.map((s) => s.id.toString())]);
 
     const seasonsForMatchup: ComputedRef<{ id: string; name: string }[]> = computed((): { id: string; name: string }[] => {
@@ -299,8 +311,8 @@ export default defineComponent({
 
     const selectedGameLength: ComputedRef<GameLength> = computed((): GameLength => {
       return gameLength.value?.filter(
-          (g) => g.gameMode == selectedLengthMode.value
-        )[0] ?? { lengths: [] };
+        (g) => g.gameMode == selectedLengthMode.value
+      )[0] ?? { lengths: [] };
     });
 
     const selectedGameHours: ComputedRef<PopularHours> = computed((): PopularHours => {
@@ -383,6 +395,8 @@ export default defineComponent({
       setMatchupLengthSeason,
       race1String,
       race2String,
+      normalizedGamesPerDay,
+      setNormalizedGamesPerDay,
     };
   },
 });

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -333,9 +333,11 @@ const data = {
       stddev: "Standard Deviation",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Games per Day",
       selectmode: "Select Mode",
+      normalized: "Normalized",
       gamemodedesc1:
-        "Game Modes are normalized to compare their popularity more easily:",
+        "Game modes are normalized to compare their popularity more easily:",
       gamemodedesc2:
         "2v2 and FFA games are counted twice, 4v4 games are counted four times",
       playersperday: "Players per Day",
@@ -522,7 +524,7 @@ const data = {
       MMR_2200: "> 2200 (~Grandmaster)",
       MMR_2000: "> 2000 (~Master)",
       MMR_1800: "> 1800 (~Diamond)",
-      MMR_1600: "> 1600 (~Platin)",
+      MMR_1600: "> 1600 (~Platinum)",
       MMR_1400: "> 1400 (~Gold)",
       MMR_1200: "> 1200 (~Silver)",
       MMR_1000: "> 1000 (~Bronze)",
@@ -883,7 +885,9 @@ const data = {
       greenbardesc: "Зеленая полоса отмечает вашу позицию на графике",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Игры в день",
       selectmode: "Выберите режим",
+      normalized: "нормализованный",
       gamemodedesc1:
         "Игровые режимы нормализованы, чтобы легче сравнивать их популярность:",
       gamemodedesc2:
@@ -1370,6 +1374,8 @@ const data = {
       greenbardesc: "녹색 선은 당신의 위치를 나타냅니다",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "하루당 게임 수",
+      normalized: "정규화됨",
       gamemodedesc1: "게임모드는 인기를 쉽게 비교할 수 있도록 표준화 됩니다.",
       gamemodedesc2: "2대2와 FFA는 2번, 4대4는 4번 계산됩니다.",
     },
@@ -1838,7 +1844,9 @@ const data = {
       stddev: "标准差",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "每日游戏数",
       selectmode: "选择模式",
+      normalized: "标准化",
       gamemodedesc1: "游戏模式计算方式：",
       gamemodedesc2: "2v2和FFA会算两次，4v4会被算4次",
       playersperday: "每日玩家数量",
@@ -2328,6 +2336,8 @@ const data = {
       greenbardesc: "Die grüne Linie zeigt deinen Platz in der Verteilung.",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Spiele pro Tag",
+      normalized: "Normalisiert",
       gamemodedesc1: "Spielmodi werden nach ihrer Spieleranzahl genormt:",
       gamemodedesc2: "2vs2 und FFA zählen doppelt, 4vs4 zählt vierfach.",
     },
@@ -2831,7 +2841,9 @@ const data = {
       greenbardesc: "Zielonia linia pokazuje twoją pozycję",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Gry na dzień",
       selectmode: "Wybierz tryb",
+      normalized: "Znormalizowany",
       gamemodedesc1:
         "Tryby gry są znormalizowane, aby łatwiej porównać ich popularność.",
       gamemodedesc2: "Mecze 2v2 i FFA są liczone podwójne, a 4v4 poczwórnie.",
@@ -3359,7 +3371,9 @@ const data = {
       greenbardesc: "Зелена смуга відзначає вашу позицію на графіку",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Ігри на день",
       selectmode: "Оберіть режим",
+      normalized: "Нормалізований",
       gamemodedesc1:
         "Ігрові режими нормалізовані, щоб легше порівнювати їх популярність:",
       gamemodedesc2:
@@ -3875,11 +3889,13 @@ const data = {
       greenbardesc: "A linha verde mostra onde você está na distribuição.\r\n",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Jogos por dia",
       selectmode: "Selecione modo",
+      normalized: "Normalizado",
       gamemodedesc1:
         "Os modos de jogos são normalizados para poder comparar mais facilmente a popularidade:",
       gamemodedesc2:
-        "Jogos de 2v2 e FFA são contadas duas vezes, jogos de 4v4 são  contadas quatro vezes",
+        "Jogos de 2v2 e FFA são contadas duas vezes, jogos de 4v4 são contadas quatro vezes",
       playersperday: "Jogadores por dia",
       playedmaps: "Mapas jogados",
       popularhours: "Horários populares",
@@ -4399,7 +4415,9 @@ const data = {
         "La ligne verte montre où vous êtes dans la répartition des joueurs.",
     },
     "components_overall-statistics_tabs_playeractivitytab": {
+      gamesperday: "Jeux par jour",
       selectmode: "Sélectionnez un Mode",
+      normalized: "Normalisé",
       gamemodedesc1:
         "Les modes de jeu sont normalisés afin de comparer plus facilement leur popularité :",
       gamemodedesc2:

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -40,6 +40,7 @@ const en = {
     GM_SC_FFA_4: "Survival Chaos",
     GM_DS: "Direct Strike 3v3",
     GM_DS_AT: "Direct Strike 3v3 AT",
+    GM_WARHAMMER_1ON1: "Warhammer 1v1",
   },
 
   gatewayNames: {


### PR DESCRIPTION
Closes https://github.com/w3champions/website/issues/845

- Fixes the date calculation for the graph; previously it would use the local date when the data was UTC midnight, so specifically for anyone with a timezone west of UTC, it would show the previous date rather than the date of the data. 
- Added a "Normalized" switch which allows turning off the normalization multiplier per game mode.
- Added the missing `GM_WARHAMMER_1ON1` entry to `en.ts` (oversight from https://github.com/w3champions/website/pull/843), also fixed `Platin`->`Platinum` for english
- Wired up translation for the "Games per Day" title and "Normalized" switch
  - I used google translate to do my best to fill them in, but surely they'll need a pass from whoever speaks those languages.
  - I skipped the SR language though because it's... horribly broken. If you take a look through it, it's obvious that the translation strings are mismatched to their keys, like they're all off by one. For example:
    ```
    winlossdesc: "MMR",
    mmr: "MMR",
    mmrdesc: "RP",
    rp: "Nivo",
    ```
    All the values are shifted up by one key. I don't speak the language so I don't feel confident to try to fix it, nor fill many of the missing keys.
- Slightly adjusted the layout:
  - Remove the `v-card-text` around the row which added padding, and to be consistent with the other graphs below
  - Add `hide-details` to the `v-select` which removes some dead space below it

Before:
![image](https://github.com/user-attachments/assets/3c69de83-293f-4920-b9bf-6660d9d05068)

After:
![image](https://github.com/user-attachments/assets/2176d733-7d63-4922-a7a0-9bb521ebfb16)
