### PR TITLE
PlayerStats: Find most played mode, redetermine on season switch

### DIFF
--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -138,7 +138,7 @@ export default defineComponent({
 
       if (isEmpty(heroStatsData)) return;
 
-      const winLossesOnMap = playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch.All
+      const winLossesOnMap = playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All
         .filter((obj: RaceWinsOnMap) => obj.race == selectedRace.value)[0]
         .winLossesOnMap
         .filter((winLossesOnMap: WinLossesOnMap) => winLossesOnMap.map == props.selectedMap)[0];

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -280,11 +280,9 @@ export default defineComponent({
     }
 
     async function initMmrRpTimeline() {
-      const selectedSeason = playerStore.selectedSeason?.id;
       let maxMode = EGameMode.GM_1ON1;
       let maxModeGames = 0;
       playerStore.gameModeStats.forEach((m) => {
-        if (m.season !== selectedSeason) return;
         if (m.games > maxModeGames) {
           maxModeGames = m.games;
           maxMode = m.gameMode;
@@ -295,7 +293,6 @@ export default defineComponent({
       let maxRace = ERaceEnum.HUMAN;
       let maxRaceGames = 0;
       playerStore.raceStats.forEach((r) => {
-        if (r.season !== selectedSeason) return;
         if (r.games > maxRaceGames) {
           maxRaceGames = r.games;
           maxRace = r.race;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -276,12 +276,13 @@ export default defineComponent({
         playerStore.loadPlayerStatsRaceVersusRaceOnMap(battleTag.value),
         playerStore.loadPlayerStatsHeroVersusRaceOnMap(battleTag.value),
         playerStore.loadPlayerGameLengths(),
+        rankingsStore.retrieveRankings(),
       ]);
     }
 
     async function initMmrRpTimeline() {
       // Make a lookup table for active game modes
-      const activeGameModes = rankingsStore.activeModes.reduce((acc, mode) => {
+      const activeGameModesMap = rankingsStore.activeModes.reduce((acc, mode) => {
         acc[mode.id] = true;
         return acc;
       }, {} as Record<number, boolean>);
@@ -289,7 +290,7 @@ export default defineComponent({
       let maxMode = EGameMode.GM_1ON1;
       let maxModeGames = 0;
       playerStore.gameModeStats.forEach((m) => {
-        if (!activeGameModes[m.gameMode]) return;
+        if (!activeGameModesMap[m.gameMode]) return;
         if (m.games > maxModeGames) {
           maxModeGames = m.games;
           maxMode = m.gameMode;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -270,12 +270,14 @@ export default defineComponent({
       if (profile.value && battleTag.value === profile.value.battleTag) return;
 
       await playerStore.loadProfile({ battleTag: battleTag.value, freshLogin: props.freshLogin });
-      await playerStore.loadGameModeStats({});
-      await playerStore.loadRaceStats();
-      await playerStore.loadPlayerStatsRaceVersusRaceOnMap(battleTag.value);
-      await playerStore.loadPlayerStatsHeroVersusRaceOnMap(battleTag.value);
-      await playerStore.loadPlayerGameLengths();
-      await playerStore.loadMatches(1);
+      await Promise.all([
+        playerStore.loadGameModeStats({}),
+        playerStore.loadRaceStats(),
+        playerStore.loadMatches(1),
+        playerStore.loadPlayerStatsRaceVersusRaceOnMap(battleTag.value),
+        playerStore.loadPlayerStatsHeroVersusRaceOnMap(battleTag.value),
+        playerStore.loadPlayerGameLengths(),
+      ]);
       await initMmrRpTimeline();
       window.scrollTo(0, 0);
     }

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -226,14 +226,7 @@ export default defineComponent({
 
     async function selectSeason(season: Season): Promise<void> {
       playerStore.SET_SELECTED_SEASON(season);
-      await Promise.all([
-        playerStore.loadGameModeStats({}),
-        playerStore.loadRaceStats(),
-        playerStore.loadMatches(1),
-        playerStore.loadPlayerStatsRaceVersusRaceOnMap(battleTag.value),
-        playerStore.loadPlayerStatsHeroVersusRaceOnMap(battleTag.value),
-        playerStore.loadPlayerGameLengths(),
-      ]);
+      await loadAllDataForSelectedSeason();
       // This requires loadGameModeStats and loadRaceStats to be called first
       await initMmrRpTimeline();
     }
@@ -270,6 +263,12 @@ export default defineComponent({
       if (profile.value && battleTag.value === profile.value.battleTag) return;
 
       await playerStore.loadProfile({ battleTag: battleTag.value, freshLogin: props.freshLogin });
+      await loadAllDataForSelectedSeason();
+      await initMmrRpTimeline();
+      window.scrollTo(0, 0);
+    }
+
+    async function loadAllDataForSelectedSeason() {
       await Promise.all([
         playerStore.loadGameModeStats({}),
         playerStore.loadRaceStats(),
@@ -278,8 +277,6 @@ export default defineComponent({
         playerStore.loadPlayerStatsHeroVersusRaceOnMap(battleTag.value),
         playerStore.loadPlayerGameLengths(),
       ]);
-      await initMmrRpTimeline();
-      window.scrollTo(0, 0);
     }
 
     async function initMmrRpTimeline() {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -280,9 +280,16 @@ export default defineComponent({
     }
 
     async function initMmrRpTimeline() {
+      // Make a lookup table for active game modes
+      const activeGameModes = rankingsStore.activeModes.reduce((acc, mode) => {
+        acc[mode.id] = true;
+        return acc;
+      }, {} as Record<number, boolean>);
+
       let maxMode = EGameMode.GM_1ON1;
       let maxModeGames = 0;
       playerStore.gameModeStats.forEach((m) => {
+        if (!activeGameModes[m.gameMode]) return;
         if (m.games > maxModeGames) {
           maxModeGames = m.games;
           maxMode = m.gameMode;


### PR DESCRIPTION
When looking at a player's stats page, the MMR timeline graph doesn't correctly choose the player's favourite mode, it always defaults to 1v1. Lately, some players (e.g. Grubby) have Direct Strike as their most played instead, so it's nice to default to that right away.

Also, when switching seasons, we should recalculate their favourite mode & race for that season. To do that, we need to await fetching the stats for the current season before calling `initMmrRpTimeline` which uses it as a dependency.

Also, the page should load significantly faster now, we can parallelize loading a bunch of the data with `Promise.all()` instead of chained `await`