### PR TITLE
Improve filter and order on the matches page for ongoing and finished

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -122,6 +122,7 @@ declare module 'vue' {
     SeasonSelect: typeof import('./src/components/common/SeasonSelect.vue')['default']
     SignInDialog: typeof import('./src/components/common/SignInDialog.vue')['default']
     SocialBox: typeof import('./src/components/common/SocialBox.vue')['default']
+    SortDirectionSelect: typeof import('./src/components/matches/SortDirectionSelect.vue')['default']
     SortSelect: typeof import('./src/components/matches/SortSelect.vue')['default']
     StreamedMatchInfo: typeof import('./src/components/matches/StreamedMatchInfo.vue')['default']
     StreamedMatchPlayerInfo: typeof import('./src/components/matches/StreamedMatchPlayerInfo.vue')['default']

--- a/src/components/common/MapSelect.vue
+++ b/src/components/common/MapSelect.vue
@@ -15,9 +15,9 @@
         </v-list>
         <v-divider></v-divider>
         <v-list dense max-height="400" class="overflow-y-auto">
-          <v-list-item v-for="(m, index) in maps" :key="index" @click="selectMap(m.key)">
+          <v-list-item v-for="(m, index) in maps" :key="index" @click="selectMap(m.mapName)">
             <v-list-item-content>
-              <v-list-item-title>{{ m.mapName }}</v-list-item-title>
+              <v-list-item-title>{{ m.displayName }}</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
         </v-list>
@@ -32,9 +32,12 @@ import { useI18n } from "vue-i18n-bridge";
 import { TranslateResult } from "vue-i18n";
 import { MapInfo } from "@/store/common/types";
 import { mdiMap } from "@mdi/js";
+import _uniqBy from 'lodash/uniqBy';
+import _sortBy from 'lodash/sortBy';
 
 type MapSelectMap = {
-  mapName: TranslateResult;
+  displayName: TranslateResult;
+  mapName: string;
   key: string;
 };
 
@@ -55,25 +58,16 @@ export default defineComponent({
   setup: (props, context) => {
     const { t } = useI18n();
     const selected = computed<string | TranslateResult>(() => {
-      const match = maps.value.find((m) => m.key === props.map);
+      const match = maps.value.find((m) => m.mapName === props.map);
       return match ? match.mapName : "Overall";
     });
 
+    // Only include unique maps that has a mapName definition
     const maps = computed<MapSelectMap[]>(() => {
-      const maps = props.mapInfo
-        .map((map) => ({ mapName: (map.mapName ?? map.map), key: map.map }))
-        .sort((mapA, mapB) => {
-          const nameA = mapA.mapName.toString().toUpperCase();
-          const nameB = mapB.mapName.toString().toUpperCase();
-          if (nameA < nameB) {
-            return -1;
-          }
-          if (nameA > nameB) {
-            return 1;
-          }
-          return 0;
-        });
-      return [{ mapName: t("mapNames.Overall"), key: "Overall" }, ...maps];
+      const maps = _sortBy(_uniqBy(props.mapInfo
+          .filter((map) => map.mapName)
+          .map((map) => ({mapName: map.mapName, key: map.map, displayName: map.mapName })), 'mapName'), 'mapName');
+      return [{ displayName: t("mapNames.Overall"), mapName: 'Overall', key: "Overall" }, ...maps];
     });
 
     function selectMap(map: string): void {

--- a/src/components/matches/SortDirectionSelect.vue
+++ b/src/components/matches/SortDirectionSelect.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-menu offset-x>
+    <template v-slot:activator="{ on }">
+      <v-btn tile v-on="on" style="background-color: transparent">
+        <v-icon class="mr-1">{{currentDirection.icon}}</v-icon>
+        {{ currentDirection.name }}
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-list>
+          <v-list-item-content>
+            <v-list-item-title>{{ $t("components_matches_sort_direction_select.sortmatchesinorder") }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list>
+        <v-divider></v-divider>
+        <v-list dense max-height="400" class="overflow-y-auto">
+          <v-list-item v-for="direction in directions" :key="direction.value" @click="currentDirection = direction">
+            <v-list-item-content>
+              <v-list-item-title>{{ direction.name }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "vue";
+import { useMatchStore } from "@/store/match/store";
+import { mdiSortAscending, mdiSortDescending } from "@mdi/js";
+import {SortDirection } from "@/store/match/types";
+import {useI18n} from "vue-i18n-bridge";
+import {TranslateResult} from "vue-i18n";
+
+interface SortDirectionSelectData {
+  name: TranslateResult;
+  value: SortDirection;
+  icon: string;
+}
+
+export default defineComponent({
+  name: "SortDirectionSelect",
+  setup: () => {
+    const { t } = useI18n();
+    const matchStore = useMatchStore();
+
+    const currentDirection = computed<SortDirection>({
+      get(): SortDirectionSelectData {
+        const selectedDirection = matchStore.sortDirection;
+        return directions.find((direction) => direction.value == selectedDirection)!;
+      },
+      set(dir: SortDirectionSelectData): void {
+        matchStore.setSortDirection(dir.value);
+      },
+    });
+
+    const directions: SortDirectionSelectData[] = [
+      {
+        name: t(`components_matches_sort_direction_select.ascending`),
+        value: SortDirection.Ascending,
+        icon: mdiSortAscending
+      },
+      {
+        name: t(`components_matches_sort_direction_select.descending`),
+        value: SortDirection.Descending,
+        icon:mdiSortDescending
+      },
+    ];
+
+    return {
+      currentDirection,
+      directions,
+    };
+  },
+});
+</script>

--- a/src/components/matches/SortSelect.vue
+++ b/src/components/matches/SortSelect.vue
@@ -2,7 +2,7 @@
   <v-menu offset-x>
     <template v-slot:activator="{ on }">
       <v-btn tile v-on="on" style="background-color: transparent">
-        <v-icon class="mr-1">{{ mdiSortAscending }}</v-icon>
+        <v-icon class="mr-1">{{mdiSortVariant}}</v-icon>
         {{ currentSort.name }}
       </v-btn>
     </template>
@@ -30,7 +30,7 @@
 import { computed, defineComponent } from "vue";
 import { SortMode } from "@/store/match/types";
 import { useMatchStore } from "@/store/match/store";
-import { mdiSortAscending } from "@mdi/js";
+import { mdiSortVariant } from "@mdi/js";
 import { useI18n } from "vue-i18n-bridge";
 import { TranslateResult } from "vue-i18n";
 
@@ -42,33 +42,38 @@ interface SortSelectData {
 export default defineComponent({
   name: "SortSelect",
   components: {},
-  setup() {
+  props: ['sortings'],
+  setup(props) {
     const { t } = useI18n();
     const matchStore = useMatchStore();
 
     const currentSort = computed<SortSelectData>({
       get(): SortSelectData {
         const selectedSort = matchStore.sort;
-        return sortings.find((sort) => sort.mode == selectedSort)!;
+        return sortings.value.find((sort) => sort.mode == selectedSort)!;
       },
       set(val: SortSelectData): void {
         matchStore.setSort(val.mode);
       },
     });
 
-    const sortings: SortSelectData[] = [
+    const sortings = computed<SortSelectData[]>(() => ([
       {
-        name: t(`components_matches_sortselect.starttimedescending`),
-        mode: SortMode.startTimeDescending,
+        name: t(`components_matches_sortselect.starttime`),
+        mode: SortMode.startTime,
       },
       {
-        name: t(`components_matches_sortselect.mmrdescending`),
-        mode: SortMode.mmrDescending,
+        name: t(`components_matches_sortselect.endtime`),
+        mode: SortMode.endTime,
       },
-    ];
+      {
+        name: t(`components_matches_sortselect.mmr`),
+        mode: SortMode.mmr,
+      },
+    ].filter(s => props.sortings.includes(s.mode))));
 
     return {
-      mdiSortAscending,
+      mdiSortVariant,
       currentSort,
       sortings,
     };

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -298,8 +298,14 @@ const data = {
     },
     components_matches_sortselect: {
       sortmatchesby: "Sort matches by:",
-      starttimedescending: "Start time",
-      mmrdescending: "MMR",
+      starttime: "Start time",
+      endtime: "End time",
+      mmr: "MMR",
+    },
+    components_matches_sort_direction_select: {
+      sortmatchesinorder: "Sort in order:",
+      ascending: "Ascending",
+      descending: "Descending",
     },
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Top live 1v1 matches",
@@ -845,6 +851,7 @@ const data = {
       selectstatus: "Выберите статус:",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Топ онлайн матчей 1vs1",
     },
@@ -1328,6 +1335,7 @@ const data = {
       selectstatus: "상태 선택",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {},
     components_matches_replayicon: {},
     "components_overall-statistics_tabs_herotab": {
@@ -1777,9 +1785,10 @@ const data = {
     },
     components_matches_sortselect: {
       sortmatchesby: "按以下方式排序：",
-      starttimedescending: "开始时间",
-      mmrdescending: "MMR",
+      starttime: "开始时间",
+      mmr: "MMR",
     },
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "置顶进行中的1V1比赛",
     },
@@ -2268,6 +2277,7 @@ const data = {
       selectstatus: "Status auswählen:",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {},
     components_matches_replayicon: {},
     "components_overall-statistics_tabs_herotab": {
@@ -2751,9 +2761,10 @@ const data = {
     },
     components_matches_sortselect: {
       sortmatchesby: "Sortuj mecze wg:",
-      starttimedescending: "Czas rozpoczęcia",
-      mmrdescending: "MMR",
+      starttime: "Czas rozpoczęcia",
+      mmr: "MMR",
     },
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Najlepsze streamowane mecze 1v1",
     },
@@ -3272,6 +3283,7 @@ const data = {
       selectstatus: "Оберіть статус:",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Топ онлайн матчів 1v1",
     },
@@ -3778,6 +3790,7 @@ const data = {
       selectstatus: "Selecione um status:",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Top partidas de 1v1 ao vivo",
     },
@@ -4290,6 +4303,7 @@ const data = {
       selectstatus: "Choisissez un statut :",
     },
     components_matches_sortselect: {},
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Top matchs 1v1 en cours",
     },
@@ -4810,9 +4824,10 @@ const data = {
     },
     components_matches_sortselect: {
       sortmatchesby: "Sortirajte mečeve po:",
-      starttimedescending: "Vreme početka",
-      mmrdescending: "MMR",
+      starttime: "Vreme početka",
+      mmr: "MMR",
     },
+    components_matches_sort_direction_select: {},
     components_matches_topongoingmatcheswithstreams: {
       toplive1v1matches: "Najpopularniji 1v1 mečevi trenutno uživo",
     },

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -13,11 +13,13 @@ export default class MatchService {
     map: string,
     mmr: Mmr,
     season: number,
+    sort: string,
+    sortDirection: string,
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
     const minMmr = mmr.min === 0 ? "" : `&minMmr=${mmr.min}`;
     const maxMmr = mmr.max === 3000 ? "" : `&maxMmr=${mmr.max}`;
-    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}`;
+    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}&sort=${sort}&sortDirection=${sortDirection}`;
     const response = await fetch(url);
     return await response.json();
   }
@@ -29,6 +31,7 @@ export default class MatchService {
     map: string,
     mmr: Mmr,
     sort: string,
+    sortDirection: string,
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
 
@@ -40,6 +43,7 @@ export default class MatchService {
       map,
       mmr,
       sort,
+      sortDirection,
     );
   }
 
@@ -51,10 +55,11 @@ export default class MatchService {
     map: string,
     mmr: Mmr,
     sort: string,
+    sortDirection: string,
   ): Promise<{ count: number; matches: Match[] }> {
     const minMmr = mmr.min === 0 ? "" : `&minMmr=${mmr.min}`;
     const maxMmr = mmr.max === 3000 ? "" : `&maxMmr=${mmr.max}`;
-    const url = `${API_URL}api/matches/ongoing?offset=${offset}&gateway=${gateway}&pageSize=${pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&sort=${sort}`;
+    const url = `${API_URL}api/matches/ongoing?offset=${offset}&gateway=${gateway}&pageSize=${pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&sort=${sort}&sortDirection=${sortDirection}`;
 
     const response = await fetch(url);
     return await response.json();

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -1,5 +1,5 @@
 import { EGameMode, PlayerScore } from "@/store/types";
-import { MatchState, MatchStatus, Mmr } from "./types";
+import { MatchState, MatchStatus, Mmr, SortDirection, SortMode } from "./types";
 import { Match, MatchDetail } from "../types";
 import MatchService from "@/services/MatchService";
 import { defineStore } from "pinia";
@@ -18,7 +18,8 @@ export const useMatchStore = defineStore("match", {
     gameMode: EGameMode.GM_1ON1,
     map: "Overall",
     mmr: { min: 0, max: 3000 } as Mmr,
-    sort: "startTimeDescending",
+    sort: SortMode.startTime,
+    sortDirection: SortDirection.Ascending,
     selectedSeason: {} as Season,
   }),
   actions: {
@@ -33,6 +34,7 @@ export const useMatchStore = defineStore("match", {
           this.map,
           this.mmr,
           this.sort,
+          this.sortDirection,
         );
 
         // Handle edge case when loading ongoing matches, if the number of matches are reduced
@@ -50,6 +52,8 @@ export const useMatchStore = defineStore("match", {
           this.map,
           this.mmr,
           this.selectedSeason.id,
+          this.sort,
+          this.sortDirection,
         );
       }
       this.SET_TOTAL_MATCHES(response.count);
@@ -65,6 +69,7 @@ export const useMatchStore = defineStore("match", {
         map || this.map,
         this.mmr,
         this.sort,
+        this.sortDirection,
       );
       this.SET_ALL_ONGOING_MATCHES(response.matches);
     },
@@ -77,7 +82,10 @@ export const useMatchStore = defineStore("match", {
     },
     async setStatus(matchStatus: MatchStatus) {
       this.SET_STATUS(matchStatus);
+      this.SET_MAP("Overall");
       this.SET_PAGE(1);
+      this.SET_SORT(matchStatus === MatchStatus.onGoing ? SortMode.startTime : SortMode.endTime);
+      this.SET_SORT_DIRECTION(matchStatus === MatchStatus.onGoing ? SortDirection.Ascending : SortDirection.Descending);
       await this.loadMatches();
     },
     async setGameMode(gameMode: EGameMode) {
@@ -96,8 +104,14 @@ export const useMatchStore = defineStore("match", {
       this.SET_PAGE(1);
       await this.loadMatches();
     },
-    async setSort(sort: string) {
+    async setSort(sort: SortMode) {
       this.SET_SORT(sort);
+      this.SET_SORT_DIRECTION(SortDirection.Ascending);
+      this.SET_PAGE(1);
+      await this.loadMatches();
+    },
+    async setSortDirection(direction: SortDirection) {
+      this.SET_SORT_DIRECTION(direction);
       this.SET_PAGE(1);
       await this.loadMatches();
     },
@@ -139,8 +153,11 @@ export const useMatchStore = defineStore("match", {
     SET_MMR(mmr: Mmr): void {
       this.mmr = mmr;
     },
-    SET_SORT(sort: string): void {
+    SET_SORT(sort: SortMode): void {
       this.sort = sort;
+    },
+    SET_SORT_DIRECTION(direction: SortDirection): void {
+      this.sortDirection = direction;
     },
     SET_PLAYER_SCORES(playerScores: PlayerScore[]): void {
       this.matchDetail.playerScores = playerScores;

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -13,7 +13,8 @@ export type MatchState = {
   gameMode: EGameMode;
   map: string;
   mmr: Mmr;
-  sort: string;
+  sort: SortMode;
+  sortDirection: SortDirection;
   selectedSeason: Season;
 };
 
@@ -23,8 +24,14 @@ export enum MatchStatus {
 }
 
 export enum SortMode {
-  startTimeDescending = "startTimeDescending",
-  mmrDescending = "mmrDescending",
+  startTime = "startTime",
+  endTime = "endTime",
+  mmr = "mmr",
+}
+
+export enum SortDirection {
+  Ascending = "asc",
+  Descending = "desc",
 }
 
 export type Mmr = {

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -12,11 +12,12 @@
               :disabledModes="disabledGameModes"
               :gameMode="gameMode"
               @gameModeChanged="gameModeChanged"
-            ></game-mode-select>
-            <map-select @mapChanged="mapChanged" :mapInfo="maps" :map="map"></map-select>
-            <mmr-select @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
-            <sort-select v-if="unfinished"></sort-select>
-            <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
+              />
+            <map-select @mapChanged="mapChanged" :mapInfo="maps" :map="map" />
+            <mmr-select @mmrChanged="mmrChanged" :mmr="mmr" />
+            <sort-select :sortings="sortmodes"/>
+            <sort-direction-select />
+            <season-select v-if="!unfinished" @seasonSelected="selectSeason" />
           </v-card-text>
           <matches-grid
             v-model="matches"
@@ -25,7 +26,7 @@
             :itemsPerPage="50"
             :unfinished="unfinished"
             :is-player-profile="false"
-          ></matches-grid>
+            />
         </v-card>
       </v-col>
     </v-row>
@@ -35,7 +36,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, onUnmounted } from "vue";
 import { Match, EGameMode } from "@/store/types";
-import { MatchStatus, Mmr } from "@/store/match/types";
+import {MatchStatus, Mmr, SortDirection, SortMode} from "@/store/match/types";
 import { Season } from "@/store/ranking/types";
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
 import MatchesStatusSelect from "@/components/matches/MatchesStatusSelect.vue";
@@ -50,10 +51,20 @@ import { useRankingStore } from "@/store/ranking/store";
 import { useMatchStore } from "@/store/match/store";
 import { MapInfo } from "@/store/common/types";
 import SeasonSelect from "@/components/common/SeasonSelect.vue";
+import SortDirectionSelect from "@/components/matches/SortDirectionSelect.vue";
 
 export default defineComponent({
   name: "MatchesView",
+  computed: {
+    SortMode() {
+      return SortMode
+    },
+    SortDirection() {
+      return SortDirection
+    }
+  },
   components: {
+    SortDirectionSelect,
     SeasonSelect,
     MatchesGrid,
     MatchesStatusSelect,
@@ -75,6 +86,7 @@ export default defineComponent({
     const gameMode = computed<EGameMode>(() => matchStore.gameMode);
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
+    const sortmodes = computed<SortMode[]>(() => matchStore.status === MatchStatus.onGoing ? [SortMode.startTime, SortMode.mmr] : [SortMode.endTime, SortMode.mmr]);
 
     const maps = computed<Array<MapInfo>>(() => {
       if (!currentSeason.value) {
@@ -141,7 +153,7 @@ export default defineComponent({
       await rankingsStore.retrieveSeasons();
       rankingsStore.setSeason(rankingsStore.seasons[0]);
       await matchStore.setSeason(rankingsStore.seasons[0]);
-      overallStatsStore.loadMatchesOnMapsPerSeason();
+      void overallStatsStore.loadMatchesOnMapsPerSeason();
       refreshMatches();
     });
 
@@ -174,6 +186,7 @@ export default defineComponent({
       mmrChanged,
       mmr,
       selectSeason,
+      sortmodes,
       unfinished,
       matches,
       totalMatches,


### PR DESCRIPTION
## Current

![image](https://github.com/user-attachments/assets/bf725eb7-595c-4a20-a1c9-8f45bf3d18b5)

![image](https://github.com/user-attachments/assets/7cca911b-eed0-4278-b417-5d7d57df1cb8)
map doesn't seem to work here and filled with a lot of noise
![image](https://github.com/user-attachments/assets/4157cb67-346e-4460-843a-a9b82e1d7a0d)


## Updated
![image](https://github.com/user-attachments/assets/c2226cf5-83db-4b47-bfc0-503f42646e3a)

![image](https://github.com/user-attachments/assets/7e603b00-e801-43ba-afaf-66463a49e32d)

Added sort order in addition to column
- starttime and mmr for ongoing
- endtime and mmr for finished

Also cleaned up the map list to only show maps that have a valid map name (handled by mmr service I think, this was also improved in a recent PR that hasn't been merged yet - should work for newer seasons at least)
![image](https://github.com/user-attachments/assets/db7f9e51-f610-43b9-ba49-a083d95354ef)

Now uses the mapName property to display in ui as well as filtering in backend

This makes it possible to find finished games on a given map
![image](https://github.com/user-attachments/assets/73fdafca-7557-498d-9b4b-a78ff108fbe3)

Or just recent high lvl games with the mmr descending sort
![image](https://github.com/user-attachments/assets/3174836e-c376-436d-8b73-eb8e595af832)
