### PR TITLE
fix: matches-hide unimplemented mmr-select component finished matches

### DIFF
--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -14,7 +14,7 @@
               @gameModeChanged="gameModeChanged"
             ></game-mode-select>
             <map-select @mapChanged="mapChanged" :mapInfo="maps" :map="map"></map-select>
-            <mmr-select @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
+            <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
           </v-card-text>


### PR DESCRIPTION
### Matches
Hiding the select-mmr component for finished matches, for now. Feature doesn't appear to have been implemented.

### Context

Reported in #suggestions 
https://discord.com/channels/688377338576109643/689789210571702284/1349295225138450453