### PR TITLE
Adds Hero Icons to matches view

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+trailingComma: all

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,1 +1,0 @@
-trailingComma: all

--- a/components.d.ts
+++ b/components.d.ts
@@ -173,6 +173,7 @@ declare module 'vue' {
     VFooter: typeof import('vuetify/lib')['VFooter']
     VForm: typeof import('vuetify/lib')['VForm']
     VIcon: typeof import('vuetify/lib')['VIcon']
+    VImage: typeof import('vuetify/lib')['VImage']
     VImg: typeof import('vuetify/lib')['VImg']
     VList: typeof import('vuetify/lib')['VList']
     VListGroup: typeof import('vuetify/lib')['VListGroup']

--- a/components.d.ts
+++ b/components.d.ts
@@ -174,7 +174,6 @@ declare module 'vue' {
     VFooter: typeof import('vuetify/lib')['VFooter']
     VForm: typeof import('vuetify/lib')['VForm']
     VIcon: typeof import('vuetify/lib')['VIcon']
-    VImage: typeof import('vuetify/lib')['VImage']
     VImg: typeof import('vuetify/lib')['VImg']
     VList: typeof import('vuetify/lib')['VList']
     VListGroup: typeof import('vuetify/lib')['VListGroup']

--- a/components.d.ts
+++ b/components.d.ts
@@ -55,6 +55,8 @@ declare module 'vue' {
     GatewaySelect: typeof import('./src/components/common/GatewaySelect.vue')['default']
     GlobalSearch: typeof import('./src/components/common/GlobalSearch.vue')['default']
     HeroIcon: typeof import('./src/components/match-details/HeroIcon.vue')['default']
+    HeroIconRow: typeof import('./src/components/matches/HeroIconRow.vue')['default']
+    HeroIconToggle: typeof import('./src/components/matches/HeroIconToggle.vue')['default']
     HeroPicture: typeof import('./src/components/match-details/HeroPicture.vue')['default']
     HeroPictureSelect: typeof import('./src/components/overall-statistics/HeroPictureSelect.vue')['default']
     HeroTab: typeof import('./src/components/overall-statistics/tabs/HeroTab.vue')['default']

--- a/components.d.ts
+++ b/components.d.ts
@@ -59,6 +59,7 @@ declare module 'vue' {
     HeroIconToggle: typeof import('./src/components/matches/HeroIconToggle.vue')['default']
     HeroPicture: typeof import('./src/components/match-details/HeroPicture.vue')['default']
     HeroPictureSelect: typeof import('./src/components/overall-statistics/HeroPictureSelect.vue')['default']
+    HeroSelect: typeof import('./src/components/matches/HeroSelect.vue')['default']
     HeroTab: typeof import('./src/components/overall-statistics/tabs/HeroTab.vue')['default']
     HeroWinrate: typeof import('./src/components/overall-statistics/HeroWinrate.vue')['default']
     HostIcon: typeof import('./src/components/matches/HostIcon.vue')['default']

--- a/src/components/match-details/HeroIcon.vue
+++ b/src/components/match-details/HeroIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="hero">
-    <hero-picture :hero-icon="hero.icon" />
-    <div v-if="showLevel"  class="text-center hero-level-flag" :class="firstHeroOrNot">
+    <hero-picture :hero-icon="hero.icon" :size="size" />
+    <div v-if="showLevel" class="text-center hero-level-flag" :class="firstHeroOrNot">
       <span>{{ hero.level }}</span>
     </div>
   </div>
@@ -33,6 +33,10 @@ export default defineComponent({
       required: false,
       default: true,
     },
+    size: {
+      type: Number,
+      required: false,
+    }
   },
   setup(props) {
     const firstHeroOrNot = ref<string>(props.firstHero ? "hero-level-flag-first-hero" : "hero-level-flag-second-hero");

--- a/src/components/match-details/HeroIcon.vue
+++ b/src/components/match-details/HeroIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="hero">
     <hero-picture :hero-icon="hero.icon" />
-    <div class="text-center hero-level-flag" :class="firstHeroOrNot">
+    <div v-if="showLevel"  class="text-center hero-level-flag" :class="firstHeroOrNot">
       <span>{{ hero.level }}</span>
     </div>
   </div>
@@ -27,6 +27,11 @@ export default defineComponent({
       type: Boolean,
       false: true,
       default: undefined,
+    },
+    showLevel: {
+      type: Boolean,
+      required: false,
+      default: true,
     },
   },
   setup(props) {

--- a/src/components/match-details/HeroIcon.vue
+++ b/src/components/match-details/HeroIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="hero">
-    <hero-picture :hero-icon="hero.icon" :size="size" />
+    <hero-picture :hero-icon="hero.name" :size="size" />
     <div v-if="showLevel" class="text-center hero-level-flag" :class="firstHeroOrNot">
       <span>{{ hero.level }}</span>
     </div>

--- a/src/components/match-details/HeroPicture.vue
+++ b/src/components/match-details/HeroPicture.vue
@@ -1,11 +1,7 @@
 <template>
   <v-tooltip top>
     <template v-slot:activator="{ on }">
-      <v-card-text
-        v-on="on"
-        class="hero-icon"
-        :style="{ 'background-image': 'url(' + heroPicture + ')' }"
-      />
+      <v-img v-on="on" :src="heroPicture" :width="size" :aspect-ratio="1 / 1"></v-img>
     </template>
     <div>{{ heroName }}</div>
   </v-tooltip>
@@ -25,6 +21,11 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    size: {
+      type: Number,
+      required: false,
+      default: 128
+    }
   },
   setup(props) {
     const { t } = useI18n();
@@ -39,16 +40,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style lang="scss" scoped>
-.hero-icon {
-  z-index: 1;
-  position: relative;
-  padding-top: 100%;
-  padding-bottom: 0;
-  width: 100%;
-  margin-bottom: -2px !important;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-</style>

--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -1,0 +1,49 @@
+<template>
+    <v-row v-if="show" :class="rowClasses" style="margin: 0;">
+      <v-col cols="auto" v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="px-1">
+        <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false"/>
+      </v-col>
+    </v-row>
+  </template>
+  
+  <script lang="ts">
+  import { computed, defineComponent, PropType } from "vue";
+  import { Hero } from "@/store/types";
+  import HeroIcon from "@/components/match-details/HeroIcon.vue";
+  
+  export default defineComponent({
+    name: "HeroIconRow",
+    components: {
+      HeroIcon,
+    },
+    props: {
+      heroes: {
+        type: Array as PropType<Hero[]>,
+        required: true,
+      },
+      left: {
+        type: Boolean,
+        required: true,
+      },
+      show: {
+        type: Boolean,
+        required: true,
+      },
+    },
+    setup(props) {
+      const rowClasses = computed(() => {
+        const classes = ['mt-n1'];
+        if (props.left) {
+          classes.push('justify-end');
+        } else {
+          classes.push('justify-start');
+        }
+        return classes;
+      });
+  
+      return {
+        rowClasses
+      };
+    },
+  });
+  </script>

--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -1,13 +1,13 @@
 <template>
-  <v-row v-if="show" :class="rowClasses" style="margin: 0;">
-    <v-col cols="auto" v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="px-1">
-      <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false" />
+  <v-row v-if="show" no-gutters>
+    <v-col v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="pa-1">
+      <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false" :size="size" />
     </v-col>
   </v-row>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType } from "vue";
+import { defineComponent, PropType } from "vue";
 import { Hero } from "@/store/types";
 import HeroIcon from "@/components/match-details/HeroIcon.vue";
 
@@ -31,21 +31,10 @@ export default defineComponent({
       required: false,
       default: false
     },
-  },
-  setup(props) {
-    const rowClasses = computed(() => {
-      const classes = ['mt-n1'];
-      if (props.left) {
-        classes.push('justify-end');
-      } else {
-        classes.push('justify-start');
-      }
-      return classes;
-    });
-
-    return {
-      rowClasses
-    };
+    size: {
+      type: Number,
+      required: false
+    },
   },
 });
 </script>

--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -1,49 +1,51 @@
 <template>
-    <v-row v-if="show" :class="rowClasses" style="margin: 0;">
-      <v-col cols="auto" v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="px-1">
-        <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false"/>
-      </v-col>
-    </v-row>
-  </template>
-  
-  <script lang="ts">
-  import { computed, defineComponent, PropType } from "vue";
-  import { Hero } from "@/store/types";
-  import HeroIcon from "@/components/match-details/HeroIcon.vue";
-  
-  export default defineComponent({
-    name: "HeroIconRow",
-    components: {
-      HeroIcon,
+  <v-row v-if="show" :class="rowClasses" style="margin: 0;">
+    <v-col cols="auto" v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="px-1">
+      <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false" />
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType } from "vue";
+import { Hero } from "@/store/types";
+import HeroIcon from "@/components/match-details/HeroIcon.vue";
+
+export default defineComponent({
+  name: "HeroIconRow",
+  components: {
+    HeroIcon,
+  },
+  props: {
+    heroes: {
+      type: Array as PropType<Hero[]>,
+      required: false,
+      default: Array<Hero[]>
     },
-    props: {
-      heroes: {
-        type: Array as PropType<Hero[]>,
-        required: true,
-      },
-      left: {
-        type: Boolean,
-        required: true,
-      },
-      show: {
-        type: Boolean,
-        required: true,
-      },
+    left: {
+      type: Boolean,
+      required: true,
     },
-    setup(props) {
-      const rowClasses = computed(() => {
-        const classes = ['mt-n1'];
-        if (props.left) {
-          classes.push('justify-end');
-        } else {
-          classes.push('justify-start');
-        }
-        return classes;
-      });
-  
-      return {
-        rowClasses
-      };
+    show: {
+      type: Boolean,
+      required: false,
+      default: false
     },
-  });
-  </script>
+  },
+  setup(props) {
+    const rowClasses = computed(() => {
+      const classes = ['mt-n1'];
+      if (props.left) {
+        classes.push('justify-end');
+      } else {
+        classes.push('justify-start');
+      }
+      return classes;
+    });
+
+    return {
+      rowClasses
+    };
+  },
+});
+</script>

--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row v-if="show" no-gutters>
-    <v-col v-for="(hero, heroIndex) in heroes" :key="heroIndex" class="pa-1">
+    <v-col v-for="(hero, heroIndex) in heroList" :key="heroIndex" class="pa-1">
       <hero-icon :hero="hero" :firstHero="heroIndex === 0" :show-level="false" :size="size" />
     </v-col>
   </v-row>
@@ -36,5 +36,14 @@ export default defineComponent({
       required: false
     },
   },
+  setup(props, context) {
+    let heroList = props.heroes;
+    if (props.left) {
+      heroList = heroList.reverse();
+    }
+    return {
+      heroList
+    };
+  }
 });
 </script>

--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   },
   setup(props, context) {
     let heroList = props.heroes;
-    if (props.left) {
+    if (props.left && heroList) {
       heroList = heroList.reverse();
     }
     return {

--- a/src/components/matches/HeroIconToggle.vue
+++ b/src/components/matches/HeroIconToggle.vue
@@ -1,0 +1,45 @@
+<template>
+    <div v-if="!unfinished" style="margin-left: auto;">
+      <v-btn
+        tile
+        class="ml-4"
+        @click="toggle"
+        style="background-color: transparent; align-items: center;"
+        >
+        <v-icon left>{{ showHeroes ? mdiEyeOff : mdiEye }}</v-icon>
+        {{ showHeroes ? $t('components_matches_matchesgrid.hideHeroIcons') : $t('components_matches_matchesgrid.showHeroIcons') }}
+      </v-btn>
+    </div>
+  </template>
+  
+  <script lang="ts">
+  import { defineComponent } from 'vue';
+  import { mdiEye, mdiEyeOff } from "@mdi/js";
+  
+  export default defineComponent({
+    name: 'HeroIconToggle',
+    props: {
+      showHeroes: {
+        type: Boolean,
+        required: true,
+      },
+      unfinished: {
+        type: Boolean,
+        required: true,
+      },
+    },
+    emits: ['update:showHeroes'],
+    setup(props, { emit }) {
+  
+      function toggle() {
+        emit('update:showHeroes', !props.showHeroes);
+      }
+  
+      return {
+        toggle,
+        mdiEye,
+        mdiEyeOff,
+      };
+    },
+  });
+  </script>

--- a/src/components/matches/HeroIconToggle.vue
+++ b/src/components/matches/HeroIconToggle.vue
@@ -1,45 +1,42 @@
 <template>
-    <div v-if="!unfinished" style="margin-left: auto;">
-      <v-btn
-        tile
-        class="ml-4"
-        @click="toggle"
-        style="background-color: transparent; align-items: center;"
-        >
-        <v-icon left>{{ showHeroes ? mdiEyeOff : mdiEye }}</v-icon>
-        {{ showHeroes ? $t('components_matches_matchesgrid.hideHeroIcons') : $t('components_matches_matchesgrid.showHeroIcons') }}
-      </v-btn>
-    </div>
-  </template>
-  
-  <script lang="ts">
-  import { defineComponent } from 'vue';
-  import { mdiEye, mdiEyeOff } from "@mdi/js";
-  
-  export default defineComponent({
-    name: 'HeroIconToggle',
-    props: {
-      showHeroes: {
-        type: Boolean,
-        required: true,
-      },
-      unfinished: {
-        type: Boolean,
-        required: true,
-      },
+  <div v-if="!unfinished" style="margin-left: auto;">
+    <v-btn tile class="ml-4" @click="toggle" style="background-color: transparent; align-items: center;">
+      <v-icon left>{{ showHeroes ? mdiEyeOff : mdiEye }}</v-icon>
+      {{ showHeroes ? $t('components_matches_matchesgrid.hideHeroIcons') :
+        $t('components_matches_matchesgrid.showHeroIcons') }}
+    </v-btn>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { mdiEye, mdiEyeOff } from "@mdi/js";
+
+export default defineComponent({
+  name: 'HeroIconToggle',
+  props: {
+    showHeroes: {
+      type: Boolean,
+      required: true,
     },
-    emits: ['update:showHeroes'],
-    setup(props, { emit }) {
-  
-      function toggle() {
-        emit('update:showHeroes', !props.showHeroes);
-      }
-  
-      return {
-        toggle,
-        mdiEye,
-        mdiEyeOff,
-      };
+    unfinished: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
-  });
-  </script>
+  },
+  emits: ['update:showHeroes'],
+  setup(props, { emit }) {
+
+    function toggle() {
+      emit('update:showHeroes', !props.showHeroes);
+    }
+
+    return {
+      toggle,
+      mdiEye,
+      mdiEyeOff,
+    };
+  },
+});
+</script>

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -63,8 +63,8 @@ export default defineComponent({
       return [{ heroName: "All Heroes", key: "All Heroes" }, ...heroList];
     });
     const selected = computed<string>(() => {
-      const match = props.hero as EHeroes;
-      return match ? match : "All Heroes";
+      const match = Object.values(EHeroes).includes(props.hero as EHeroes);
+      return match ? t(`heroNames.${props.hero}`) : "All Heroes";
     });
 
     function selectHero(hero: EHeroes): void {

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-menu offset-x>
+    <template v-slot:activator="{ on }">
+      <v-btn tile v-on="on" style="background-color: transparent">
+        <v-icon style="margin-right: 5px">{{ mdiDramaMasks }}</v-icon>
+        {{ selected }}
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-list>
+          <v-list-item-content>
+            <v-list-item-title>{{ $t("common.selecthero") }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list>
+        <v-divider></v-divider>
+        <v-list dense max-height="400" class="overflow-y-auto">
+          <v-list-item v-for="(m, index) in heroes" :key="index" @click="selectHero(m.key)">
+            <v-list-item-content>
+              <v-list-item-title>{{ m.heroName }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "vue";
+import { useI18n } from "vue-i18n-bridge";
+import { TranslateResult } from "vue-i18n";
+import { mdiDramaMasks } from "@mdi/js";
+import { EHeroes } from "@/store/heroes";
+
+type HeroSelectHero = {
+  heroName: TranslateResult;
+  key: EHeroes | string;
+};
+
+export default defineComponent({
+  name: "HeroSelect",
+  props: {
+    hero: {
+      type: String,
+      required: false,
+      default: "All Heroes",
+    }
+  },
+  setup: (props, context) => {
+    const { t } = useI18n();
+    const heroes = computed<HeroSelectHero[]>(() => {
+      const heroList = Object.values(EHeroes)
+        .map((hero) => ({ heroName: t(`heroNames.${hero}`), key: hero }))
+        .sort((heroA, heroB) => {
+          if (heroA.heroName < heroB.heroName) {
+            return -1;
+          }
+          if (heroA.heroName > heroB.heroName) {
+            return 1;
+          } return 0;
+        });
+      return [{ heroName: "All Heroes", key: "All Heroes" }, ...heroList];
+    });
+    const selected = computed<string>(() => {
+      const match = props.hero as EHeroes;
+      return match ? match : "All Heroes";
+    });
+
+    function selectHero(hero: EHeroes): void {
+      context.emit("heroChanged", hero);
+    }
+
+    return {
+      mdiDramaMasks,
+      selected,
+      heroes,
+      selectHero,
+    };
+  },
+});
+</script>
+
+<style></style>

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -15,7 +15,7 @@
         </v-list>
         <v-divider></v-divider>
         <v-list dense max-height="400" class="overflow-y-auto">
-          <v-list-item v-for="hero in heroFilters" :key="hero.id" @click="selectHero(hero)">
+          <v-list-item v-for="hero in heroFilters" :key="hero.type" @click="selectHero(hero)">
             <v-list-item-content>
               <v-list-item-title>{{ $t(`heroNames.${hero.name}`) }}</v-list-item-title>
             </v-list-item-content>
@@ -56,7 +56,7 @@ export default defineComponent({
 
     const selectHero = (hero: HeroFilter) => {
       selectedHero.value = hero;
-      context.emit("heroChanged", hero.id);
+      context.emit("heroChanged", hero.type);
     };
 
     return {

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -10,7 +10,7 @@
       <v-card-text>
         <v-list>
           <v-list-item-content>
-            <v-list-item-title>{{ $t("common.selecthero") }}</v-list-item-title>
+            <v-list-item-title>{{ $t("common.selecthero_highestlevel") }}</v-list-item-title>
           </v-list-item-content>
         </v-list>
         <v-divider></v-divider>

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -4,11 +4,7 @@
       <table class="custom-table">
         <thead>
           <tr>
-            <td
-              v-for="header in headers"
-              :key="header.name"
-              :style="header.style"
-            >
+            <td v-for="header in headers" :key="header.name" :style="header.style">
               {{ header.text }}
             </td>
             <td v-if="!unfinished">
@@ -19,62 +15,37 @@
         <tbody>
           <tr v-for="item in matches" :key="item.id">
             <td>
-              <div
-                v-if="isFfa(item.gameMode)"
-                @click="goToMatchDetailPage(item)"
-                class="my-3"
-                :class="{ clickable: !unfinished }"
-              >
+              <div v-if="isFfa(item.gameMode)" @click="goToMatchDetailPage(item)" class="my-3"
+                :class="{ clickable: !unfinished }">
                 <v-row justify="center" v-if="alwaysLeftName">
                   <v-col offset="4" class="py-1">
-                    <team-match-info
-                      :not-clickable="!unfinished"
-                      :team="getPlayerTeam(item)"
-                      :unfinishedMatch="unfinished"
-                      :is-anonymous="true"
-                      :highlightedPlayer="alwaysLeftName"
-                      :showHeroes="showHeroes"
-                    ></team-match-info>
+                    <team-match-info :not-clickable="!unfinished" :team="getPlayerTeam(item)"
+                      :unfinishedMatch="unfinished" :is-anonymous="true" :highlightedPlayer="alwaysLeftName"
+                      :showHeroes="showHeroes"></team-match-info>
                   </v-col>
                 </v-row>
                 <v-row justify="center" v-for="(team, index) in getOpponentTeams(item)" :key="index">
                   <v-col offset="4" class="py-1">
-                    <team-match-info
-                      :not-clickable="!unfinished"
-                      :team="team"
-                      :unfinishedMatch="unfinished"
-                      :is-anonymous="true"
-                      :showHeroes="showHeroes"
-                    ></team-match-info>
+                    <team-match-info :not-clickable="!unfinished" :team="team" :unfinishedMatch="unfinished"
+                      :is-anonymous="true" :showHeroes="showHeroes"></team-match-info>
                   </v-col>
                 </v-row>
               </div>
-              <v-row
-                v-if="!isFfa(item.gameMode)"
-                @click="goToMatchDetailPage(item)"
-                :class="{ clickable: !unfinished }"
-              >
+              <v-row v-if="!isFfa(item.gameMode)" @click="goToMatchDetailPage(item)"
+                :class="{ clickable: !unfinished }">
                 <v-col cols="5.5" class="team-match-info-container left-side py-2" align-self="center">
-                  <team-match-info
-                    :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
-                    :unfinishedMatch="unfinished"
-                    :left="true"
-                    :highlightedPlayer="nameIfNonSolo(item)"
-                    :showHeroes="showHeroes"
-                  ></team-match-info>
+                  <team-match-info :not-clickable="!unfinished"
+                    :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)" :unfinishedMatch="unfinished"
+                    :left="true" :highlightedPlayer="nameIfNonSolo(item)" :showHeroes="showHeroes"></team-match-info>
                 </v-col>
                 <v-col cols="1" align-self="center" class="py-2">
                   <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
                   <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo"></host-icon>
                 </v-col>
                 <v-col cols="5.5" class="team-match-info-container py-2" align-self="center">
-                  <team-match-info
-                    :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
-                    :unfinishedMatch="unfinished"
-                    :showHeroes="showHeroes"
-                  ></team-match-info>
+                  <team-match-info :not-clickable="!unfinished"
+                    :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)" :unfinishedMatch="unfinished"
+                    :showHeroes="showHeroes"></team-match-info>
                 </v-col>
               </v-row>
             </td>
@@ -176,7 +147,7 @@ export default defineComponent({
     showHeroes: {
       type: Boolean,
       required: false,
-      default: true,
+      default: false,
     },
   },
   setup(props, context) {
@@ -373,6 +344,7 @@ export default defineComponent({
     justify-content: end;
   }
 }
+
 .clickable {
   cursor: pointer;
 }

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -61,6 +61,7 @@
                     :unfinishedMatch="unfinished"
                     :left="true"
                     :highlightedPlayer="nameIfNonSolo(item)"
+                    :show-heroes="showHeroes"
                   ></team-match-info>
                 </v-col>
                 <v-col cols="1" align-self="center" class="py-2">

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -4,7 +4,11 @@
       <table class="custom-table">
         <thead>
           <tr>
-            <td v-for="header in headers" :key="header.name" :style="header.style">
+            <td
+              v-for="header in headers"
+              :key="header.name"
+              :style="header.style"
+            >
               {{ header.text }}
             </td>
             <td v-if="!unfinished">
@@ -15,37 +19,61 @@
         <tbody>
           <tr v-for="item in matches" :key="item.id">
             <td>
-              <div v-if="isFfa(item.gameMode)" @click="goToMatchDetailPage(item)" class="my-3"
-                :class="{ clickable: !unfinished }">
+              <div
+                v-if="isFfa(item.gameMode)"
+                @click="goToMatchDetailPage(item)"
+                class="my-3"
+                :class="{ clickable: !unfinished }"
+              >
                 <v-row justify="center" v-if="alwaysLeftName">
                   <v-col offset="4" class="py-1">
-                    <team-match-info :not-clickable="!unfinished" :team="getPlayerTeam(item)"
-                      :unfinishedMatch="unfinished" :is-anonymous="true" :highlightedPlayer="alwaysLeftName"
-                      :showHeroes="showHeroes"></team-match-info>
+                    <team-match-info
+                      :not-clickable="!unfinished"
+                      :team="getPlayerTeam(item)"
+                      :unfinishedMatch="unfinished"
+                      :is-anonymous="true"
+                      :highlightedPlayer="alwaysLeftName"
+                      :show-heroes="showHeroes"
+                    ></team-match-info>
                   </v-col>
                 </v-row>
                 <v-row justify="center" v-for="(team, index) in getOpponentTeams(item)" :key="index">
                   <v-col offset="4" class="py-1">
-                    <team-match-info :not-clickable="!unfinished" :team="team" :unfinishedMatch="unfinished"
-                      :is-anonymous="true" :showHeroes="showHeroes"></team-match-info>
+                    <team-match-info
+                      :not-clickable="!unfinished"
+                      :team="team"
+                      :unfinishedMatch="unfinished"
+                      :is-anonymous="true"
+                      :show-heroes="showHeroes"
+                    ></team-match-info>
                   </v-col>
                 </v-row>
               </div>
-              <v-row v-if="!isFfa(item.gameMode)" @click="goToMatchDetailPage(item)"
-                :class="{ clickable: !unfinished }">
-                <v-col cols="5.5" class="team-match-info-container left-side py-2" align-self="center">
-                  <team-match-info :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)" :unfinishedMatch="unfinished"
-                    :left="true" :highlightedPlayer="nameIfNonSolo(item)" :showHeroes="showHeroes"></team-match-info>
+              <v-row
+                v-if="!isFfa(item.gameMode)"
+                @click="goToMatchDetailPage(item)"
+                :class="{ clickable: !unfinished }"
+              >
+                <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
+                  <team-match-info
+                    :not-clickable="!unfinished"
+                    :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
+                    :unfinishedMatch="unfinished"
+                    :left="true"
+                    :highlightedPlayer="nameIfNonSolo(item)"
+                  ></team-match-info>
                 </v-col>
                 <v-col cols="1" align-self="center" class="py-2">
                   <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
                   <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo"></host-icon>
                 </v-col>
-                <v-col cols="5.5" class="team-match-info-container py-2" align-self="center">
-                  <team-match-info :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)" :unfinishedMatch="unfinished"
-                    :showHeroes="showHeroes"></team-match-info>
+                <v-col cols="5.5" class="team-match-info-container" align-self="center">
+                  <team-match-info
+                    :not-clickable="!unfinished"
+                    :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
+                    :unfinishedMatch="unfinished"
+                    :show-heroes="showHeroes"
+                  ></team-match-info>
                 </v-col>
               </v-row>
             </td>

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -33,6 +33,7 @@
                       :unfinishedMatch="unfinished"
                       :is-anonymous="true"
                       :highlightedPlayer="alwaysLeftName"
+                      :showHeroes="showHeroes"
                     ></team-match-info>
                   </v-col>
                 </v-row>
@@ -43,6 +44,7 @@
                       :team="team"
                       :unfinishedMatch="unfinished"
                       :is-anonymous="true"
+                      :showHeroes="showHeroes"
                     ></team-match-info>
                   </v-col>
                 </v-row>
@@ -52,24 +54,26 @@
                 @click="goToMatchDetailPage(item)"
                 :class="{ clickable: !unfinished }"
               >
-                <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
+                <v-col cols="5.5" class="team-match-info-container left-side py-2" align-self="center">
                   <team-match-info
                     :not-clickable="!unfinished"
                     :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
                     :unfinishedMatch="unfinished"
                     :left="true"
                     :highlightedPlayer="nameIfNonSolo(item)"
+                    :showHeroes="showHeroes"
                   ></team-match-info>
                 </v-col>
-                <v-col cols="1" align-self="center">
+                <v-col cols="1" align-self="center" class="py-2">
                   <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
                   <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo"></host-icon>
                 </v-col>
-                <v-col cols="5.5" class="team-match-info-container" align-self="center">
+                <v-col cols="5.5" class="team-match-info-container py-2" align-self="center">
                   <team-match-info
                     :not-clickable="!unfinished"
                     :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
                     :unfinishedMatch="unfinished"
+                    :showHeroes="showHeroes"
                   ></team-match-info>
                 </v-col>
               </v-row>
@@ -168,6 +172,11 @@ export default defineComponent({
     isPlayerProfile: {
       type: Boolean,
       required: true,
+    },
+    showHeroes: {
+      type: Boolean,
+      required: false,
+      default: true,
     },
   },
   setup(props, context) {

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -6,29 +6,35 @@
       :rndRace="rndRace"
       :big="bigRaceIcon"
     />
-    <span :class="{ 'mr-2': left, 'ml-2': !left }">
-      <a
-        class="name-link"
-        :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
-        @click="notClickable ? null : goToPlayer()"
-        @click.middle="openProfileInNewTab()"
-        @click.right="openProfileInNewTab()"
-      >
-        {{ nameWithoutBtag }}
-        <span class="number-text">({{ currentRating }})</span>
-        <span class="number-text" v-if="mmrChange !== 0" :class="won">
-          <span v-if="mmrChange > 0">+{{ mmrChange }}</span>
-          <span v-else>{{ mmrChange }}</span>
-        </span>
-      </a>
-      <div class="flag-container" :class="{ 'ml-1': !left }">
+    <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
+      <span>
+        <a
+          class="name-link"
+          :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
+          @click="notClickable ? null : goToPlayer()"
+          @click.middle="openProfileInNewTab()"
+          @click.right="openProfileInNewTab()"
+        >
+          {{ nameWithoutBtag }}
+          <span class="number-text">({{ currentRating }})</span>
+          <span class="number-text" v-if="mmrChange !== 0" :class="won">
+            <span v-if="mmrChange > 0">+{{ mmrChange }}</span>
+            <span v-else>{{ mmrChange }}</span>
+          </span>
+        </a>
         <country-flag-extended
           :countryCode="player.countryCode"
           :location="player.location"
           size="small"
+          class="ml-1"
         />
-      </div>
-    </span>
+      </span>
+      <hero-icon-row
+        :heroes="player.heroes"
+        :left="left"
+        :show="showHeroes"
+      />
+    </div>
     <player-icon
       v-if="left"
       :race="race"
@@ -81,6 +87,11 @@ export default defineComponent({
       undefined,
     },
     highlighted: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    showHeroes: {
       type: Boolean,
       required: false,
       default: false,
@@ -150,8 +161,22 @@ export default defineComponent({
 <style lang="scss" scoped>
 .player-info {
   display: flex;
+  flex-direction: row;
+  align-items: center;
   position: relative;
-  overflow: hidden;
+}
+
+.details-column {
+  display: flex;
+  flex-direction: column;
+}
+
+span > a {
+  display: inline-block;
+}
+
+span > .flag-container {
+  display: inline-block;
 }
 
 .player-info__right {
@@ -159,10 +184,8 @@ export default defineComponent({
   text-align: right;
   z-index: 2;
 
-  .flag-container {
-    right: 38px;
-    top: 15px;
-    height: 0px;
+  .details-column {
+    align-items: flex-end;
   }
 }
 
@@ -171,15 +194,9 @@ export default defineComponent({
   text-align: left;
   z-index: 2;
 
-  .flag-container {
-    left: 35px;
-    top: 15px;
-    height: 0px;
+  .details-column {
+    align-items: flex-start;
   }
-}
-
-.flag-container {
-  position: absolute;
 }
 
 .name-link {

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -1,20 +1,11 @@
 <template>
   <div class="player-info" :class="textClass">
-    <player-icon
-      v-if="!left"
-      :race="race"
-      :rndRace="rndRace"
-      :big="bigRaceIcon"
-    />
+    <player-icon v-if="!left" :race="race" :rndRace="rndRace" :big="bigRaceIcon" />
     <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
       <span>
-        <a
-          class="name-link"
-          :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
-          @click="notClickable ? null : goToPlayer()"
-          @click.middle="openProfileInNewTab()"
-          @click.right="openProfileInNewTab()"
-        >
+        <a class="name-link" :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
+          @click="notClickable ? null : goToPlayer()" @click.middle="openProfileInNewTab()"
+          @click.right="openProfileInNewTab()">
           {{ nameWithoutBtag }}
           <span class="number-text">({{ currentRating }})</span>
           <span class="number-text" v-if="mmrChange !== 0" :class="won">
@@ -22,25 +13,11 @@
             <span v-else>{{ mmrChange }}</span>
           </span>
         </a>
-        <country-flag-extended
-          :countryCode="player.countryCode"
-          :location="player.location"
-          size="small"
-          class="ml-1"
-        />
       </span>
-      <hero-icon-row
-        :heroes="player.heroes"
-        :left="left"
-        :show="showHeroes"
-      />
+      <country-flag-extended :countryCode="player.countryCode" :location="player.location" size="small" class="ml-1" />
+      <hero-icon-row :heroes="player.heroes" :left="left" :show="showHeroes" :size="24" />
     </div>
-    <player-icon
-      v-if="left"
-      :race="race"
-      :rndRace="rndRace"
-      :big="bigRaceIcon"
-    />
+    <player-icon v-if="left" :race="race" :rndRace="rndRace" :big="bigRaceIcon" />
   </div>
 </template>
 
@@ -171,11 +148,11 @@ export default defineComponent({
   flex-direction: column;
 }
 
-span > a {
+span>a {
   display: inline-block;
 }
 
-span > .flag-container {
+span>.flag-container {
   display: inline-block;
 }
 

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -1,23 +1,42 @@
 <template>
   <div class="player-info" :class="textClass">
-    <player-icon v-if="!left" :race="race" :rndRace="rndRace" :big="bigRaceIcon" />
+    <player-icon
+      v-if="!left"
+      :race="race"
+      :rndRace="rndRace"
+      :big="bigRaceIcon"
+    />
     <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
-      <span>
-        <a class="name-link" :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
-          @click="notClickable ? null : goToPlayer()" @click.middle="openProfileInNewTab()"
-          @click.right="openProfileInNewTab()">
-          {{ nameWithoutBtag }}
-          <span class="number-text">({{ currentRating }})</span>
-          <span class="number-text" v-if="mmrChange !== 0" :class="won">
-            <span v-if="mmrChange > 0">+{{ mmrChange }}</span>
-            <span v-else>{{ mmrChange }}</span>
-          </span>
-        </a>
-      </span>
-      <country-flag-extended :countryCode="player.countryCode" :location="player.location" size="small" class="ml-1" />
+      <span :class="{ 'mr-2': left, 'ml-2': !left }">
+        <a
+        class="name-link"
+        :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
+        @click="notClickable ? null : goToPlayer()"
+        @click.middle="openProfileInNewTab()"
+        @click.right="openProfileInNewTab()"
+      >
+        {{ nameWithoutBtag }}
+        <span class="number-text">({{ currentRating }})</span>
+        <span class="number-text" v-if="mmrChange !== 0" :class="won">
+          <span v-if="mmrChange > 0">+{{ mmrChange }}</span>
+          <span v-else>{{ mmrChange }}</span>
+        </span>
+      </a>
+    </span>
+      <div class="flag-container" :class="{ 'ml-1': !left }">
+        <country-flag-extended
+          :countryCode="player.countryCode"
+          :location="player.location"
+          size="small"
+        />
       <hero-icon-row :heroes="player.heroes" :left="left" :show="showHeroes" :size="24" />
     </div>
-    <player-icon v-if="left" :race="race" :rndRace="rndRace" :big="bigRaceIcon" />
+    <player-icon
+      v-if="left"
+      :race="race"
+      :rndRace="rndRace"
+      :big="bigRaceIcon"
+    />
   </div>
 </template>
 
@@ -28,10 +47,12 @@ import { ERaceEnum, PlayerInTeam } from "@/store/types";
 import PlayerIcon from "@/components/matches/PlayerIcon.vue";
 import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
 import { getProfileUrl } from "@/helpers/url-functions";
+import HeroIconRow from "@/components/matches/HeroIconRow.vue";
 
 export default defineComponent({
   name: "PlayerMatchInfo",
   components: {
+    HeroIconRow,
     PlayerIcon,
     CountryFlagExtended,
   },

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -7,7 +7,7 @@
         :big="bigRaceIcon"
     />
     <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
-      <span :class="{ 'mr-2': left, 'ml-2': !left }">
+      <span>
         <a
             class="name-link"
             :class="[won, $props.highlighted ? 'font-weight-bold' : '']"

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="player-info" :class="textClass">
     <player-icon
-      v-if="!left"
-      :race="race"
-      :rndRace="rndRace"
-      :big="bigRaceIcon"
+        v-if="!left"
+        :race="race"
+        :rndRace="rndRace"
+        :big="bigRaceIcon"
     />
     <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
       <span :class="{ 'mr-2': left, 'ml-2': !left }">
         <a
-        class="name-link"
-        :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
-        @click="notClickable ? null : goToPlayer()"
-        @click.middle="openProfileInNewTab()"
-        @click.right="openProfileInNewTab()"
-      >
+            class="name-link"
+            :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
+            @click="notClickable ? null : goToPlayer()"
+            @click.middle="openProfileInNewTab()"
+            @click.right="openProfileInNewTab()"
+        >
         {{ nameWithoutBtag }}
         <span class="number-text">({{ currentRating }})</span>
         <span class="number-text" v-if="mmrChange !== 0" :class="won">
@@ -25,17 +25,18 @@
     </span>
       <div class="flag-container" :class="{ 'ml-1': !left }">
         <country-flag-extended
-          :countryCode="player.countryCode"
-          :location="player.location"
-          size="small"
+            :countryCode="player.countryCode"
+            :location="player.location"
+            size="small"
         />
-      <hero-icon-row :heroes="player.heroes" :left="left" :show="showHeroes" :size="24" />
+      </div>
+      <hero-icon-row :heroes="player.heroes" :left="left" :show="showHeroes" :size="24"/>
     </div>
     <player-icon
-      v-if="left"
-      :race="race"
-      :rndRace="rndRace"
-      :big="bigRaceIcon"
+        v-if="left"
+        :race="race"
+        :rndRace="rndRace"
+        :big="bigRaceIcon"
     />
   </div>
 </template>
@@ -134,13 +135,14 @@ export default defineComponent({
       if (!showPlayerInfo.value) return;
 
       router
-        .push({
-          path: getProfileUrl(props.player.battleTag),
-        })
-        .catch((err) => {
-          return err;
-        });
+          .push({
+            path: getProfileUrl(props.player.battleTag),
+          })
+          .catch((err) => {
+            return err;
+          });
     }
+
     return {
       won,
       race,
@@ -169,11 +171,11 @@ export default defineComponent({
   flex-direction: column;
 }
 
-span>a {
+span > a {
   display: inline-block;
 }
 
-span>.flag-container {
+span > .flag-container {
   display: inline-block;
 }
 

--- a/src/components/matches/TeamMatchInfo.vue
+++ b/src/components/matches/TeamMatchInfo.vue
@@ -3,16 +3,21 @@
     <div
       v-for="(player, index) in team.players"
       :key="index"
-      :class="{ mt2: index > 0 }"
+      class="my-2"
     >
       <player-match-info
         :unfinishedMatch="unfinishedMatch"
-        :player="team.players[index]"
+        :player="player"
         :left="left"
         :big-race-icon="bigRaceIcon"
         :not-clickable="notClickable"
         :is-anonymous="isAnonymous"
-        :highlighted="highlightedPlayer === team.players[index].battleTag"
+        :highlighted="highlightedPlayer === player.battleTag"
+      />
+      <hero-icon-row
+        :heroes="player.heroes"
+        :left="left"
+        :show="showHeroes"
       />
     </div>
   </div>
@@ -22,11 +27,13 @@
 import { defineComponent, PropType } from "vue";
 import { Team } from "@/store/types";
 import PlayerMatchInfo from "@/components/matches/PlayerMatchInfo.vue";
+import HeroIconRow from "@/components/matches/HeroIconRow.vue";
 
 export default defineComponent({
   name: "TeamMatchInfo",
   components: {
     PlayerMatchInfo,
+    HeroIconRow,
   },
   props: {
     team: {
@@ -63,7 +70,12 @@ export default defineComponent({
       type: String,
       required: false,
       default: "",
-    }
+    },
+    showHeroes: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 });
 </script>

--- a/src/components/matches/TeamMatchInfo.vue
+++ b/src/components/matches/TeamMatchInfo.vue
@@ -13,11 +13,7 @@
         :not-clickable="notClickable"
         :is-anonymous="isAnonymous"
         :highlighted="highlightedPlayer === player.battleTag"
-      />
-      <hero-icon-row
-        :heroes="player.heroes"
-        :left="left"
-        :show="showHeroes"
+        :show-heroes="showHeroes"
       />
     </div>
   </div>

--- a/src/components/matches/TeamMatchInfo.vue
+++ b/src/components/matches/TeamMatchInfo.vue
@@ -3,7 +3,6 @@
     <div
       v-for="(player, index) in team.players"
       :key="index"
-      class="my-2"
     >
       <player-match-info
         :unfinishedMatch="unfinishedMatch"

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -68,8 +68,16 @@
         </v-col>
       </v-row>
     </v-card-text>
-    <matches-grid v-model="matches" :total-matches="totalMatches" :items-per-page="50" :always-left-name="battleTag"
-      only-show-enemy @pageChanged="onPageChanged" :is-player-profile="true" :showHeroes="showHeroIcons"></matches-grid>
+    <matches-grid
+      v-model="matches"
+      :total-matches="totalMatches"
+      :items-per-page="50"
+      :always-left-name="battleTag"
+      only-show-enemy
+      @pageChanged="onPageChanged"
+      :is-player-profile="true"
+      :show-heroes="showHeroIcons"
+    ></matches-grid>
   </div>
 </template>
 

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -50,6 +50,9 @@
             outlined
           />
         </v-col>
+        <v-col align-self="center">
+          <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event" />
+        </v-col>
       </v-row>
     </v-card-title>
     <v-card-text v-if="foundPlayer">
@@ -65,15 +68,8 @@
         </v-col>
       </v-row>
     </v-card-text>
-    <matches-grid
-      v-model="matches"
-      :total-matches="totalMatches"
-      :items-per-page="50"
-      :always-left-name="battleTag"
-      only-show-enemy
-      @pageChanged="onPageChanged"
-      :is-player-profile="true"
-    ></matches-grid>
+    <matches-grid v-model="matches" :total-matches="totalMatches" :items-per-page="50" :always-left-name="battleTag"
+      only-show-enemy @pageChanged="onPageChanged" :is-player-profile="true" :showHeroes="showHeroIcons"></matches-grid>
   </div>
 </template>
 
@@ -86,12 +82,14 @@ import { EGameMode, ERaceEnum, Match, PlayerInTeam, Team } from "@/store/types";
 import PlayerSearch from "@/components/common/PlayerSearch.vue";
 import { usePlayerStore } from "@/store/player/store";
 import { useRankingStore } from "@/store/ranking/store";
+import HeroIconToggle from "@/components/matches/HeroIconToggle.vue";
 
 export default defineComponent({
   name: "PlayerMatchesTab",
   components: {
     MatchesGrid,
     PlayerSearch,
+    HeroIconToggle,
   },
   props: {
     id: {
@@ -105,6 +103,7 @@ export default defineComponent({
     const rankingsStore = useRankingStore();
     const isLoadingMatches = ref<boolean>(false);
     const foundPlayer = ref<string>("");
+    const showHeroIcons = ref<boolean>(true);
 
     const battleTag = computed<string>(() => decodeURIComponent(props.id));
     const totalMatches = computed<number>(() => playerStore.totalMatches);
@@ -242,6 +241,7 @@ export default defineComponent({
       totalMatches,
       battleTag,
       onPageChanged,
+      showHeroIcons,
     };
   },
 });

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -340,6 +340,7 @@ const en = {
   },
 
   heroNames: {
+    allfilter: "All Heroes",
     all: "Any hero selection",
     none: "No hero selection",
     archmage: "Archmage",
@@ -404,8 +405,7 @@ const en = {
     russia_east_via_asia_east2: "Russia East via Asia East 2",
     russia_central_via_korea_central2: "Russia Central via Korea Central 2",
     africa_east_via_sg: "Africa East via Singapore",
-    africa_east_via_sg_azure_via_simple_cloud:
-      "Africa East via Singapore via simplecloud",
+    africa_east_via_sg_azure_via_simple_cloud: "Africa East via Singapore via simplecloud",
   },
 };
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -380,6 +380,8 @@ const en = {
   components_matches_matchesgrid: {
     replay: "Replay",
     floNode: "Flo Node",
+    showHeroIcons: "Show Heros",
+    hideHeroIcons: "Hide Heros",
   },
 
   proxies: {
@@ -402,7 +404,8 @@ const en = {
     russia_east_via_asia_east2: "Russia East via Asia East 2",
     russia_central_via_korea_central2: "Russia Central via Korea Central 2",
     africa_east_via_sg: "Africa East via Singapore",
-    africa_east_via_sg_azure_via_simple_cloud: "Africa East via Singapore via simplecloud",
+    africa_east_via_sg_azure_via_simple_cloud:
+      "Africa East via Singapore via simplecloud",
   },
 };
 

--- a/src/services/HeroService.ts
+++ b/src/services/HeroService.ts
@@ -1,0 +1,10 @@
+import { API_URL } from "@/main";
+import { HeroFilter } from "@/store/heroes";
+
+export default class HeroService {
+  public static async retrieveHeroes(): Promise<HeroFilter[]> {
+    const url = `${API_URL}api/hero/filters`;
+    const response = await fetch(url);
+    return await response.json();
+  }
+}

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -2,6 +2,7 @@ import { EGameMode, ERaceEnum, Match, MatchDetail } from "@/store/types";
 import { API_URL } from "@/main";
 import { Gateways } from "@/store/ranking/types";
 import { Mmr } from "@/store/match/types";
+import {EHeroes} from "@/store/heroes";
 
 export default class MatchService {
   static pageSize = 50;
@@ -13,11 +14,15 @@ export default class MatchService {
     map: string,
     mmr: Mmr,
     season: number,
+    hero: string,
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
     const minMmr = mmr.min === 0 ? "" : `&minMmr=${mmr.min}`;
     const maxMmr = mmr.max === 3000 ? "" : `&maxMmr=${mmr.max}`;
-    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}`;
+    const heroQuery = Object.values(EHeroes).includes(hero as EHeroes)
+      ? `&hero=${hero}`
+      : "";
+    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}${heroQuery}`;
     const response = await fetch(url);
     return await response.json();
   }

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -2,7 +2,7 @@ import { EGameMode, ERaceEnum, Match, MatchDetail } from "@/store/types";
 import { API_URL } from "@/main";
 import { Gateways } from "@/store/ranking/types";
 import { Mmr } from "@/store/match/types";
-import {EHeroes} from "@/store/heroes";
+import { EHeroes } from "@/store/heroes";
 
 export default class MatchService {
   static pageSize = 50;
@@ -14,14 +14,12 @@ export default class MatchService {
     map: string,
     mmr: Mmr,
     season: number,
-    hero: string,
+    hero: number,
   ): Promise<{ count: number; matches: Match[] }> {
     const offset = page * this.pageSize;
     const minMmr = mmr.min === 0 ? "" : `&minMmr=${mmr.min}`;
     const maxMmr = mmr.max === 3000 ? "" : `&maxMmr=${mmr.max}`;
-    const heroQuery = Object.values(EHeroes).includes(hero as EHeroes)
-      ? `&hero=${hero}`
-      : "";
+    const heroQuery = hero > 0 ? `&hero=${hero}` : "";
     const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}&season=${season}${heroQuery}`;
     const response = await fetch(url);
     return await response.json();

--- a/src/store/common/store.ts
+++ b/src/store/common/store.ts
@@ -1,0 +1,26 @@
+import { defineStore } from "pinia";
+import { CommonState } from "./types";
+import { HeroFilter } from "../heroes";
+import HeroService from "@/services/HeroService";
+
+export const useCommonStore = defineStore("commonState", {
+  state: (): CommonState => ({
+    heroFilters: [] as HeroFilter[],
+  } as CommonState),
+  actions: {
+    async loadHeroFilters() {
+      const filters = await HeroService.retrieveHeroes();
+      this.SET_HERO_FILTERS(filters);
+    },
+    getDefaultHeroFilter(): HeroFilter | undefined {
+      if (this.heroFilters.length > 0) {
+        return this.heroFilters.find((hero) => hero.name === "all");
+      } else {
+        return undefined;
+      }
+    },
+    SET_HERO_FILTERS(heroFilters: HeroFilter[]): void {
+      this.heroFilters = heroFilters;
+    },
+  },
+});

--- a/src/store/common/types.ts
+++ b/src/store/common/types.ts
@@ -1,3 +1,5 @@
+import { HeroFilter } from "../heroes";
+
 export enum EChatScope {
   ALL = 0,
   ALLIES = 1,
@@ -8,4 +10,8 @@ export enum EChatScope {
 export type MapInfo = {
   readonly mapName: string;
   readonly map: string;
+};
+
+export type CommonState = {
+  heroFilters: HeroFilter[];
 };

--- a/src/store/heroes.ts
+++ b/src/store/heroes.ts
@@ -28,7 +28,7 @@ export enum EHeroes {
 }
 
 export type HeroFilter = {
-  id: number;
+  type: number;
   name: string;
 };
 

--- a/src/store/heroes.ts
+++ b/src/store/heroes.ts
@@ -27,6 +27,11 @@ export enum EHeroes {
   WARDEN = "warden",
 }
 
+export type HeroFilter = {
+  id: number;
+  name: string;
+};
+
 export type HeroData = {
   [key: string]: {
     race: ERaceEnum;

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -21,6 +21,7 @@ export const useMatchStore = defineStore("match", {
     sort: "startTimeDescending",
     selectedSeason: {} as Season,
     showHeroIcons: false,
+    selectedHero: "All Heroes",
   }),
   actions: {
     async loadMatches() {
@@ -51,6 +52,7 @@ export const useMatchStore = defineStore("match", {
           this.map,
           this.mmr,
           this.selectedSeason.id,
+          this.selectedHero,
         );
       }
       this.SET_TOTAL_MATCHES(response.count);
@@ -113,6 +115,13 @@ export const useMatchStore = defineStore("match", {
     async setShowHeroIcons(showHeroIcons: boolean) {
       this.SET_SHOW_HERO_ICONS(showHeroIcons);
     },
+
+    async setSelectedHero(hero: string) {
+      this.SET_SELECTED_HERO(hero);
+      this.SET_PAGE(1);
+      await this.loadMatches();
+    },
+
     SET_PAGE(page: number): void {
       this.page = page;
     },
@@ -154,6 +163,8 @@ export const useMatchStore = defineStore("match", {
     },
     SET_SHOW_HERO_ICONS(showHeroIcons: boolean): void {
       this.showHeroIcons = showHeroIcons;
+    SET_SELECTED_HERO(hero: string): void {
+      this.selectedHero = hero;
     },
   },
 });

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -20,6 +20,7 @@ export const useMatchStore = defineStore("match", {
     mmr: { min: 0, max: 3000 } as Mmr,
     sort: "startTimeDescending",
     selectedSeason: {} as Season,
+    showHeroIcons: false,
   }),
   actions: {
     async loadMatches() {
@@ -109,6 +110,9 @@ export const useMatchStore = defineStore("match", {
     async setPlayerScores(playerScores: PlayerScore[]) {
       this.SET_PLAYER_SCORES(playerScores);
     },
+    async setShowHeroIcons(showHeroIcons: boolean) {
+      this.SET_SHOW_HERO_ICONS(showHeroIcons);
+    },
     SET_PAGE(page: number): void {
       this.page = page;
     },
@@ -147,6 +151,9 @@ export const useMatchStore = defineStore("match", {
     },
     SET_SEASON(season: Season): void {
       this.selectedSeason = season;
+    },
+    SET_SHOW_HERO_ICONS(showHeroIcons: boolean): void {
+      this.showHeroIcons = showHeroIcons;
     },
   },
 });

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -21,7 +21,7 @@ export const useMatchStore = defineStore("match", {
     sort: "startTimeDescending",
     selectedSeason: {} as Season,
     showHeroIcons: false,
-    selectedHero: "All Heroes",
+    selectedHeroFilter: -1,
   }),
   actions: {
     async loadMatches() {
@@ -52,7 +52,7 @@ export const useMatchStore = defineStore("match", {
           this.map,
           this.mmr,
           this.selectedSeason.id,
-          this.selectedHero,
+          this.selectedHeroFilter,
         );
       }
       this.SET_TOTAL_MATCHES(response.count);
@@ -116,8 +116,8 @@ export const useMatchStore = defineStore("match", {
       this.SET_SHOW_HERO_ICONS(showHeroIcons);
     },
 
-    async setSelectedHero(hero: string) {
-      this.SET_SELECTED_HERO(hero);
+    async setSelectedHeroFilter(hero: number) {
+      this.SET_SELECTED_HERO_FILTER(hero);
       this.SET_PAGE(1);
       await this.loadMatches();
     },
@@ -163,8 +163,9 @@ export const useMatchStore = defineStore("match", {
     },
     SET_SHOW_HERO_ICONS(showHeroIcons: boolean): void {
       this.showHeroIcons = showHeroIcons;
-    SET_SELECTED_HERO(hero: string): void {
-      this.selectedHero = hero;
+    },
+    SET_SELECTED_HERO_FILTER(hero: number): void {
+      this.selectedHeroFilter = hero;
     },
   },
 });

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -16,7 +16,7 @@ export type MatchState = {
   sort: string;
   selectedSeason: Season;
   showHeroIcons: boolean;
-  selectedHero: string;
+  selectedHeroFilter: number;
 };
 
 export enum MatchStatus {

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -16,6 +16,7 @@ export type MatchState = {
   sort: string;
   selectedSeason: Season;
   showHeroIcons: boolean;
+  selectedHero: string;
 };
 
 export enum MatchStatus {

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -15,6 +15,7 @@ export type MatchState = {
   mmr: Mmr;
   sort: string;
   selectedSeason: Season;
+  showHeroIcons: boolean;
 };
 
 export enum MatchStatus {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -19,6 +19,7 @@ export type PlayerInTeam = {
   location?: string;
   countryCode?: string;
   twitch?: string | null;
+	heroes: Hero[];
 };
 
 export type Team = {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -19,7 +19,7 @@ export type PlayerInTeam = {
   location?: string;
   countryCode?: string;
   twitch?: string | null;
-	heroes: Hero[];
+  heroes: Hero[];
 };
 
 export type Team = {
@@ -81,7 +81,7 @@ export interface UnitScore {
 }
 
 export interface Hero {
-  icon: string;
+  name: string;
   level: number;
 }
 

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -6,7 +6,7 @@
           <v-card-title>
             {{ $t("views_app.matches") }}
           </v-card-title>
-          <v-card-text>
+          <v-card-text class="d-flex align-center">
             <matches-status-select />
             <game-mode-select
               :disabledModes="disabledGameModes"
@@ -17,6 +17,7 @@
             <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
+            <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event" :unfinished="unfinished" />
           </v-card-text>
           <matches-grid
             v-model="matches"
@@ -25,6 +26,7 @@
             :itemsPerPage="50"
             :unfinished="unfinished"
             :is-player-profile="false"
+            :showHeroes="showHeroIcons"
           ></matches-grid>
         </v-card>
       </v-col>
@@ -50,6 +52,8 @@ import { useRankingStore } from "@/store/ranking/store";
 import { useMatchStore } from "@/store/match/store";
 import { MapInfo } from "@/store/common/types";
 import SeasonSelect from "@/components/common/SeasonSelect.vue";
+import { ref } from "vue";
+import HeroIconToggle from "@/components/matches/HeroIconToggle.vue";
 
 export default defineComponent({
   name: "MatchesView",
@@ -61,6 +65,7 @@ export default defineComponent({
     MapSelect,
     MmrSelect,
     SortSelect,
+    HeroIconToggle,
   },
   setup() {
     const overallStatsStore = useOverallStatsStore();
@@ -75,6 +80,8 @@ export default defineComponent({
     const gameMode = computed<EGameMode>(() => matchStore.gameMode);
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
+
+    const showHeroIcons = ref<boolean>(true);
 
     const maps = computed<Array<MapInfo>>(() => {
       if (!currentSeason.value) {
@@ -179,6 +186,7 @@ export default defineComponent({
       matches,
       totalMatches,
       onPageChanged,
+      showHeroIcons,
     };
   },
 });

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -14,7 +14,7 @@
             <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
-            <hero-select v-if="!unfinished" @heroChanged="heroChanged" :hero="hero"></hero-select>
+            <hero-select v-if="!unfinished" @heroChanged="heroChanged"></hero-select>
             <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event"
               :unfinished="unfinished" />
           </v-card-text>
@@ -45,9 +45,7 @@ import { useMatchStore } from "@/store/match/store";
 import { MapInfo } from "@/store/common/types";
 import SeasonSelect from "@/components/common/SeasonSelect.vue";
 import HeroSelect from "@/components/matches/HeroSelect.vue";
-import { ref } from "vue";
 import HeroIconToggle from "@/components/matches/HeroIconToggle.vue";
-import { EHeroes } from "@/store/heroes";
 import { useI18n } from "vue-i18n-bridge";
 
 export default defineComponent({
@@ -80,7 +78,6 @@ export default defineComponent({
     const gameMode = computed<EGameMode>(() => matchStore.gameMode);
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
-    const hero = computed<EHeroes>(() => matchStore.selectedHero);
 
     const showHeroIcons = computed<boolean>(() => matchStore.showHeroIcons);
 
@@ -188,8 +185,8 @@ export default defineComponent({
       matchStore.setShowHeroIcons(showHeroIcons);
     }
 
-    async function heroChanged(hero: string): Promise<void> {
-      await matchStore.setSelectedHero(hero);
+    async function heroChanged(hero: number): Promise<void> {
+      await matchStore.setSelectedHeroFilter(hero);
     }
 
     return {
@@ -208,7 +205,6 @@ export default defineComponent({
       onPageChanged,
       showHeroIcons,
       toggleShowHeroIcons,
-      hero,
       heroChanged,
     };
   },

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -15,7 +15,7 @@
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
             <hero-select v-if="!unfinished" @heroChanged="heroChanged"></hero-select>
-            <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event"
+            <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="toggleShowHeroIcons"
               :unfinished="unfinished" />
           </v-card-text>
           <matches-grid v-model="matches" :totalMatches="totalMatches" @pageChanged="onPageChanged" :itemsPerPage="50"

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -8,8 +8,11 @@
           </v-card-title>
           <v-card-text class="d-flex align-center">
             <matches-status-select />
-            <game-mode-select :disabledModes="disabledGameModes" :gameMode="gameMode"
-              @gameModeChanged="gameModeChanged"></game-mode-select>
+            <game-mode-select
+              :disabledModes="disabledGameModes"
+              :gameMode="gameMode"
+              @gameModeChanged="gameModeChanged"
+            ></game-mode-select>
             <map-select @mapChanged="mapChanged" :mapInfo="maps" :map="map"></map-select>
             <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
@@ -18,8 +21,15 @@
             <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="toggleShowHeroIcons"
               :unfinished="unfinished" />
           </v-card-text>
-          <matches-grid v-model="matches" :totalMatches="totalMatches" @pageChanged="onPageChanged" :itemsPerPage="50"
-            :unfinished="unfinished" :is-player-profile="false" :showHeroes="showHeroIcons"></matches-grid>
+          <matches-grid
+            v-model="matches"
+            :totalMatches="totalMatches"
+            @pageChanged="onPageChanged"
+            :itemsPerPage="50"
+            :unfinished="unfinished"
+            :is-player-profile="false"
+            :show-heroes="showHeroIcons"
+          ></matches-grid>
         </v-card>
       </v-col>
     </v-row>
@@ -72,9 +82,7 @@ export default defineComponent({
     const matches = computed<Match[]>(() => matchStore.matches);
     const totalMatches = computed<number>(() => matchStore.totalMatches);
     const currentSeason = computed<Season>(() => rankingsStore.seasons[0]);
-    const unfinished = computed<boolean>(
-      () => matchStore.status === MatchStatus.onGoing
-    );
+    const unfinished = computed<boolean>(() => matchStore.status === MatchStatus.onGoing);
     const gameMode = computed<EGameMode>(() => matchStore.gameMode);
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
@@ -108,36 +116,25 @@ export default defineComponent({
     const mapsByGameMode = computed<Record<EGameMode, Set<MapInfo>>>(() => {
       const filterSeasons =
         matchStore.status === MatchStatus.onGoing
-          ? (matchesOnMapPerSeason: MatchesOnMapPerSeason) =>
-              matchesOnMapPerSeason.season === currentSeason.value.id
-          : (matchesOnMapPerSeason: MatchesOnMapPerSeason) =>
-              matchesOnMapPerSeason.season >= 0;
+          ? (matchesOnMapPerSeason: MatchesOnMapPerSeason) => matchesOnMapPerSeason.season === currentSeason.value.id
+          : (matchesOnMapPerSeason: MatchesOnMapPerSeason) => matchesOnMapPerSeason.season >= 0;
 
       return overallStatsStore.matchesOnMapPerSeason
         .filter(filterSeasons)
-        .reduce<Record<EGameMode, Set<MapInfo>>>(
-          (mapsByMode, matchesOnMapPerSeason) => {
-            for (const modes of matchesOnMapPerSeason.matchesOnMapPerModes) {
-              // just get the map name and ignore the count
-              const mapsInfos = modes.maps.map(({ map, mapName }) => ({
-                map,
-                mapName,
-              }));
+        .reduce<Record<EGameMode, Set<MapInfo>>>((mapsByMode, matchesOnMapPerSeason) => {
+          for (const modes of matchesOnMapPerSeason.matchesOnMapPerModes) {
+            // just get the map name and ignore the count
+            const mapsInfos = modes.maps.map(({ map, mapName }) => ({ map, mapName }));
 
-              if (!mapsByMode[modes.gameMode]) {
-                mapsByMode[modes.gameMode] = new Set(mapsInfos);
-              } else {
-                // combine this seasons mode maps with other seasons modes maps without dupes
-                mapsByMode[modes.gameMode] = new Set([
-                  ...mapsByMode[modes.gameMode],
-                  ...mapsInfos,
-                ]);
-              }
+            if (!mapsByMode[modes.gameMode]) {
+              mapsByMode[modes.gameMode] = new Set(mapsInfos);
+            } else {
+              // combine this seasons mode maps with other seasons modes maps without dupes
+              mapsByMode[modes.gameMode] = new Set([...mapsByMode[modes.gameMode], ...mapsInfos]);
             }
-            return mapsByMode;
-          },
-          {} as Record<EGameMode, Set<MapInfo>>
-        );
+          }
+          return mapsByMode;
+        }, {} as Record<EGameMode, Set<MapInfo>>);
     });
 
     async function getMatches(): Promise<void> {

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -8,41 +8,18 @@
           </v-card-title>
           <v-card-text class="d-flex align-center">
             <matches-status-select />
-            <game-mode-select
-              :disabledModes="disabledGameModes"
-              :gameMode="gameMode"
-              @gameModeChanged="gameModeChanged"
-            ></game-mode-select>
-            <map-select
-              @mapChanged="mapChanged"
-              :mapInfo="maps"
-              :map="map"
-            ></map-select>
-            <mmr-select
-              v-if="unfinished"
-              @mmrChanged="mmrChanged"
-              :mmr="mmr"
-            ></mmr-select>
+            <game-mode-select :disabledModes="disabledGameModes" :gameMode="gameMode"
+              @gameModeChanged="gameModeChanged"></game-mode-select>
+            <map-select @mapChanged="mapChanged" :mapInfo="maps" :map="map"></map-select>
+            <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
-            <season-select
-              v-if="!unfinished"
-              @seasonSelected="selectSeason"
-            ></season-select>
-            <hero-icon-toggle
-              :showHeroes="showHeroIcons"
-              @update:showHeroes="toggleShowHeroIcons"
-              :unfinished="unfinished"
-            />
+            <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
+            <hero-select v-if="!unfinished" @heroChanged="heroChanged" :hero="hero"></hero-select>
+            <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event"
+              :unfinished="unfinished" />
           </v-card-text>
-          <matches-grid
-            v-model="matches"
-            :totalMatches="totalMatches"
-            @pageChanged="onPageChanged"
-            :itemsPerPage="50"
-            :unfinished="unfinished"
-            :is-player-profile="false"
-            :showHeroes="showHeroIcons"
-          ></matches-grid>
+          <matches-grid v-model="matches" :totalMatches="totalMatches" @pageChanged="onPageChanged" :itemsPerPage="50"
+            :unfinished="unfinished" :is-player-profile="false" :showHeroes="showHeroIcons"></matches-grid>
         </v-card>
       </v-col>
     </v-row>
@@ -67,8 +44,11 @@ import { useRankingStore } from "@/store/ranking/store";
 import { useMatchStore } from "@/store/match/store";
 import { MapInfo } from "@/store/common/types";
 import SeasonSelect from "@/components/common/SeasonSelect.vue";
+import HeroSelect from "@/components/matches/HeroSelect.vue";
 import { ref } from "vue";
 import HeroIconToggle from "@/components/matches/HeroIconToggle.vue";
+import { EHeroes } from "@/store/heroes";
+import { useI18n } from "vue-i18n-bridge";
 
 export default defineComponent({
   name: "MatchesView",
@@ -81,8 +61,11 @@ export default defineComponent({
     MmrSelect,
     SortSelect,
     HeroIconToggle,
+    HeroSelect,
   },
   setup() {
+    const { t } = useI18n();
+
     const overallStatsStore = useOverallStatsStore();
     const rankingsStore = useRankingStore();
     const matchStore = useMatchStore();
@@ -97,6 +80,7 @@ export default defineComponent({
     const gameMode = computed<EGameMode>(() => matchStore.gameMode);
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
+    const hero = computed<EHeroes>(() => matchStore.selectedHero);
 
     const showHeroIcons = computed<boolean>(() => matchStore.showHeroIcons);
 
@@ -196,11 +180,16 @@ export default defineComponent({
     function mmrChanged(mmr: Mmr): void {
       matchStore.setMmr(mmr);
     }
+
     async function selectSeason(season: Season): Promise<void> {
       await matchStore.setSeason(season);
     }
     function toggleShowHeroIcons(showHeroIcons: boolean): void {
       matchStore.setShowHeroIcons(showHeroIcons);
+    }
+
+    async function heroChanged(hero: string): Promise<void> {
+      await matchStore.setSelectedHero(hero);
     }
 
     return {
@@ -219,6 +208,8 @@ export default defineComponent({
       onPageChanged,
       showHeroIcons,
       toggleShowHeroIcons,
+      hero,
+      heroChanged,
     };
   },
 });

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -81,7 +81,7 @@ export default defineComponent({
     const map = computed<string>(() => matchStore.map);
     const mmr = computed<Mmr>(() => matchStore.mmr);
 
-    const showHeroIcons = ref<boolean>(true);
+    const showHeroIcons = ref<boolean>(false);
 
     const maps = computed<Array<MapInfo>>(() => {
       if (!currentSeason.value) {

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -17,7 +17,7 @@
             <mmr-select v-if="unfinished" @mmrChanged="mmrChanged" :mmr="mmr"></mmr-select>
             <sort-select v-if="unfinished"></sort-select>
             <season-select v-if="!unfinished" @seasonSelected="selectSeason"></season-select>
-            <hero-select v-if="!unfinished" @heroChanged="heroChanged"></hero-select>
+            <hero-select v-if="!unfinished && showHeroSelect" @heroChanged="heroChanged"></hero-select>
             <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="toggleShowHeroIcons"
               :unfinished="unfinished" />
           </v-card-text>
@@ -88,9 +88,10 @@ export default defineComponent({
     const mmr = computed<Mmr>(() => matchStore.mmr);
 
     const showHeroIcons = computed<boolean>(() => matchStore.showHeroIcons);
+    const showHeroSelect = computed<boolean>(() => gameMode.value === EGameMode.GM_1ON1 || gameMode.value === EGameMode.GM_1ON1_TOURNAMENT);
 
     const maps = computed<Array<MapInfo>>(() => {
-      if (!currentSeason.value) {
+      if (!currentSeason.value) { 
         return [];
       }
 
@@ -202,6 +203,7 @@ export default defineComponent({
       onPageChanged,
       showHeroIcons,
       toggleShowHeroIcons,
+      showHeroSelect,
       heroChanged,
     };
   },

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -422,19 +422,19 @@ export default defineComponent({
 
   &.one-v-one {
     .live-match__map {
-      top: 33px;
+      top: 40px;
     }
   }
   &.two-v-two-at {
-    height: 67px;
+    height: 95px;
     .live-match__map {
-      top: 65px;
+      top: 90px;
     }
   }
   &.four-v-four {
-    height: 135px;
+    height: 195px;
     .live-match__map {
-      top: 130px;
+      top: 190px;
     }
   }
 }


### PR DESCRIPTION
I'm not a front end dev or capable at all with UI, so there are quite likely issues or obvious improvements that could be made for this. I added the icons, hopefully, in a way that doesn't take up too much space and works okay for the matches grid. I defaulted the icons to be hidden by default, and also to not have the icons show the level as they take up a lot of space.

- `HeroIcon` component updated to have a toggle for displaying level or not as showing the level flag in the matches grid didn't look good as it took up a lot of space. 
- Added `HeroIconRow` component for displaying the hero icons in the Matches view
- Added `HeroIconToggle` component to toggle displaying hero icons and not.
    - Also updated `MatchesGrid` to pass toggle value
    - Defaults to hidden
- Some changes to padding/margins

Image to show what it looks like
![image](https://github.com/user-attachments/assets/eae325fa-9e10-4cfa-8955-90c343b314c0)

