### PR TITLE
Preserve sorting when rankings update

### DIFF
--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -325,9 +325,6 @@ export default defineComponent({
       if (triggerTwitchLookup) {
         getStreamStatus();
       }
-
-      sortedRankings.value = [];
-      sortColumn.value = "Rank";
     }
 
     async function getStreamStatus(): Promise<void> {


### PR DESCRIPTION
From Neo

idk where to put this, but i might have a feature / bugfix request 😅 

when i'm on the homepage https://www.w3champions.com/rankings
and sort by MMR, the sorting resets after x seconds
is that intended or something we can fix?