### PR TITLE
MatchDetails: Layout adjustments, tooltips

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,7 @@
             <v-icon>{{ mdiInvertColors }}</v-icon>
           </v-btn>
         </template>
-        <v-list class="theme-selector">
+        <v-list max-height="400" class="theme-selector overflow-y-auto">
           <v-list-item @click="setTheme('human')">
             <v-list-item-title>{{ $t("races.HUMAN") }}</v-list-item-title>
           </v-list-item>

--- a/src/components/clans/MemberManagementMenu.vue
+++ b/src/components/clans/MemberManagementMenu.vue
@@ -6,7 +6,7 @@
       </v-btn>
     </template>
     <v-card>
-      <v-list dense>
+      <v-list dense max-height="400" class="overflow-y-auto">
         <v-list-item
           v-for="a in actions"
           :key="a.name"

--- a/src/components/common/GameModeSelect.vue
+++ b/src/components/common/GameModeSelect.vue
@@ -16,7 +16,7 @@
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item
             v-for="mode in gameModes()"
             :key="mode.id"

--- a/src/components/common/MapSelect.vue
+++ b/src/components/common/MapSelect.vue
@@ -14,7 +14,7 @@
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item v-for="(m, index) in maps" :key="index" @click="selectMap(m.key)">
             <v-list-item-content>
               <v-list-item-title>{{ m.mapName }}</v-list-item-title>

--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -13,7 +13,7 @@
             <v-list-item-title>{{ $t("components_common_seasonselect.prevseasons") }}</v-list-item-title>
           </v-list-item-content>
         </v-list>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item v-for="season in seasons" :key="season.id" @click="selectSeason(season)">
             <v-list-item-content>
               <v-list-item-title>{{ $t("components_common_seasonselect.season") }} {{ season.id }}</v-list-item-title>

--- a/src/components/match-details/MatchDetailHeroRow.vue
+++ b/src/components/match-details/MatchDetailHeroRow.vue
@@ -2,7 +2,7 @@
   <v-row justify="center">
     <v-col
       v-if="heroesOfWinner.length !== 3"
-      :cols="heroesOfWinner.length === 1 ? 2 : 1"
+      :cols="heroesOfWinner.length <= 1 ? 2 : 1"
     />
     <v-col cols="1" v-if="heroesOfWinner.length === 3">
       <hero-icon :hero="heroesOfWinner[2]" />

--- a/src/components/match-details/MatchHighlights.vue
+++ b/src/components/match-details/MatchHighlights.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <v-col>
     <v-row>
-      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'">
+      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'" class="pa-1">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-icon class="mr-4 ml-4" v-on="on">{{ mdiSkull }}</v-icon>
@@ -9,12 +9,12 @@
           <div>{{ $t("components_match-details_matchhighlights.heroeskilled") }}</div>
         </v-tooltip>
       </v-col>
-      <v-col :class="heroKillsComparison" :align="left ? 'left' : 'right'">
+      <v-col :class="heroKillsComparison" :align="left ? 'left' : 'right'" class="pa-1">
         {{ getText(heroKills) }}
       </v-col>
     </v-row>
     <v-row>
-      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'">
+      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'" class="pa-1">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-icon class="mr-4 ml-4" v-on="on">{{ mdiChevronTripleUp }}</v-icon>
@@ -22,12 +22,12 @@
           <div>{{ $t("components_match-details_matchhighlights.xpgained") }}</div>
         </v-tooltip>
       </v-col>
-      <v-col :class="experienceComparison" :align="left ? 'left' : 'right'">
+      <v-col :class="experienceComparison" :align="left ? 'left' : 'right'" class="pa-1">
         {{ getText(experience) }}
       </v-col>
     </v-row>
     <v-row>
-      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'">
+      <v-col :order="left ? 0 : 1" :align="left ? 'right' : 'left'" class="pa-1">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-icon class="mr-4 ml-4" v-on="on">{{ mdiTreasureChest }}</v-icon>
@@ -35,11 +35,11 @@
           <div>{{ $t("components_match-details_matchhighlights.itemscollected") }}</div>
         </v-tooltip>
       </v-col>
