### PR TITLE
GamesPerDay: Recalculate "All" as normalized

### DIFF
--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -43,7 +43,10 @@ export default defineComponent({
     );
 
     // Get the list of dates for the x-axis
-    const gameDayDates = computed(() => allSet.value.gameDays.map((g) => utcToZonedTime(parseJSON(g.date), "UTC")));
+    const gameDayDates = computed(() => allSet.value.gameDays
+      .slice(0, allSet.value.gameDays.length - 1) // Drop today's data (last entry)
+      .map((g) => utcToZonedTime(parseJSON(g.date), "UTC"))
+    );
 
     // Recompute the "All" set using all the other game modes,
     // using each mode's normalizing multiplier (the backend doesn't normalize)
@@ -94,6 +97,7 @@ export default defineComponent({
             borderColor: mapColor(c.gameMode),
             borderWidth: 1.5,
             tension: 0.4, // Smooth line.
+            pointHitRadius: 6,
           } satisfies ChartDataset<"line">)),
       };
     });

--- a/src/components/overall-statistics/ActivityPerDayChart.vue
+++ b/src/components/overall-statistics/ActivityPerDayChart.vue
@@ -75,7 +75,7 @@ export default defineComponent({
           // Filter out inactive gamemodes, but show total games (UNDEFINED)
           .filter((c) => activeGameModeIds.includes(c.gameMode) || c.gameMode === EGameMode.UNDEFINED)
           // Only show the mode that user selected (but "All" shows everything)
-          .filter((c) => 
+          .filter((c) =>
             props.selectedGameMode === EGameMode.UNDEFINED
             || c.gameMode === props.selectedGameMode
           )

--- a/src/components/overall-statistics/AmountPerDayChart.vue
+++ b/src/components/overall-statistics/AmountPerDayChart.vue
@@ -38,6 +38,7 @@ export default defineComponent({
           borderColor: "rgba(54, 162, 235, 1)",
           borderWidth: 1.5,
           tension: 0.4, // Smooth line.
+          pointHitRadius: 6,
         },
       ],
     }));

