### PR TITLE
Use map name instead of map file name in matchup statistics

### DIFF
--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -10,8 +10,8 @@
     >
       <template v-slot:body>
         <tbody>
-          <tr v-for="item in stats" :key="item.map">
-            <td>{{ item.map }}</td>
+        <tr v-for="item in stats" :key="item.mapName || item.map">
+          <td>{{ item.mapName || item.map }}</td>
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[1]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[2]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[4]" />

--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -10,8 +10,8 @@
     >
       <template v-slot:body>
         <tbody>
-        <tr v-for="item in stats" :key="item.mapName || item.map">
-          <td>{{ item.mapName || item.map }}</td>
+          <tr v-for="item in stats" :key="item.mapName || item.map">
+            <td>{{ item.mapName || item.map }}</td>
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[1]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[2]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[4]" />

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -76,6 +76,7 @@ export type ModeStat = {
 
 export interface WinLossesOnMap {
   map: string;
+  mapName?: string;
   winLosses: RaceStat[];
 }
 


### PR DESCRIPTION
Hi, this is my first PR here. :)

The goal is to replace these map file names with the maps' actual names.

![image](https://github.com/user-attachments/assets/6216215d-e9b6-43e2-b64e-ae25808fe6fa)

The proper map names are already available from the race-on-map-versus-race endpoint.

![image](https://github.com/user-attachments/assets/22ba47a2-a393-4dae-84f4-a413ae6e6285)

race-on-map-versus-race populates the nice mapName by leveraging matchmaking-service/ladder/active-modes. If the matchmaking service does not have information about the maps in question, then mapName can be null. In that case the front end should fall back to item.map (the map file name which is currently used).