-      <v-col :class="itemsCollectedComparison" :align="left ? 'left' : 'right'">
+      <v-col :class="itemsCollectedComparison" :align="left ? 'left' : 'right'" class="pa-1">
         {{ getText(itemsCollected) }}
       </v-col>
     </v-row>
-  </div>
+  </v-col>
 </template>
 
 <script lang="ts">

--- a/src/components/matches/HostIcon.vue
+++ b/src/components/matches/HostIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip bottom style="white-space: pre-line">
+  <v-tooltip bottom transition="scroll-y-transition" style="white-space: pre-line">
     <template v-slot:activator="{ on }">
       <div v-on="on" class="globe">
         <v-img :src="icon" :max-height="18" :max-width="18"></v-img>

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -27,6 +27,7 @@
                       :team="getPlayerTeam(item)"
                       :unfinishedMatch="unfinished"
                       :is-anonymous="true"
+                      :highlightedPlayer="alwaysLeftName"
                     ></team-match-info>
                   </v-col>
                 </v-row>
@@ -48,6 +49,7 @@
                     :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
                     :unfinishedMatch="unfinished"
                     :left="true"
+                    :highlightedPlayer="alwaysLeftName"
                   ></team-match-info>
                 </v-col>
                 <v-col cols="1" align-self="center">