--- a/src/components/overall-statistics/AmountPerDayChart.vue
+++ b/src/components/overall-statistics/AmountPerDayChart.vue
@@ -6,7 +6,7 @@ import { computed, defineComponent, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { GameDay } from "@/store/overallStats/types";
 import LineChart from "@/components/overall-statistics/LineChart.vue";
-import { ChartData, ChartDataset } from "chart.js";
+import { ChartData } from "chart.js";
 import { parseJSON } from "date-fns";
 import { utcToZonedTime } from "date-fns-tz";
 

--- a/src/components/overall-statistics/AmountPerDayChart.vue
+++ b/src/components/overall-statistics/AmountPerDayChart.vue
@@ -2,12 +2,13 @@
   <line-chart :chart-data="chartData" />
 </template>
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, ref } from "vue";
+import { computed, defineComponent, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { GameDay } from "@/store/overallStats/types";
 import LineChart from "@/components/overall-statistics/LineChart.vue";
-import { ChartData } from "chart.js";
+import { ChartData, ChartDataset } from "chart.js";
 import { parseJSON } from "date-fns";
+import { utcToZonedTime } from "date-fns-tz";
 
 export default defineComponent({
   name: "AmountPerDayChart",
@@ -23,25 +24,23 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
 
-    const gameDayDates = ref<Date[]>(props.gameDays.map((g) => parseJSON(g.date)));
+    const gameDayDates = ref<Date[]>(props.gameDays.map((g) => utcToZonedTime(parseJSON(g.date), "UTC")));
     const gameDayCounts = ref<number[]>(props.gameDays.map((g) => g.gamesPlayed));
 
-    const chartData: ComputedRef<ChartData> = computed((): ChartData => {
-      return {
-        labels: gameDayDates.value,
-        datasets: [
-          {
-            label: t("components_overall-statistics_tabs_playeractivitytab.playersperday").toString(),
-            data: gameDayCounts.value,
-            fill: true,
-            backgroundColor: "rgba(54, 162, 235, 0.2)",
-            borderColor: "rgba(54, 162, 235, 1)",
-            borderWidth: 1.5,
-            tension: 0.4, // Smooth line.
-          },
-        ],
-      };
-    });
+    const chartData = computed<ChartData<"line">>(() => ({
+      labels: gameDayDates.value,
+      datasets: [
+        {
+          label: t("components_overall-statistics_tabs_playeractivitytab.playersperday").toString(),
+          data: gameDayCounts.value,
+          fill: true,
+          backgroundColor: "rgba(54, 162, 235, 0.2)",
+          borderColor: "rgba(54, 162, 235, 1)",
+          borderWidth: 1.5,
+          tension: 0.4, // Smooth line.
+        },
+      ],
+    }));
 
     return {
       chartData,

--- a/src/components/overall-statistics/BarChart.vue
+++ b/src/components/overall-statistics/BarChart.vue
@@ -1,13 +1,14 @@
 <template>
   <bar-chart-generic
-      :data="chartData"
-      :options="chartOptions"
+    :data="chartData"
+    :options="chartOptions"
   />
 </template>
 
 <script lang="ts">
-import { BarController, BarElement, CategoryScale, Chart as ChartJS, ChartOptions, Filler, LinearScale, Tooltip, Legend } from "chart.js";
+import { BarController, BarElement, CategoryScale, Chart as ChartJS, ChartOptions, Filler, LinearScale, Tooltip, Legend, ChartData } from "chart.js";
 import chartJSPluginAnnotation from "chartjs-plugin-annotation";
+import { PropType } from "vue";
 import { Bar as BarChartGeneric } from "vue-chartjs";
 
 ChartJS.register(BarController);
@@ -51,7 +52,12 @@ export default {
   components: { BarChartGeneric },
   props: {
     chartData: {
-      type: Object,
+      // Unfortunately we can't use ChartData<"bar"> here,
+      // because we sometimes pass mixed charts (line and bar)
+      // which chartjs supports, but vue-chartjs doesn't expose
+      // types for.
+      type: Object as PropType<ChartData<any>>,
+      required: true,
     },
     chartOptions: {
       type: Object,

--- a/src/components/overall-statistics/GameLengthChart.vue
+++ b/src/components/overall-statistics/GameLengthChart.vue
@@ -3,9 +3,9 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, PropType } from "vue";
+import { computed, defineComponent, PropType } from "vue";
 import { useI18n } from "vue-i18n-bridge";
-import { GameLength, Length } from "@/store/overallStats/types";
+import { GameLength } from "@/store/overallStats/types";
 import BarChart from "@/components/overall-statistics/BarChart.vue";
 import { ChartData } from "chart.js";
 import { formatSecondsToDuration } from "@/helpers/date-functions";
@@ -24,16 +24,16 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
 
-    const trimmedStats: ComputedRef<Length[]> = computed((): Length[] => {
+    const trimmedStats = computed(() => {
       const stats = props.gameLength.lengths.slice(4); // Do not display games lasting less than 2 minutes.
       stats.pop(); // Do not display the last entry, because all games longer than the last timeslot are accumulated here.
       return stats;
     });
 
-    const passedTime: ComputedRef<string[]> = computed((): string[] => trimmedStats.value.map((g) => formatSecondsToDuration(g.seconds)));
-    const gamesCount: ComputedRef<number[]> = computed((): number[] => trimmedStats.value.map((g) => g.games));
+    const passedTime = computed(() => trimmedStats.value.map((g) => formatSecondsToDuration(g.seconds)));
+    const gamesCount = computed(() => trimmedStats.value.map((g) => g.games));
 
-    const gameHourChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const gameHourChartData = computed<ChartData<"bar">>(() => {
       return {
         labels: passedTime.value,
         datasets: [

--- a/src/components/overall-statistics/LineChart.vue
+++ b/src/components/overall-statistics/LineChart.vue
@@ -1,7 +1,7 @@
 <template>
   <line-chart-generic
-      :data="chartData"
-      :options="chartOptions"
+    :data="chartData"
+    :options="chartOptions"
   />
 </template>
 
@@ -20,9 +20,12 @@ import {
   Legend,
   ChartArea,
   ScriptableContext,
+  ChartData,
+  Point,
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import chartJSPluginAnnotation from "chartjs-plugin-annotation";
+import { PropType } from "vue";
 import { Line as LineChartGeneric } from "vue-chartjs";
 
 ChartJS.register(LineController);
@@ -104,7 +107,8 @@ export default {
   components: { LineChartGeneric },
   props: {
     chartData: {
-      type: Object,
+      type: Object as PropType<ChartData<"line">>,
+      required: true,
     },
     chartOptions: {
       type: Object,

--- a/src/components/overall-statistics/LineChart.vue
+++ b/src/components/overall-statistics/LineChart.vue
@@ -21,7 +21,6 @@ import {
   ChartArea,
   ScriptableContext,
   ChartData,
-  Point,
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import chartJSPluginAnnotation from "chartjs-plugin-annotation";

--- a/src/components/overall-statistics/MapsPerSeasonChart.vue
+++ b/src/components/overall-statistics/MapsPerSeasonChart.vue
@@ -2,7 +2,7 @@
   <bar-chart :chart-data="barChartData" />
 </template>
 <script lang="ts">
-import { computed, ComputedRef, defineComponent } from "vue";
+import { computed, defineComponent } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { ChartData } from "chart.js";
 import BarChart from "@/components/overall-statistics/BarChart.vue";

--- a/src/components/overall-statistics/MapsPerSeasonChart.vue
+++ b/src/components/overall-statistics/MapsPerSeasonChart.vue
@@ -22,10 +22,10 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
 
-    const mapNames: ComputedRef<string[]> = computed((): string[] => props.mapsPerSeason.map((m) => m.mapName ?? m.map));
-    const gamesCount: ComputedRef<number[]> = computed((): number[] => props.mapsPerSeason.map((m) => m.count));
+    const mapNames = computed(() => props.mapsPerSeason.map((m) => m.mapName ?? m.map));
+    const gamesCount = computed(() => props.mapsPerSeason.map((m) => m.count));
 
-    const barChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const barChartData = computed<ChartData<"bar">>(() => {
       return {
         labels: mapNames.value,
         datasets: [

--- a/src/components/overall-statistics/MatchupLengthBarChart.vue
+++ b/src/components/overall-statistics/MatchupLengthBarChart.vue
@@ -5,11 +5,10 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent } from "vue";
+import { computed, defineComponent } from "vue";
 import BarChart from "@/components/overall-statistics/BarChart.vue";
 import { useOverallStatsStore } from "@/store/overallStats/store";
 import { formatSecondsToDuration } from "@/helpers/date-functions";
-import { Length } from "@/store/overallStats/types";
 import { useI18n } from "vue-i18n-bridge";
 import { ChartData } from "chart.js";
 
@@ -22,21 +21,22 @@ export default defineComponent({
     const { t } = useI18n();
     const statsStore = useOverallStatsStore();
 
-    const lengths: ComputedRef<Length[]> = computed((): Length[] => {
+    const lengths = computed(() => {
       const mmrRange = statsStore.matchupMmrRange;
       return statsStore.matchupLength?.lengthsByMmrRange?.[mmrRange] || [];
     });
 
-    const games: ComputedRef<number[]> = computed((): number[] => lengths.value.slice(4).map((e) => e.games)); // slicing to ignoring first 2 min of game);
+    // slicing to ignoring first 2 min of game
+    const games = computed(() => lengths.value.slice(4).map((e) => e.games));
 
-    const intervals: ComputedRef<string[]> = computed((): string[] => {
+    const intervals = computed(() => {
       const intervals = lengths.value.map((e) => formatSecondsToDuration(e.seconds));
       // games in the last position have 60 min or more, so add + as suffix
       intervals[intervals.length - 1] = intervals[intervals.length - 1] + "+";
       return intervals.slice(4); // slicing to ignoring first 2 min of game
     });
 
-    const matchupLengthChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const matchupLengthChartData = computed<ChartData<"bar">>(() => {
       return {
         labels: intervals.value,
         datasets: [

--- a/src/components/overall-statistics/MmrDistributionChart.vue
+++ b/src/components/overall-statistics/MmrDistributionChart.vue
@@ -40,7 +40,7 @@ export default defineComponent({
     const playerStore = usePlayerStore();
     const gameModeStats: ComputedRef<ModeStat[]> = computed((): ModeStat[] => playerStore.gameModeStats);
 
-    const colors: ComputedRef<string[]> = computed((): string[] => {
+    const colors = computed(() => {
       const colors: string[] = [];
       for (let i = 0; i < props.mmrDistribution.distributedMmrs.length; i++) {
         if (
@@ -122,7 +122,7 @@ export default defineComponent({
         .reverse();
     });
 
-    const mmrDistributionChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const mmrDistributionChartData = computed<ChartData<"bar"|"line">>(() => {
       return {
         labels: props.mmrDistribution.distributedMmrs.map((d) => `> ${d.mmr}`),
         datasets: [
@@ -149,26 +149,26 @@ export default defineComponent({
 
     const mmrDistributionChartOptions: ComputedRef<ChartOptions> = computed((): ChartOptions => {
       const annotations: { [key: string]: AnnotationOptions } = mmrGroupOfLoggedInPlayer.value
-          ? {
-            x: {
-              type: "line",
-              scaleID: "x",
-              value: `> ${mmrGroupOfLoggedInPlayer.value}`,
-              borderColor: "rgb(28,95,47, 0.7)",
-              borderWidth: 2,
-              borderDash: [10, 10],
-              label: {
-                display: true,
-                content: "Your MMR",
-                backgroundColor: "rgb(28,95,47, 0.7)",
-                yAdjust: 10,
-                xAdjust: isTop50percent.value ? 40 : -40, //Move label to left or right of line
-                position: "start",
-                borderRadius: 0,
-              },
+        ? {
+          x: {
+            type: "line",
+            scaleID: "x",
+            value: `> ${mmrGroupOfLoggedInPlayer.value}`,
+            borderColor: "rgb(28,95,47, 0.7)",
+            borderWidth: 2,
+            borderDash: [10, 10],
+            label: {
+              display: true,
+              content: "Your MMR",
+              backgroundColor: "rgb(28,95,47, 0.7)",
+              yAdjust: 10,
+              xAdjust: isTop50percent.value ? 40 : -40, //Move label to left or right of line
+              position: "start",
+              borderRadius: 0,
             },
-          }
-          : {};
+          },
+        }
+        : {};
 
       return {
         plugins: {

--- a/src/components/overall-statistics/MmrDistributionChart.vue
+++ b/src/components/overall-statistics/MmrDistributionChart.vue
@@ -142,6 +142,7 @@ export default defineComponent({
             data: cumulativeSumData.value,
             borderColor: "rgb(60,208,88)",
             fill: false,
+            pointHitRadius: 6,
           },
         ],
       };

--- a/src/components/overall-statistics/PlayedHeroesChart.vue
+++ b/src/components/overall-statistics/PlayedHeroesChart.vue
@@ -80,7 +80,7 @@ export default defineComponent({
       return flatten(computedArray);
     });
 
-    const chartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const chartData = computed<ChartData<"bar">>(() => {
       return {
         labels: orderedHeroes.value.map((p: PlayedHero) => p.icon),
         datasets: [

--- a/src/components/overall-statistics/PopularGameTimeChart.vue
+++ b/src/components/overall-statistics/PopularGameTimeChart.vue
@@ -54,7 +54,7 @@ export default defineComponent({
 
     const gamesCount: ComputedRef<number[]> = computed((): number[] => timeslots.value.map((g) => g.games));
 
-    const gameHourChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const gameHourChartData = computed<ChartData<"bar">>(() => {
       return {
         labels: gameStartHour.value,
         datasets: [

--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -33,6 +33,7 @@ import { useI18n } from "vue-i18n-bridge";
 import { TranslateResult } from "vue-i18n";
 import { RaceStat, WinLossesOnMap } from "@/store/player/types";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
+import { ERaceEnum } from "@/store/types";
 
 interface RaceToMapStatHeader {
   text: TranslateResult;
@@ -55,11 +56,18 @@ export default defineComponent({
     const { t } = useI18n();
 
     function totalWins(stat: RaceStat[]) {
+      const totalGames = stat.map((s) => s.games).reduce((a, b) => a + b, 0);
       const totalWins = stat.map((s) => s.wins).reduce((a, b) => a + b, 0);
       const totalLosses = stat.map((s) => s.losses).reduce((a, b) => a + b, 0);
       const totalWinrate = totalLosses + totalWins != 0 ? totalWins / (totalWins + totalLosses) : 0;
 
-      return { wins: totalWins, losses: totalLosses, winrate: totalWinrate };
+      return {
+        games: totalGames,
+        wins: totalWins,
+        losses: totalLosses,
+        winrate: totalWinrate,
+        race: ERaceEnum.TOTAL,
+      };
     }
 
     const headers: RaceToMapStatHeader[] = [

--- a/src/components/overall-statistics/tabs/PlayerActivityTab.vue
+++ b/src/components/overall-statistics/tabs/PlayerActivityTab.vue
@@ -21,7 +21,7 @@
             @change="setNormalizedGamesPerDay"
             :label="$t(`components_overall-statistics_tabs_playeractivitytab.normalized`)"
           ></v-switch>
-          <div v-if="isAllMode">
+          <div v-if="normalizedGamesPerDay">
             {{ $t("components_overall-statistics_tabs_playeractivitytab.gamemodedesc1") }}
             <br />
             {{ $t("components_overall-statistics_tabs_playeractivitytab.gamemodedesc2") }}

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -87,9 +87,9 @@
               <template v-slot:activator="{ on }">
                 <v-card-text
                   v-on="on"
-                  :class="getCorrectClasses(race, number)"
-                  @click="isLoggedInPlayer ? savePicture(race, number) : null"
-                  :style="{'background-image': 'url(' + picture(race, number) + ')'}"
+                  :class="getCorrectClasses(raceToAvatar(race), number)"
+                  @click="isLoggedInPlayer ? savePicture(raceToAvatar(race), number) : null"
+                  :style="{'background-image': 'url(' + picture(raceToAvatar(race), number) + ')'}"
                 />
               </template>
               <span>{{ winsOf(winsOfRace(race), number, race) }}</span>
@@ -300,7 +300,6 @@
                         label="About"
                         clearable
                         :rules="[rules.maxLength(300)]"
-                        value
                         v-model="userProfile.about"
                         :hint="$t('components_player_playeravatar.aboutdesc')"
                       ></v-textarea>
@@ -480,6 +479,18 @@ export default defineComponent({
       personalSettingsDialogOpened.value = false;
     }
 
+    function raceToAvatar(race: ERaceEnum): EAvatarCategory {
+      return {
+        [ERaceEnum.RANDOM]: EAvatarCategory.RANDOM,
+        [ERaceEnum.HUMAN]: EAvatarCategory.HUMAN,
+        [ERaceEnum.ORC]: EAvatarCategory.ORC,
+        [ERaceEnum.NIGHT_ELF]: EAvatarCategory.NIGHTELF,
+        [ERaceEnum.UNDEAD]: EAvatarCategory.UNDEAD,
+        [ERaceEnum.TOTAL]: EAvatarCategory.TOTAL,
+        [ERaceEnum.STARTER]: EAvatarCategory.STARTER,
+      }[race];
+    }
+
     function getCorrectClasses(category: EAvatarCategory, iconId: number): string[] {
       const classes = ["player-avatar-choosing"];
       if (props.isLoggedInPlayer && enabledIfEnoughWins(category, iconId)) classes.push("pointer");
@@ -619,6 +630,7 @@ export default defineComponent({
       rules,
       resetUserProfile,
       saveUserProfile,
+      raceToAvatar,
     };
   },
 });

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -37,7 +37,7 @@
 
 <script lang="ts">
 import { computed, ComputedRef, defineComponent, ref } from "vue";
-import { PlayerHeroStatistic } from "@/store/player/types";
+import { NumbersByPlayerHeroStatistic, PlayerHeroStatistic } from "@/store/player/types";
 import { mdiMenuLeft } from "@mdi/js";
 import { mdiMenuRight } from "@mdi/js";
 
@@ -67,9 +67,9 @@ export default defineComponent({
       { text: "vs. Undead", value: "ud" },
       { text: "vs. Night Elf", value: "ne" },
       { text: "vs. Random", value: "rand" },
-    ];
+    ] satisfies { text: string, value: keyof PlayerHeroStatistic}[];
 
-    const headersWithoutImageAndName = headers.slice(2);
+    const headersWithoutImageAndName = headers.slice(2) as { text: string, value: keyof NumbersByPlayerHeroStatistic}[];
 
     return {
       mdiMenuLeft,

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, PropType, ref } from "vue";
+import { computed, defineComponent, PropType, ref } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { getAsset } from "@/helpers/url-functions";
 import RaceIcon from "@/components/player/RaceIcon.vue";
@@ -85,14 +85,12 @@ export default defineComponent({
     const playerStore = usePlayerStore();
     const paginationSize = 10;
     const page = ref<number>(1);
-    const selectedRace: ComputedRef<number> = computed((): number => Number(selectedTab.value.split("-")[1]));
-    const pageOffset: ComputedRef<number> = computed((): number => paginationSize * page.value);
-    const pageLength: ComputedRef<number> = computed((): number => Math.ceil(heroWinRates().length / paginationSize));
-    const heroStatsCurrentPage: ComputedRef<PlayerHeroWinRateForStatisticsTab[]> = computed((): PlayerHeroWinRateForStatisticsTab[] => heroWinRates().slice((pageOffset.value - paginationSize), pageOffset.value));
+    const selectedRace = computed(() => Number(selectedTab.value.split("-")[1]));
+    const pageOffset = computed(() => paginationSize * page.value);
+    const pageLength = computed(() => Math.ceil(heroWinRates().length / paginationSize));
+    const heroStatsCurrentPage = computed(() => heroWinRates().slice((pageOffset.value - paginationSize), pageOffset.value));
 
-    const selectedTab: ComputedRef<string> = computed((): string => {
-      return defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All);
-    });
+    const selectedTab = computed(() => defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All));
 
     const headers = [
       { text: "", value: "image" },
@@ -105,7 +103,7 @@ export default defineComponent({
       { text: "vs. Random", value: ERaceEnum.RANDOM },
     ];
 
-    const headersWithoutImageAndName = headers.slice(2);
+    const headersWithoutImageAndName = headers.slice(2) as { text: string; value: ERaceEnum }[];
 
     function getImageForTable(heroId: string): string {
       const src: string = getAsset(`heroes/${heroId}.png`);

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       return { ...defaultOptions(), ...options };
     });
 
-    const mmrRpChartData: ComputedRef<ChartData> = computed((): ChartData => {
+    const mmrRpChartData = computed<ChartData<"line">>(() => {
       return {
         labels: dates.value,
         datasets: [

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -72,6 +72,7 @@ export default defineComponent({
             pointStyle: "circle",
             pointRadius: 1.2,
             pointBorderWidth: 1.8,
+            pointHitRadius: 6,
             tension: 0.4, // Smooth line.
           },
           {
@@ -85,6 +86,7 @@ export default defineComponent({
             pointStyle: "circle",
             pointRadius: 1.2,
             pointBorderWidth: 1.8,
+            pointHitRadius: 6,
             tension: 0.4, // Smooth line.
           },
         ],

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent } from "vue";
+import { computed, defineComponent } from "vue";
 import { RaceWinsOnMap } from "@/store/player/types";
 import RaceToMapStat from "@/components/overall-statistics/RaceToMapStat.vue";
 import { ERaceEnum } from "@/store/types";
@@ -45,11 +45,9 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const isStatsEmpty: ComputedRef<boolean> = computed((): boolean => isEmpty(props.stats));
+    const isStatsEmpty = computed(() => isEmpty(props.stats));
 
-    const selectedTab: ComputedRef<string> = computed((): string => {
-      return defaultStatsTab(props.stats);
-    });
+    const selectedTab = computed(() => defaultStatsTab(props.stats));
 
     return {
       ERaceEnum,

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -177,6 +177,7 @@ export type FractionForTooltip = {
 };
 
 export type NumbersByRaceForTooltip = {
+  [ERaceEnum.RANDOM]: FractionForTooltip;
   [ERaceEnum.HUMAN]: FractionForTooltip;
   [ERaceEnum.NIGHT_ELF]: FractionForTooltip;
   [ERaceEnum.ORC]: FractionForTooltip;

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -163,12 +163,25 @@ export type PlayerGameLength = {
 };
 
 export type PlayerHeroStatistic = {
+  image: string;
+  name: string;
   hero: string;
   total: string;
   ud: string;
   orc: string;
   hu: string;
   ne: string;
+  rand: string;
+  numbers_by_race: NumbersByPlayerHeroStatistic;
+};
+
+export type NumbersByPlayerHeroStatistic = {
+  total: FractionForTooltip;
+  ud: FractionForTooltip;
+  orc: FractionForTooltip;
+  hu: FractionForTooltip;
+  ne: FractionForTooltip;
+  rand: FractionForTooltip;
 };
 
 export type FractionForTooltip = {


### PR DESCRIPTION
This normalizes the "All" line on the games per day graph, by recalculating the data from all the other game modes, ignoring the value from the backend, when Normalized is switched on. This makes sure that "All" isn't smaller than popular modes like Direct Strike that have a multiplier.

Also increased the `pointHitRadius` on all the line graphs so that hovering on specific datapoints is easier.

I also cleaned up some type errors I noticed from clicking around on the various graph components.

Before:

![image](https://github.com/user-attachments/assets/81b42db1-85d6-4158-8962-62a2368b05be)

After:

![image](https://github.com/user-attachments/assets/d830a630-a096-4eb3-b148-fceaad85e60a)
