### PR TITLE
Brighten the human theme's red/green, split the color between human/orc

### DIFF
--- a/src/scss/light/human.scss
+++ b/src/scss/light/human.scss
@@ -11,6 +11,14 @@
   align-items: center !important;
   justify-content: center !important;
 
+  .won {
+    color: var(--v-success-darken1) !important;
+  }
+  
+  .lost {
+    color: var(--v-error-darken1) !important;
+  }
+
   .v-data-table,
   .custom-table {
     tr:hover {

--- a/src/scss/light/index.scss
+++ b/src/scss/light/index.scss
@@ -2,14 +2,6 @@
 @import "./orc.scss";
 
 .theme--light {
-  .won {
-    color: var(--v-success-darken2) !important;
-  }
-  
-  .lost {
-    color: var(--v-error-darken2) !important;
-  }
-
   .custom-table {
     td {
       border-bottom: thin solid rgba(0, 0, 0, 0.12);

--- a/src/scss/light/orc.scss
+++ b/src/scss/light/orc.scss
@@ -1,7 +1,7 @@
+@import "../shared/index.scss";
+
 // #c12b12 orc red
 // #5c2604 orc brown
-
-@import "../shared/index.scss";
 
 .theme--light.v-application.orc {
   --w3-bg-glass: rgba(199, 186, 161, 0.9);
@@ -11,4 +11,12 @@
   background-size: cover !important;
   align-items: center !important;
   justify-content: center !important;
+
+  .won {
+    color: var(--v-success-darken2) !important;
+  }
+  
+  .lost {
+    color: var(--v-error-darken2) !important;
+  }
 }


### PR DESCRIPTION
Live colors:

![image](https://github.com/user-attachments/assets/f8fe067d-7550-4ffb-9a61-1f2bd03fb827)

From #856:

![image](https://github.com/user-attachments/assets/eabe099d-8658-4688-8c06-cb9f1e78f7a5)

This PR:

![image](https://github.com/user-attachments/assets/3cd66755-c19a-402e-976e-93f2c7c2f44e)
