### PR TITLE
fix hero usage and hero winrate tabs

### DIFF
--- a/src/components/player/PlayerHeroStatistics.vue
+++ b/src/components/player/PlayerHeroStatistics.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType } from "vue";
+import { computed, defineComponent, PropType, ref, watch } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { getAsset } from "@/helpers/url-functions";
 import RaceIcon from "@/components/player/RaceIcon.vue";
@@ -55,7 +55,14 @@ export default defineComponent({
     const playerStore = usePlayerStore();
 
     const selectedRace = computed<number>(() => Number(selectedTab.value.split("-")[1]));
-    const selectedTab = computed<string>(() => defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All));
+
+    const selectedTab = ref<string>(defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All));
+
+    watch(() => playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All,
+        (newData) => {
+          selectedTab.value = defaultStatsTab(newData);
+        }
+    );
 
     function getImageForTable(heroId: string): string {
       const src: string = getAsset(`heroes/${heroId}.png`);

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType, ref } from "vue";
+import { computed, defineComponent, PropType, ref, watch } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { getAsset } from "@/helpers/url-functions";
 import RaceIcon from "@/components/player/RaceIcon.vue";
@@ -90,7 +90,13 @@ export default defineComponent({
     const pageLength = computed(() => Math.ceil(heroWinRates().length / paginationSize));
     const heroStatsCurrentPage = computed(() => heroWinRates().slice((pageOffset.value - paginationSize), pageOffset.value));
 
-    const selectedTab = computed(() => defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All));
+    const selectedTab = ref<string>(defaultStatsTab(playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All));
+
+    watch(() => playerStore.playerStatsRaceVersusRaceOnMap.raceWinsOnMapByPatch?.All,
+        (newData) => {
+          selectedTab.value = defaultStatsTab(newData);
+        }
+    );
 
     const headers = [
       { text: "", value: "image" },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/56cbf145-3507-42cd-bd26-7263d5261a84)

ref() usage is needed so that clicking the tab will updated selectedTab().
We also need to listen for when there is new data (initial page load, season changed...) so that we can set the tab according to the user's most played race. This is achieved with watch() instead of computed().