### PR TITLE
Parallelize OverallStatistics data loading, small text change

### DIFF
--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -520,7 +520,7 @@ const data = {
       America: "America",
     },
     mmrLeagueRanges: {
-      MMR_0: "all",
+      MMR_0: "All",
       MMR_2200: "> 2200 (~Grandmaster)",
       MMR_2000: "> 2000 (~Master)",
       MMR_1800: "> 1800 (~Diamond)",
@@ -2458,7 +2458,7 @@ const data = {
       America: "Amerika",
     },
     mmrLeagueRanges: {
-      MMR_0: "alle",
+      MMR_0: "Alle",
       MMR_2200: "> 2200 (~Großmeister)",
       MMR_2000: "> 2000 (~Meister)",
       MMR_1800: "> 1800 (~Diamant)",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -50,11 +50,11 @@ const en = {
   },
 
   mmrLeagueRanges: {
-    MMR_0: "all",
+    MMR_0: "All",
     MMR_2200: "> 2200 (~Grandmaster)",
     MMR_2000: "> 2000 (~Master)",
     MMR_1800: "> 1800 (~Diamond)",
-    MMR_1600: "> 1600 (~Platin)",
+    MMR_1600: "> 1600 (~Platinum)",
     MMR_1400: "> 1400 (~Gold)",
     MMR_1200: "> 1200 (~Silver)",
     MMR_1000: "> 1000 (~Bronze)",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -183,9 +183,11 @@ export default defineComponent({
     onMounted(async (): Promise<void> => {
       await rankingsStore.retrieveSeasons();
       rankingsStore.setSeason(rankingsStore.seasons[0]);
-      await rankingsStore.getTopFive();
-      await infoMessagesStore.loadNews();
-      await rankingsStore.retrieveActiveGameModes();
+      await Promise.all([
+        rankingsStore.getTopFive(),
+        infoMessagesStore.loadNews(),
+        rankingsStore.retrieveActiveGameModes(),
+      ]);
       // this.activeGameModes = this.rankingsStore.activeModes;
     });
 

--- a/src/views/OverallStatistics.vue
+++ b/src/views/OverallStatistics.vue
@@ -63,19 +63,21 @@ export default defineComponent({
     const verifiedBtag: ComputedRef<string> = computed((): string => oauthStore.blizzardVerifiedBtag);
 
     async function init() {
-      await overallStatsStore.loadGamesPerDayStatistics();
-      await overallStatsStore.loadMatchesOnMapsPerSeason();
-      await overallStatsStore.loadPlayersPerDayStatistics();
-      await overallStatsStore.loadGameLengthStatistics();
-      await overallStatsStore.loadPopularGameHours();
-      await overallStatsStore.loadMapAndRaceStatistics();
-      await overallStatsStore.loadMatchupLengthStatistics(1, 1, "all");
+      const promises = [];
+      promises.push(overallStatsStore.loadGamesPerDayStatistics());
+      promises.push(overallStatsStore.loadMatchesOnMapsPerSeason());
+      promises.push(overallStatsStore.loadPlayersPerDayStatistics());
+      promises.push(overallStatsStore.loadGameLengthStatistics());
+      promises.push(overallStatsStore.loadPopularGameHours());
+      promises.push(overallStatsStore.loadMapAndRaceStatistics());
+      promises.push(overallStatsStore.loadMatchupLengthStatistics(1, 1, "all"));
       if (verifiedBtag.value) {
-        await playerStore.loadProfile({
+        promises.push(playerStore.loadProfile({
           battleTag: verifiedBtag.value,
           freshLogin: false,
-        });
+        }));
       }
+      await Promise.all(promises);
     }
 
     onMounted((): void => {


### PR DESCRIPTION
Similar to #852, we can parallelize with `Promise.all`. I'm using a `.push()` approach because one of them is in an `if` so that's the most convenient way to have a variable amount of items in that array.