### PR TITLE
Redirect un-encoded player URLs if possible

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -244,9 +244,9 @@ export default defineComponent({
     onMounted((): void => {
       // Since # is a reserver character for the "fragment/hash" part of the URL
       // we can try to redirect to the correct URL if the hash is a battle tag,
-      // (starts with 4 digits). It may also be followed by a tab name, for
-      // example Someone#9999/matches would redirect to Someone%239999/matches
-      if (window.location.hash.match(/^#\d{4}\b/)) {
+      // (starts with at least 4 digits). It may also be followed by a tab name,
+      // for example Someone#9999/matches would redirect to Someone%239999/matches
+      if (window.location.hash.match(/^#\d{4}/)) {
         const url = new URL(window.location.href);
         url.pathname = `${url.pathname}${url.hash}`;
         url.hash = "";

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -242,7 +242,7 @@ export default defineComponent({
     }
 
     onMounted((): void => {
-      // Since # is a reserver character for the "fragment/hash" part of the URL
+      // Since # is a reserved character for the "fragment/hash" part of the URL
       // we can try to redirect to the correct URL if the hash is a battle tag,
       // (starts with at least 4 digits). It may also be followed by a tab name,
       // for example Someone#9999/matches would redirect to Someone%239999/matches

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onUnmounted, ref, watch } from "vue";
+import { computed, defineComponent, onMounted, onUnmounted, ref, watch } from "vue";
 import { PlayerProfile } from "@/store/player/types";
 import { EGameMode, ERaceEnum, Match, PlayerInTeam, Team } from "@/store/types";
 import { Season } from "@/store/ranking/types";
@@ -240,6 +240,19 @@ export default defineComponent({
       playerStore.SET_ONGOING_MATCH({} as Match);
       clearInterval(_intervalRefreshHandle);
     }
+
+    onMounted((): void => {
+      // Since # is a reserver character for the "fragment/hash" part of the URL
+      // we can try to redirect to the correct URL if the hash is a battle tag,
+      // (starts with 4 digits). It may also be followed by a tab name, for
+      // example Someone#9999/matches would redirect to Someone%239999/matches
+      if (window.location.hash.match(/^#\d{4}\b/)) {
+        const url = new URL(window.location.href);
+        url.pathname = `${url.pathname}${url.hash}`;
+        url.hash = "";
+        window.location.href = url.toString();
+      }
+    });
 
     onUnmounted((): void => {
       stopLoadingMatches();


### PR DESCRIPTION
This is a bit of a fun hack.

For example, you might request https://w3champions.com/player/Ruhigengeist#1200 but this results in a broken page since no user is found. We can be smarter about this because the `#` is the "fragment" (aka "hash") part of the URL, so we can redirect on mount to the correct URL i.e. https://w3champions.com/player/Ruhigengeist%231200 and it can even work if there's a path like `/matches` at the end.