@@ -152,7 +154,7 @@ export default defineComponent({
     isPlayerProfile: {
       type: Boolean,
       required: true,
-    }
+    },
   },
   setup(props, context) {
     const { t } = useI18n();

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -19,7 +19,12 @@
         <tbody>
           <tr v-for="item in matches" :key="item.id">
             <td>
-              <div v-if="isFfa(item.gameMode)" @click="goToMatchDetailPage(item)" class="clickable my-3">
+              <div 
+                v-if="isFfa(item.gameMode)"
+                @click="goToMatchDetailPage(item)"
+                class="my-3"
+                :class="{ clickable: !unfinished }"
+              >
                 <v-row justify="center" v-if="alwaysLeftName">
                   <v-col offset="4" class="py-1">
                     <team-match-info
@@ -42,7 +47,11 @@
                   </v-col>
                 </v-row>
               </div>
-              <v-row @click="goToMatchDetailPage(item)" v-if="!isFfa(item.gameMode)" class="clickable">
+              <v-row
+                v-if="!isFfa(item.gameMode)"
+                @click="goToMatchDetailPage(item)"
+                :class="{ clickable: !unfinished }"
+              >
                 <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
                   <team-match-info
                     :not-clickable="!unfinished"

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -19,7 +19,7 @@
         <tbody>
           <tr v-for="item in matches" :key="item.id">
             <td>
-              <div v-if="isFfa(item.gameMode)"  @click="goToMatchDetailPage(item)" class="my-3">
+              <div v-if="isFfa(item.gameMode)" @click="goToMatchDetailPage(item)" class="clickable my-3">
                 <v-row justify="center" v-if="alwaysLeftName">
                   <v-col offset="4" class="py-1">
                     <team-match-info
@@ -41,8 +41,8 @@
                   </v-col>
                 </v-row>
               </div>
-              <v-row @click="goToMatchDetailPage(item)" v-if="!isFfa(item.gameMode)">
-                <v-col cols="5.5" class="team-match-info-container left-side">
+              <v-row @click="goToMatchDetailPage(item)" v-if="!isFfa(item.gameMode)" class="clickable">
+                <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
                   <team-match-info
                     :not-clickable="!unfinished"
                     :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
@@ -50,11 +50,11 @@
                     :left="true"
                   ></team-match-info>
                 </v-col>
-                <v-col cols="1">
-                  <span class="text-no-wrap">VS</span>
+                <v-col cols="1" align-self="center">
+                  <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
                   <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo"></host-icon>
                 </v-col>
-                <v-col cols="5.5" class="team-match-info-container">
+                <v-col cols="5.5" class="team-match-info-container" align-self="center">
                   <team-match-info
                     :not-clickable="!unfinished"
                     :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
@@ -326,5 +326,8 @@ export default defineComponent({
   &.left-side {
     justify-content: end;
   }
+}
+.clickable {
+  cursor: pointer;
 }
 </style>

--- a/src/components/matches/MatchesStatusSelect.vue
+++ b/src/components/matches/MatchesStatusSelect.vue
@@ -16,7 +16,7 @@
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item
             v-for="s in matchStatuses"
             :key="s.status"

--- a/src/components/matches/PlayerIcon.vue
+++ b/src/components/matches/PlayerIcon.vue
@@ -1,5 +1,10 @@
 <template>
-  <span :class="classes"></span>
+  <v-tooltip bottom style="white-space: pre-line">
+    <template v-slot:activator="{ on }">
+      <span v-on="on" :class="classes"></span>
+    </template>
+    <span>{{ (isRandom ? `${$t("races.RANDOM")} -> ` : "") + $t(`races.${raceName}`) }}</span>
+  </v-tooltip>
 </template>
 
 <script lang="ts">
@@ -41,6 +46,8 @@ export default defineComponent({
 
     return {
       classes,
+      isRandom: props.rndRace !== null,
+      raceName: ERaceEnum[props.rndRace] ?? ERaceEnum[props.race],
     };
   },
 });
@@ -61,6 +68,8 @@ export default defineComponent({
   height: 36px;
   background-position: center;
   background-size: cover;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .race-icon-HUMAN {

--- a/src/components/matches/PlayerIcon.vue
+++ b/src/components/matches/PlayerIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip bottom style="white-space: pre-line">
+  <v-tooltip top style="white-space: pre-line">
     <template v-slot:activator="{ on }">
       <span v-on="on" :class="classes"></span>
     </template>

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -21,7 +21,7 @@
           <span v-else>{{ mmrChange }}</span>
         </span>
       </a>
-      <div class="flag-container">
+      <div class="flag-container" :class="{ 'ml-1': !left }">
         <country-flag-extended
           :countryCode="player.countryCode"
           :location="player.location"

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -9,7 +9,7 @@
     <span :class="{ 'mr-2': left, 'ml-2': !left }">
       <a
         class="name-link"
-        :class="won"
+        :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
         @click="notClickable ? null : goToPlayer()"
         @click.middle="openProfileInNewTab()"
         @click.right="openProfileInNewTab()"
@@ -79,6 +79,11 @@ export default defineComponent({
       type: Boolean,
       required: false,
       undefined,
+    },
+    highlighted: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   setup(props) {

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -5,9 +5,8 @@
       :race="race"
       :rndRace="rndRace"
       :big="bigRaceIcon"
-      class="mr-1"
     />
-    <div>
+    <span :class="{ 'mr-2': left, 'ml-2': !left }">
       <a
         class="name-link"
         :class="won"
@@ -29,13 +28,12 @@
           size="small"
         />
       </div>
-    </div>
+    </span>
     <player-icon
       v-if="left"
       :race="race"
       :rndRace="rndRace"
       :big="bigRaceIcon"
-      class="ml-2"
     />
   </div>
 </template>

--- a/src/components/matches/SortSelect.vue
+++ b/src/components/matches/SortSelect.vue
@@ -14,7 +14,7 @@
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item v-for="sort in sortings" :key="sort.mode" @click="currentSort = sort">
             <v-list-item-content>
               <v-list-item-title>{{ sort.name }}</v-list-item-title>

--- a/src/components/matches/TeamMatchInfo.vue
+++ b/src/components/matches/TeamMatchInfo.vue
@@ -2,8 +2,8 @@
   <div v-if="team">
     <div
       v-for="(player, index) in team.players"
-      v-bind:key="index"
-      v-bind:class="{ mt2: index > 0 }"
+      :key="index"
+      :class="{ mt2: index > 0 }"
     >
       <player-match-info
         :unfinishedMatch="unfinishedMatch"
@@ -12,6 +12,7 @@
         :big-race-icon="bigRaceIcon"
         :not-clickable="notClickable"
         :is-anonymous="isAnonymous"
+        :highlighted="highlightedPlayer === team.players[index].battleTag"
       />
     </div>
   </div>
@@ -58,6 +59,11 @@ export default defineComponent({
       required: false,
       default: false,
     },
+    highlightedPlayer: {
+      type: String,
+      required: false,
+      default: "",
+    }
   },
 });
 </script>

--- a/src/components/player/RaceIcon.vue
+++ b/src/components/player/RaceIcon.vue
@@ -1,15 +1,18 @@
 <template>
-  <div>
-    <img
-      v-if="renderIcon"
-      :src="renderIcon"
-      :title="enumToString.toString()"
-      class="race-icon"
-      height="24px"
-      width="auto"
-      :alt="enumToString.toString()"
-    />
-  </div>
+  <v-tooltip v-if="renderIcon" top style="white-space: pre-line">
+    <template v-slot:activator="{ on }">
+      <img
+        v-on="on"
+        :src="renderIcon"
+        :title="enumToString.toString()"
+        class="race-icon"
+        height="24px"
+        width="auto"
+        :alt="enumToString.toString()"
+      />
+    </template>
+    <span>{{ enumToString }}</span>
+  </v-tooltip>
 </template>
 
 <script lang="ts">

--- a/src/components/tournaments/TournamentSelect.vue
+++ b/src/components/tournaments/TournamentSelect.vue
@@ -16,7 +16,7 @@
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>
-        <v-list dense>
+        <v-list dense max-height="400" class="overflow-y-auto">
           <v-list-item
             v-for="tournament in tournaments"
             :key="tournament.id"

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -34,7 +34,7 @@
                 </v-list-item-content>
               </v-list>
               <v-divider></v-divider>
-              <v-list dense class="countries-list">
+              <v-list dense max-height="400" class="countries-list overflow-y-auto">
                 <v-list-item
                   v-for="item in countries"
                   :key="item.countryCode"
@@ -77,7 +77,7 @@
                   <v-list-item-title>Previous seasons:</v-list-item-title>
                 </v-list-item-content>
               </v-list>
-              <v-list dense>
+              <v-list dense max-height="400" class="overflow-y-auto">
                 <v-list-item
                   v-for="item in seasons"
                   :key="item.id"

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -18,20 +18,20 @@
                   style="padding-right: 0px"
                 ></host-icon>
               </v-col>
-              <v-col cols="4" v-if="!matchIsFFA">
+              <v-col cols="4" v-if="!matchIsFFA" align-self="center">
                 <team-match-info
                   :big-race-icon="true"
                   :left="true"
                   :team="match.teams[0]"
                 />
               </v-col>
-              <v-col cols="1" class="text-center" >
+              <v-col cols="1" class="text-center" align-self="center" >
                 <span v-if="!matchIsFFA">{{ $t(`views_matchdetail.vs`) }}</span>
               </v-col>
-              <v-col v-if="!matchIsFFA" cols="4">
+              <v-col v-if="!matchIsFFA" cols="4" align-self="center">
                 <team-match-info :big-race-icon="true" :team="match.teams[1]" />
               </v-col>
-              <v-col v-if="matchIsFFA" cols="6">
+              <v-col v-if="matchIsFFA" cols="6" align-self="center">
                 <team-match-info
                   class="ma-1"
                   :big-race-icon="true"
@@ -65,12 +65,7 @@
           <v-card-title v-if="isJubileeGame" class="justify-center">
             {{ $t(`views_matchdetail.jubileeGameMessage`) }}
           </v-card-title>
-          <v-card-title class="justify-center small-title">
-            <v-card-subtitle>
-              {{ mapNameFromMatch(match) }} ({{ matchDuration }})
-              {{ playedDate }}
-            </v-card-subtitle>
-          </v-card-title>
+          <v-card-title class="justify-center">{{ `${mapNameFromMatch(match)} (${matchDuration}) | ${playedDate}` }}</v-card-title>
           <div v-if="isCompleteGame">
             <match-detail-hero-row
               v-for="(player, index) in scoresOfWinners"
@@ -163,7 +158,7 @@ import { Gateways } from "@/store/ranking/types";
 import HostIcon from "@/components/matches/HostIcon.vue";
 import { mapNameFromMatch } from "@/mixins/MatchMixin";
 import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
-import { formatSecondsToDuration, formatTimestampStringToDate } from "@/helpers/date-functions";
+import { formatSecondsToDuration, formatTimestampStringToDateTime } from "@/helpers/date-functions";
 import { useMatchStore } from "@/store/match/store";
 import _keyBy from "lodash/keyBy";
 import { battleTagToName } from "@/helpers/profile";
@@ -190,7 +185,7 @@ export default defineComponent({
 
     const match: ComputedRef<Match> = computed((): Match => matchStore.matchDetail.match);
     const matchDuration: ComputedRef<string> = computed((): string => formatSecondsToDuration(match.value.durationInSeconds));
-    const playedDate: ComputedRef<string> = computed((): string => formatTimestampStringToDate(match.value.startTime));
+    const playedDate: ComputedRef<string> = computed((): string => formatTimestampStringToDateTime(match.value.startTime));
     const ffaPlayers: ComputedRef<PlayerScore[]> = computed((): PlayerScore[] => [ffaWinner.value, ...ffaLosers.value]);
     const gateWay: ComputedRef<string> = computed((): string => Gateways[matchStore.matchDetail.match.gateWay]);
     const season: ComputedRef<number> = computed((): number => matchStore.matchDetail.match.season ?? 1);
@@ -375,6 +370,7 @@ export default defineComponent({
 .subicon {
   display: block;
   position: absolute;
-  right: 1%;
+  top: 8px;
+  right: 8px;
 }
 </style>

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -30,7 +30,7 @@
                 </v-list-item-content>
               </v-list>
               <v-divider></v-divider>
-              <v-list dense class="leagues-list">
+              <v-list dense max-height="400" class="leagues-list overflow-y-auto">
                 <v-list-item
                   v-for="item in ladders"
                   :key="item.id"
@@ -123,7 +123,7 @@
                 </v-list-item-title>
               </v-list-item-content>
             </v-list>
-            <v-list dense>
+            <v-list dense max-height="400" class="overflow-y-auto">
               <v-list-item
                 v-for="item in seasons"
                 :key="item.id"


### PR DESCRIPTION
Some adjustments to the Match Details & Match History screens:

- Override the padding on the kill/exp/items boxes to shrink them a bit, so that stats for each player has more of a gap
- Vertically center the `VS` in both places (and player names on Match Details in 1v1 since the region/season box on the left causes it to be larger)
- Add the time on the match details screen (it was already shown in the match history so might as well also show it on the more detailed screen). Also added a `|` divider, thought it looked a bit more visually balanced with it. Up for debate tho.
- Increase the size of the map name/duration/time title, there's room for it and it's important information
- Changed the ping tooltip transition to slide down instead of pop in from the center, thought it felt a bit nicer
- Added the :point_up_2: cursor on the clickable area on the match history table, wasn't obvious it was clickable or where to click to get to the match details screen (`.clickable` class)
- Added a hover tooltip on the race icon, especially helpful for Random since it can be difficult to tell which race they actually got since it's behind the `?` & its drop shadow. Shows as `Random -> {RACE}` if it was random, as simply `{RACE}` otherwise for non-random. 
![image](https://github.com/user-attachments/assets/292c8868-4ab2-463e-9ec9-6d7a2979d9fd)
- Because of the new `v-tooltip` wrapper component, I had to rework how the margins were set, instead applying them on the player name+mmr container.
- The season translation string was `Season:` which produced `Season:: 20`. I got rid of the extra `:` in the translations (google sheet updated as well)
- Very slightly adjusted the position of the download replay button so it properly sits in the corner with even gap on both sides.

Before:
![image](https://github.com/user-attachments/assets/4f66ee93-b2b1-4b27-bf5f-50550d2ef0d0)

After:
![image](https://github.com/user-attachments/assets/f89384dc-9f27-46de-94fa-8270761fb255)

Before:
![image](https://github.com/user-attachments/assets/46c8d338-182a-4e35-a86e-3b5ecf60e0a9)

After:
![image](https://github.com/user-attachments/assets/db843d66-8d20-4edb-9ac0-8762023205dc)
