### PR TITLE
Add "All" mode in match history tab

### DIFF
--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -17,7 +17,7 @@
         <v-col cols="12" md="2">
           <v-select
             class="over-chart-select-box"
-            :items="activeGameModes()"
+            :items="activeGameModesWithAll()"
             item-text="name"
             item-value="id"
             @change="setSelectedGameModeForSearch"
@@ -80,7 +80,7 @@
 <script lang="ts">
 import { computed, ComputedRef, defineComponent, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
-import { loadActiveGameModes, activeGameModes } from "@/mixins/GameModesMixin";
+import { loadActiveGameModes, activeGameModesWithAll } from "@/mixins/GameModesMixin";
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
 import { EGameMode, ERaceEnum, Match, PlayerInTeam, Team } from "@/store/types";
 import PlayerSearch from "@/components/common/PlayerSearch.vue";
@@ -227,7 +227,7 @@ export default defineComponent({
     }
 
     return {
-      activeGameModes,
+      activeGameModesWithAll,
       profileMatchesGameMode,
       playerRace,
       opponentRace,


### PR DESCRIPTION
Fixes a minor issue reported in https://discord.com/channels/688377338576109643/769295273310027797/1289351937610747976, since there was no All mode in the select, if you pick a different mode then it's impossible to go back to All without refreshing. Super simple fix.