### PR TITLE
Adjusted won/loss color for improved contrast

### DIFF
--- a/src/scss/dark/index.scss
+++ b/src/scss/dark/index.scss
@@ -2,6 +2,14 @@
 @import "./nightelf.scss";
 
 .theme--dark {
+  .won {
+    color: var(--v-success-base) !important;
+  }
+  
+  .lost {
+    color: var(--v-error-base) !important;
+  }
+
   .custom-table {
     td {
       border-bottom: thin solid hsla(0, 0%, 100%, 0.12);

--- a/src/scss/light/index.scss
+++ b/src/scss/light/index.scss
@@ -2,6 +2,14 @@
 @import "./orc.scss";
 
 .theme--light {
+  .won {
+    color: var(--v-success-darken2) !important;
+  }
+  
+  .lost {
+    color: var(--v-error-darken2) !important;
+  }
+
   .custom-table {
     td {
       border-bottom: thin solid rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
When using light or dark theme, the default `green`/`red` colors don't have ideal contrast on all 4 themes. On dark themes, the green is too dark. On light themes the red is too light. And the green/red pairings don't match in contrast.

To fix this, I think we should use a lightened green/red on dark themes and a darkened green/red on light themes. Vuetify sets color variables for us already that we can use (success/error colors) which have correct contrast against eachother.

The difference is subtle, but here's a comparison:

Before (Orc):
![image](https://github.com/user-attachments/assets/cbc6df52-b4f2-4141-a43e-f59291735e07)

After (Orc):
![image](https://github.com/user-attachments/assets/49b2b0da-c8c4-452a-8b72-d8c7e3ad82a2)

Before (Night Elf):
![image](https://github.com/user-attachments/assets/86b1a1cc-d33a-4817-ac22-2eea7c34e9b0)

After (Night Elf):
![image](https://github.com/user-attachments/assets/d616abd8-d58a-4d7f-9625-fca5ead07f55)

