### PR TITLE
Preserve sorting when rankings update

### DIFF
--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -326,8 +326,9 @@ export default defineComponent({
         getStreamStatus();
       }
 
-      sortedRankings.value = [];
-      sortColumn.value = "Rank";
+      if (sortColumn.value && _lastSortFunction) {
+        sortedRankings.value = isSortedAsc.value ? newVal.sort(_lastSortFunction) : newVal.sort(_lastSortFunction).reverse();
+      }
     }
 
     async function getStreamStatus(): Promise<void> {


### PR DESCRIPTION
Neo:
```
idk where to put this, but i might have a feature / bugfix request 😅 

when i'm on the homepage https://www.w3champions.com/rankings
and sort by MMR, the sorting resets after x seconds
is that intended or something we can fix?
```

In this gif, I have simulated the rankings refresh to happen every 2 seconds, and alternately the data of Happy and Sacha26 are swapped. One can see that the sorting is preserved.

![sort4 gif](https://github.com/user-attachments/assets/8b8a673a-3202-4e3f-b75f-06c1486f2eec)
