### PR TITLE
Plenty of small adjustments

### DIFF
--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -12,11 +12,14 @@
         <tbody>
           <tr v-for="item in sortedStats" :key="item.mapName || item.map">
             <td>{{ item.mapName || item.map }}</td>
-            <player-stats-race-versus-race-on-map-table-cell :stats="totalWins(item.winLosses)" />
-            <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[1]" />
-            <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[2]" />
-            <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[4]" />
-            <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[3]" />
+            <player-stats-race-versus-race-on-map-table-cell
+              :stats="totalWins(item.winLosses)"
+            />
+            <player-stats-race-versus-race-on-map-table-cell
+              v-for="(winLoss, index) in item.winLosses"
+              :key="index"
+              :stats="winLoss"
+            />
           </tr>
         </tbody>
       </template>
@@ -71,13 +74,22 @@ export default defineComponent({
       };
     }
 
-    // Sort the maps by total games played, descending.
     const sortedStats = computed(() => {
-      return [...props.stats].sort((a, b) => {
-        const totalGamesA = a.winLosses.reduce((sum, current) => sum + current.games, 0);
-        const totalGamesB = b.winLosses.reduce((sum, current) => sum + current.games, 0);
-        return totalGamesB - totalGamesA;
-      });
+      return [...props.stats]
+        // Sort the maps by total games played, descending.
+        .sort((a, b) => {
+          const totalGamesA = a.winLosses.reduce((sum, current) => sum + current.games, 0);
+          const totalGamesB = b.winLosses.reduce((sum, current) => sum + current.games, 0);
+          return totalGamesB - totalGamesA;
+        })
+        .map((stat) => ({
+          ...stat,
+          winLosses: [...stat.winLosses]
+            // Remove RANDOM race
+            .filter((winLoss) => winLoss.race !== ERaceEnum.RANDOM)
+            // Sort winLosses by race for consistent ordering
+            .sort((a, b) => a.race - b.race),
+        }));
     });
 
     const headers: RaceToMapStatHeader[] = [

--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -39,6 +39,7 @@ interface RaceToMapStatHeader {
   text: TranslateResult;
   sortable: boolean;
   width: string;
+  align?: 'left' | 'center' | 'right';
 }
 
 export default defineComponent({
@@ -89,26 +90,31 @@ export default defineComponent({
         text: t("components_overall-statistics_racetomapstat.total"),
         sortable: false,
         width: "25px",
+        align: "right",
       },
       {
         text: t("components_overall-statistics_racetomapstat.vshu"),
         sortable: false,
         width: "25px",
+        align: "right",
       },
       {
         text: t("components_overall-statistics_racetomapstat.vsorc"),
         sortable: false,
         width: "25px",
+        align: "right",
       },
       {
         text: t("components_overall-statistics_racetomapstat.vsne"),
         sortable: false,
         width: "25px",
+        align: "right",
       },
       {
         text: t("components_overall-statistics_racetomapstat.vsud"),
         sortable: false,
         width: "25px",
+        align: "right",
       },
     ];
 

--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -2,7 +2,7 @@
   <div>
     <v-data-table
       :headers="headers"
-      :items="stats"
+      :items="sortedStats"
       :items-per-page="-1"
       hide-default-footer
       :mobile-breakpoint="400"
@@ -10,7 +10,7 @@
     >
       <template v-slot:body>
         <tbody>
-          <tr v-for="item in stats" :key="item.mapName || item.map">
+          <tr v-for="item in sortedStats" :key="item.mapName || item.map">
             <td>{{ item.mapName || item.map }}</td>
             <player-stats-race-versus-race-on-map-table-cell :stats="totalWins(item.winLosses)" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[1]" />
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { TranslateResult } from "vue-i18n";
 import { RaceStat, WinLossesOnMap } from "@/store/player/types";
@@ -52,7 +52,7 @@ export default defineComponent({
       required: true,
     },
   },
-  setup() {
+  setup(props) {
     const { t } = useI18n();
 
     function totalWins(stat: RaceStat[]) {
@@ -69,6 +69,15 @@ export default defineComponent({
         race: ERaceEnum.TOTAL,
       };
     }
+
+    // Sort the maps by total games played, descending.
+    const sortedStats = computed(() => {
+      return [...props.stats].sort((a, b) => {
+        const totalGamesA = a.winLosses.reduce((sum, current) => sum + current.games, 0);
+        const totalGamesB = b.winLosses.reduce((sum, current) => sum + current.games, 0);
+        return totalGamesB - totalGamesA;
+      });
+    });
 
     const headers: RaceToMapStatHeader[] = [
       {
@@ -106,6 +115,7 @@ export default defineComponent({
     return {
       headers,
       totalWins,
+      sortedStats,
     };
   },
 });

--- a/src/components/overall-statistics/RaceToMapStat.vue
+++ b/src/components/overall-statistics/RaceToMapStat.vue
@@ -12,11 +12,11 @@
         <tbody>
           <tr v-for="item in stats" :key="item.mapName || item.map">
             <td>{{ item.mapName || item.map }}</td>
+            <player-stats-race-versus-race-on-map-table-cell :stats="totalWins(item.winLosses)" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[1]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[2]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[4]" />
             <player-stats-race-versus-race-on-map-table-cell :stats="item.winLosses[3]" />
-            <player-stats-race-versus-race-on-map-table-cell :stats="totalWins(item.winLosses)" />
           </tr>
         </tbody>
       </template>
@@ -77,6 +77,11 @@ export default defineComponent({
         width: "25px",
       },
       {
+        text: t("components_overall-statistics_racetomapstat.total"),
+        sortable: false,
+        width: "25px",
+      },
+      {
         text: t("components_overall-statistics_racetomapstat.vshu"),
         sortable: false,
         width: "25px",
@@ -93,11 +98,6 @@ export default defineComponent({
       },
       {
         text: t("components_overall-statistics_racetomapstat.vsud"),
-        sortable: false,
-        width: "25px",
-      },
-      {
-        text: t("components_overall-statistics_racetomapstat.total"),
         sortable: false,
         width: "25px",
       },

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -57,13 +57,13 @@
                     :lossThreshold="0.49"
                   />
                   <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[3]"
+                    :stats="item.winLosses[4]"
                     :compareRace="item.race"
                     :winThreshold="0.51"
                     :lossThreshold="0.49"
                   />
                   <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[4]"
+                    :stats="item.winLosses[3]"
                     :compareRace="item.race"
                     :winThreshold="0.51"
                     :lossThreshold="0.49"
@@ -126,11 +126,11 @@ export default defineComponent({
         sortable: false,
       },
       {
-        text: t("components_overall-statistics_tabs_winratestab.vsud"),
+        text: t("components_overall-statistics_tabs_winratestab.vsne"),
         sortable: false,
       },
       {
-        text: t("components_overall-statistics_tabs_winratestab.vsne"),
+        text: t("components_overall-statistics_tabs_winratestab.vsud"),
         sortable: false,
       },
       {
@@ -172,7 +172,10 @@ export default defineComponent({
 
       if (!statsPerMapAndRace) return [];
 
-      return statsPerMapAndRace.ratio.slice(1, 5).concat(statsPerMapAndRace.ratio[0]);
+      return statsPerMapAndRace.ratio
+        .slice(1, 5)
+        .sort((a, b) => a.race - b.race)
+        .concat(statsPerMapAndRace.ratio[0]);
     });
 
     const patches = computed<string[]>(() => {

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -45,31 +45,9 @@
                 <tr v-for="item in items" :key="item.race">
                   <td>{{ $t("races." + raceEnums[item.race]) }}</td>
                   <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[1]"
-                    :compareRace="item.race"
-                    :winThreshold="0.51"
-                    :lossThreshold="0.49"
-                  />
-                  <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[2]"
-                    :compareRace="item.race"
-                    :winThreshold="0.51"
-                    :lossThreshold="0.49"
-                  />
-                  <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[4]"
-                    :compareRace="item.race"
-                    :winThreshold="0.51"
-                    :lossThreshold="0.49"
-                  />
-                  <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[3]"
-                    :compareRace="item.race"
-                    :winThreshold="0.51"
-                    :lossThreshold="0.49"
-                  />
-                  <player-stats-race-versus-race-on-map-table-cell
-                    :stats="item.winLosses[0]"
+                    v-for="(winloss, index) in item.winLosses"
+                    :key="index"
+                    :stats="winloss"
                     :compareRace="item.race"
                     :winThreshold="0.51"
                     :lossThreshold="0.49"
@@ -165,6 +143,12 @@ export default defineComponent({
       });
     });
 
+    const sortByRaceWithRandomLast = (a: { race: ERaceEnum }, b: { race: ERaceEnum }): number => {
+      if (a.race === ERaceEnum.RANDOM) return 1;
+      if (b.race === ERaceEnum.RANDOM) return -1;
+      return a.race - b.race;
+    };
+
     const raceWinrate = computed<Ratio[]>(() => {
       if (!statsPerRaceAndMap.value || !statsPerRaceAndMap.value[0] || !statsPerRaceAndMap.value[0].patchToStatsPerModes[selectedPatch.value]) {
         return [];
@@ -178,10 +162,10 @@ export default defineComponent({
 
       if (!statsPerMapAndRace) return [];
 
+      // Sort both the rows and columns by race.
       return statsPerMapAndRace.ratio
-        .slice(1, 5)
-        .sort((a, b) => a.race - b.race)
-        .concat(statsPerMapAndRace.ratio[0]);
+        .sort(sortByRaceWithRandomLast)
+        .map((item) => ({ ...item, winLosses: [...item.winLosses].sort(sortByRaceWithRandomLast) }));
     });
 
     const patches = computed<string[]>(() => {

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -96,6 +96,7 @@ import { useOverallStatsStore } from "@/store/overallStats/store";
 interface WinratesTabHeader {
   text: TranslateResult;
   sortable: boolean;
+  align?: 'left' | 'center' | 'right';
 }
 
 export default defineComponent({
@@ -120,22 +121,27 @@ export default defineComponent({
       {
         text: t("components_overall-statistics_tabs_winratestab.vshu"),
         sortable: false,
+        align: "right",
       },
       {
         text: t("components_overall-statistics_tabs_winratestab.vsorc"),
         sortable: false,
+        align: "right",
       },
       {
         text: t("components_overall-statistics_tabs_winratestab.vsne"),
         sortable: false,
+        align: "right",
       },
       {
         text: t("components_overall-statistics_tabs_winratestab.vsud"),
         sortable: false,
+        align: "right",
       },
       {
         text: t("components_overall-statistics_tabs_winratestab.vsrdm"),
         sortable: false,
+        align: "right",
       },
     ];
 

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -325,7 +325,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from "vue";
+import { computed, defineComponent, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n-bridge";
 import { ERaceEnum, EAvatarCategory } from "@/store/types";
 import { ECountries } from "@/store/countries";
@@ -334,6 +334,7 @@ import PlayerSocials from "./PlayerSocials.vue";
 import { getAvatarUrl } from "@/helpers/url-functions";
 import { enumKeys } from "@/helpers/general";
 import { usePersonalSettingsStore } from "@/store/personalSettings/store";
+import { usePlayerStore } from "@/store/player/store";
 import { mdiAccountCheck, mdiFlag, mdiHome, mdiPencil, mdiTwitch, mdiTwitter, mdiYoutube } from "@mdi/js";
 import { useRouter } from "vue-router/composables";
 import { CountryType } from "@/store/ranking/types";
@@ -357,6 +358,7 @@ export default defineComponent({
     const { t } = useI18n();
     const router = useRouter();
     const personalSettingsStore = usePersonalSettingsStore();
+    const playerStore = usePlayerStore();
     const races = [ERaceEnum.HUMAN, ERaceEnum.ORC, ERaceEnum.NIGHT_ELF, ERaceEnum.UNDEAD, ERaceEnum.RANDOM, ERaceEnum.TOTAL];
     const countries = ref<CountryType[]>([]);
     const iconsDialogOpened = ref<boolean>(false);
@@ -557,6 +559,16 @@ export default defineComponent({
     onMounted((): void => {
       init();
     });
+
+    // Watch for battleTag changes and reload personal settings
+    watch(
+      () => playerStore.battleTag,
+      (newBattleTag, oldBattleTag) => {
+        if (newBattleTag && newBattleTag !== oldBattleTag) {
+          init();
+        }
+      }
+    );
 
     async function init() {
       await personalSettingsStore.loadPersonalSetting();

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -29,6 +29,7 @@
     </v-simple-table>
 
     <v-pagination
+      v-if="pageLength > 1"
       v-model="page"
       :length="pageLength"
       :prev-icon="mdiMenuLeft"
@@ -54,7 +55,7 @@ export default defineComponent({
   },
   setup(props) {
     const page = ref<number>(1);
-    const paginationSize = 10;
+    const paginationSize = 16;
 
     const pageOffset = computed<number>(() => paginationSize * page.value);
     const pageLength = computed<number>(() => Math.ceil(props.heroStatistics.length / paginationSize));

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -67,8 +67,8 @@ export default defineComponent({
       { text: "Total", value: "total" },
       { text: "vs. Human", value: "hu" },
       { text: "vs. Orc", value: "orc" },
-      { text: "vs. Undead", value: "ud" },
       { text: "vs. Night Elf", value: "ne" },
+      { text: "vs. Undead", value: "ud" },
       { text: "vs. Random", value: "rand" },
     ] satisfies { text: string; value: keyof PlayerHeroStatistic }[];
 

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -4,7 +4,11 @@
       <template v-slot:default>
         <thead>
           <tr>
-            <th v-for="header in headers" :key="header.value" class="text-left">
+            <th
+              v-for="header in headers"
+              :key="header.value"
+              :class="`text-${header.align}`"
+            >
               {{ header.text }}
             </th>
           </tr>
@@ -15,7 +19,7 @@
             <td v-html="item.name"></td>
             <v-tooltip v-for="header in headersWithoutImageAndName" :key="header.value" top>
               <template v-slot:activator="{ on }">
-                <td v-on="on" v-html="item[header.value]"></td>
+                <td v-on="on" v-html="item[header.value]" class="text-right"></td>
               </template>
               <div v-if="item.numbers_by_race[header.value]">
                 {{ $t("components_player_playeravatar.games") }} {{ item.numbers_by_race[header.value].number }}
@@ -62,15 +66,15 @@ export default defineComponent({
     const heroStatsCurrentPage = computed<PlayerHeroStatistic[]>(() => props.heroStatistics.slice((pageOffset.value - paginationSize), pageOffset.value));
 
     const headers = [
-      { text: "", value: "image" },
-      { text: "Hero", value: "name" },
-      { text: "Total", value: "total" },
-      { text: "vs. Human", value: "hu" },
-      { text: "vs. Orc", value: "orc" },
-      { text: "vs. Night Elf", value: "ne" },
-      { text: "vs. Undead", value: "ud" },
-      { text: "vs. Random", value: "rand" },
-    ] satisfies { text: string; value: keyof PlayerHeroStatistic }[];
+      { text: "", value: "image", align: "left" },
+      { text: "Hero", value: "name", align: "left" },
+      { text: "Total", value: "total", align: "right" },
+      { text: "vs. Human", value: "hu", align: "right" },
+      { text: "vs. Orc", value: "orc", align: "right" },
+      { text: "vs. Night Elf", value: "ne", align: "right" },
+      { text: "vs. Undead", value: "ud", align: "right" },
+      { text: "vs. Random", value: "rand", align: "right" },
+    ] satisfies { text: string; value: keyof PlayerHeroStatistic; align: 'left' | 'right' }[];
 
     const headersWithoutImageAndName = headers.slice(2) as { text: string; value: keyof NumbersByPlayerHeroStatistic }[];
 

--- a/src/components/player/PlayerHeroStatisticsTable.vue
+++ b/src/components/player/PlayerHeroStatisticsTable.vue
@@ -18,7 +18,9 @@
                 <td v-on="on" v-html="item[header.value]"></td>
               </template>
               <div v-if="item.numbers_by_race[header.value]">
-                {{ item.numbers_by_race[header.value].number }}/{{ item.numbers_by_race[header.value].total }}
+                {{ $t("components_player_playeravatar.games") }} {{ item.numbers_by_race[header.value].number }}
+                &nbsp;&nbsp;
+                {{ $t("common.total") }} <span class="number-text">{{ item.numbers_by_race[header.value].total }}</span>
               </div>
             </v-tooltip>
           </tr>

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -109,8 +109,8 @@ export default defineComponent({
       { text: "Total", value: ERaceEnum.TOTAL },
       { text: "vs. Human", value: ERaceEnum.HUMAN },
       { text: "vs. Orc", value: ERaceEnum.ORC },
-      { text: "vs. Undead", value: ERaceEnum.UNDEAD },
       { text: "vs. Night Elf", value: ERaceEnum.NIGHT_ELF },
+      { text: "vs. Undead", value: ERaceEnum.UNDEAD },
       { text: "vs. Random", value: ERaceEnum.RANDOM },
     ];
 

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -44,6 +44,7 @@
               </v-simple-table>
 
               <v-pagination
+                v-if="pageLength > 1"
                 v-model="page"
                 :length="pageLength"
                 :prev-icon="mdiMenuLeft"
@@ -87,7 +88,7 @@ export default defineComponent({
   setup(props) {
     const { t } = useI18n();
     const playerStore = usePlayerStore();
-    const paginationSize = 10;
+    const paginationSize = 16;
     const page = ref<number>(1);
     const selectedRace = computed(() => Number(selectedTab.value.split("-")[1]));
     const pageOffset = computed(() => paginationSize * page.value);

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -17,7 +17,7 @@
                 <template v-slot:default>
                   <thead>
                     <tr>
-                      <th v-for="header in headers" :key="header.value" class="text-left">
+                      <th v-for="header in headers" :key="header.value" :class="`text-${header.align}`">
                         {{ header.text }}
                       </th>
                     </tr>
@@ -28,7 +28,7 @@
                       <td v-html="item.name"></td>
                       <v-tooltip v-for="header in headersWithoutImageAndName" :key="header.value" top>
                         <template v-slot:activator="{ on }">
-                          <td v-on="on" v-html="item[header.value]"></td>
+                          <td v-on="on" :class="[...getWinRateClass(item, header.value), 'text-right']" v-html="item[header.value]"></td>
                         </template>
                         <div v-if="item.numbers_by_race[header.value]">
                           <span class="number-text won">{{ item.numbers_by_race[header.value].number }}W</span>
@@ -84,6 +84,16 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    winThreshold: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
+    lossThreshold: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
   },
   setup(props) {
     const { t } = useI18n();
@@ -103,18 +113,38 @@ export default defineComponent({
         }
     );
 
+    function getWinRateClass(heroStats: PlayerHeroWinRateForStatisticsTab, raceEnum: ERaceEnum): string[] {
+      const classes: string[] = [];
+      const raceStats = heroStats.numbers_by_race[raceEnum];
+
+      if (!raceStats || raceStats.total === 0) {
+        classes.push("stats-empty");
+        return classes;
+      }
+
+      const winrate = raceStats.number / raceStats.total;
+      if (winrate > (props.winThreshold || 0.6)) {
+        classes.push("won");
+      }
+      if (winrate < (props.lossThreshold || 0.4)) {
+        classes.push("lost");
+      }
+
+      return classes;
+    }
+
     const headers = [
-      { text: "", value: "image" },
-      { text: "Hero", value: "name" },
-      { text: "Total", value: ERaceEnum.TOTAL },
-      { text: "vs. Human", value: ERaceEnum.HUMAN },
-      { text: "vs. Orc", value: ERaceEnum.ORC },
-      { text: "vs. Night Elf", value: ERaceEnum.NIGHT_ELF },
-      { text: "vs. Undead", value: ERaceEnum.UNDEAD },
-      { text: "vs. Random", value: ERaceEnum.RANDOM },
+      { text: "", value: "image", align: "left" },
+      { text: "Hero", value: "name", align: "left" },
+      { text: "Total", value: ERaceEnum.TOTAL, align: "right" },
+      { text: "vs. Human", value: ERaceEnum.HUMAN, align: "right" },
+      { text: "vs. Orc", value: ERaceEnum.ORC, align: "right" },
+      { text: "vs. Night Elf", value: ERaceEnum.NIGHT_ELF, align: "right" },
+      { text: "vs. Undead", value: ERaceEnum.UNDEAD, align: "right" },
+      { text: "vs. Random", value: ERaceEnum.RANDOM, align: "right" },
     ];
 
-    const headersWithoutImageAndName = headers.slice(2) as { text: string; value: ERaceEnum }[];
+    const headersWithoutImageAndName = headers.slice(2) as { text: string; value: ERaceEnum; align: 'left' | 'center' | 'right' }[];
 
     function getImageForTable(heroId: string): string {
       const src: string = getAsset(`heroes/${heroId}.png`);
@@ -203,6 +233,7 @@ export default defineComponent({
       headersWithoutImageAndName,
       page,
       pageLength,
+      getWinRateClass,
     };
   },
 });

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -31,7 +31,11 @@
                           <td v-on="on" v-html="item[header.value]"></td>
                         </template>
                         <div v-if="item.numbers_by_race[header.value]">
-                          {{ item.numbers_by_race[header.value].number }}/{{ item.numbers_by_race[header.value].total }}
+                          <span class="number-text won">{{ item.numbers_by_race[header.value].number }}W</span>
+                          -
+                          <span class="number-text lost">{{ item.numbers_by_race[header.value].total - item.numbers_by_race[header.value].number }}L</span>
+                          &nbsp;&nbsp;
+                          {{ $t("common.total") }} <span class="number-text">{{ item.numbers_by_race[header.value].total }}</span>
                         </div>
                       </v-tooltip>
                     </tr>

--- a/src/components/player/PlayerHeroWinRate.vue
+++ b/src/components/player/PlayerHeroWinRate.vue
@@ -189,7 +189,7 @@ export default defineComponent({
         };
         resp.push(playerWinRate);
       }) || [];
-      return resp;
+      return resp.sort((a, b) => b.numbers_by_race[ERaceEnum.TOTAL].total - a.numbers_by_race[ERaceEnum.TOTAL].total);
     }
 
     return {

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -49,7 +49,7 @@ export default defineComponent({
             beginAtZero: false,
             title: {
               display: true,
-              text: "RP",
+              text: "Level",
             },
           },
         },
@@ -77,7 +77,7 @@ export default defineComponent({
           },
           {
             yAxisID: "y1",
-            label: "RP",
+            label: "Level",
             data: rpValues.value,
             borderColor: "rgb(150, 80, 100)",
             fill: true,

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -1,14 +1,14 @@
 <template>
   <v-tabs v-model="selectedTab" v-if="!isStatsEmpty">
     <v-tabs-slider></v-tabs-slider>
-    <v-tab v-for="stat of stats" :key="stat.race" :href="`#tab-${stat.race}`">
+    <v-tab v-for="stat of sortedStats" :key="stat.race" :href="`#tab-${stat.race}`">
       <span v-if="stat.race === ERaceEnum.TOTAL">
         {{ $t("common.allraces") }}
       </span>
       <race-icon v-else :race="stat.race" />
     </v-tab>
 
-    <v-tab-item v-for="stat of stats" :key="stat.race" :value="'tab-' + stat.race">
+    <v-tab-item v-for="stat of sortedStats" :key="stat.race" :value="'tab-' + stat.race">
       <v-card-text>
         <v-row>
           <v-col cols="md-12">
@@ -49,10 +49,17 @@ export default defineComponent({
 
     const selectedTab = computed(() => defaultStatsTab(props.stats));
 
+    // Sort by race, so that the tabs are in the correct order.
+    const sortedStats = computed(() => {
+      if (!props.stats) return [];
+      return [...props.stats].sort((a, b) => a.race - b.race);
+    });
+
     return {
       ERaceEnum,
       selectedTab,
       isStatsEmpty,
+      sortedStats,
     };
   },
 });

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -6,7 +6,11 @@
       </td>
     </template>
     <div>
-      {{ stats.wins }} - {{ stats.losses }}
+      <span class="number-text won">{{ stats.wins }}W</span>
+      -
+      <span class="number-text lost">{{ stats.losses }}L</span>
+      &nbsp;&nbsp;
+      {{ $t("common.total") }} <span class="number-text">{{ stats.games }}</span>
     </div>
   </v-tooltip>
 </template>

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -1,7 +1,7 @@
 <template>
   <v-tooltip top>
     <template v-slot:activator="{ on }">
-      <td v-on="on" class="number-text" :class="toWinClass">
+      <td v-on="on" class="number-text text-right" :class="toWinClass">
         {{ toWinText }}
       </td>
     </template>
@@ -88,9 +88,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style lang="scss" scoped>
-.stats-empty {
-  padding-left: 30px;
-}
-</style>

--- a/src/components/player/RecentPerformance.vue
+++ b/src/components/player/RecentPerformance.vue
@@ -3,15 +3,17 @@
     <h5 class="recent-performance__title">
       {{ $t("components_player_recentperformance.recentperformance") }}
     </h5>
-    <ul class="recent-performance__results">
-      <li v-for="(resultSymbol, index) in lastTenMatchesPerformance" :key="resultSymbol + index">
-        <v-chip color="transparent" :title="resultSymbol === 'W' ? 'Win' : 'Loss'" label style="padding: 0">
-          <v-icon class="sword-icon" :color="resultSymbol === 'W' ? 'green' : 'red'">
-            {{ mdiShieldSwordOutline }}
-          </v-icon>
-        </v-chip>
-      </li>
-    </ul>
+    <div class="recent-performance__results-wrapper">
+      <ul :class="{ 'recent-performance__results': true, 'enough-items': lastTenMatchesPerformance.length > 1 }">
+        <li v-for="(resultSymbol, index) in lastTenMatchesPerformance.slice().reverse()" :key="resultSymbol + index">
+          <v-chip color="transparent" :title="resultSymbol === 'W' ? 'Win' : 'Loss'" label style="padding: 0">
+            <v-icon class="sword-icon" :color="resultSymbol === 'W' ? 'green' : 'red'">
+              {{ mdiShieldSwordOutline }}
+            </v-icon>
+          </v-chip>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -49,11 +51,40 @@ export default defineComponent({
     text-align: center;
   }
 
-  &__results {
+  &__results-wrapper {
     display: flex;
     justify-content: center;
-    padding: 0;
+  }
+
+  &__results {
+    position: relative;
+    padding: 0 0 5px 0;
+    display: flex;
+    justify-content: center;
     list-style-type: none;
+    width: fit-content;
+
+    &.enough-items {
+      mask-image: linear-gradient(to left, black 70%, rgba(0, 0, 0, 0.4));
+      mask-size: 100% 100%;
+      mask-repeat: no-repeat;
+    }
+
+    &.enough-items::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 4px;
+      background: linear-gradient(
+        to left,
+        color-mix(in srgb, var(--v-primary-base) 70%, transparent) 70%,
+        color-mix(in srgb, var(--v-primary-base) 20%, transparent)
+      );
+      pointer-events: none;
+      border-radius: 4px;
+    }
   }
 }
 </style>

--- a/src/scss/dark/index.scss
+++ b/src/scss/dark/index.scss
@@ -28,5 +28,17 @@
     .v-btn {
       color: rgb(255, 212, 40);
     }
+
+    .v-tooltip__content {
+      background-color: var(--v-w3-race-bg-lighten2);
+      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+      &.menuable__content__active {
+        opacity: 1;
+      }
+    }
+
+    .v-pagination .v-pagination__item--active {
+      color: rgba(0, 0, 0, 0.87);
+    }
   }
 }

--- a/src/scss/light/index.scss
+++ b/src/scss/light/index.scss
@@ -7,4 +7,15 @@
       border-bottom: thin solid rgba(0, 0, 0, 0.12);
     }
   }
+
+  &.v-application {
+    .v-tooltip__content {
+      background-color: var(--v-w3-race-bg-lighten1);
+      color: var(--v-secondary-darken1);
+      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+      &.menuable__content__active {
+        opacity: 1;
+      }
+    }
+  }
 }

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -30,4 +30,4 @@ $material-dark: (
     'toolbar': var(--v-w3-race-bg-base),
     'app-bar': var(--w3-bg-glass),
     'navigation-drawer': var(--w3-bg-glass),
-)
+);

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -48,7 +48,7 @@
             <div class="live-match__indicator">
               Live
               <span class="circle red blinker"></span>
-              <span class="live-match__duration">{{ getDuration(ongoingMatch) }}'</span>
+              <span class="live-match__duration">{{ getDuration(ongoingMatch) }}</span>
             </div>
             <div v-if="!isOngoingMatchFFA">
               <div class="live-match__team1">
@@ -197,12 +197,17 @@ export default defineComponent({
       return "";
     });
 
-    function getDuration(match: Match): number {
-      const today = new Date();
-      const diffMs = today.getTime() - new Date(match.startTime.toString()).getTime(); // milliseconds between now & Christmas
-      const diffMins = Math.round(((diffMs % 86400000) % 3600000) / 60000); // minutes
+    function getDuration(match: Match): string {
+      const now = new Date();
+      const start = new Date(match.startTime.toString());
+      const diffMs = now.getTime() - start.getTime();
 
-      return diffMins;
+      const totalMinutes = Math.floor(diffMs / 60000);
+      const hours = Math.floor(totalMinutes / 60);
+      const minutes = totalMinutes % 60;
+
+      if (hours > 0) return `${hours}h ${minutes}m`;
+      return `${minutes}m`;
     }
 
     function getPlayerTeam(match: Match): Team | undefined {
@@ -418,6 +423,7 @@ export default defineComponent({
   .live-match__duration {
     position: absolute;
     left: 44px;
+    width: 70px;
   }
 
   &.one-v-one {


### PR DESCRIPTION
- `RP` -> `Level` in the MMR graph for consistency elsewhere (people are generally confused by the term RP)

![image](https://github.com/user-attachments/assets/661d6451-9f6d-4bd3-93a2-ee5cc7b50351)


- Updated the last 10 games display to match the launcher's; reversed the order to have newest on the right, fadeout on the left with the bar indicator.

Before & After
![image](https://github.com/user-attachments/assets/626281d3-1287-44f2-9b9a-6a7c05741831) 
![image](https://github.com/user-attachments/assets/852f7991-bc93-45cf-a3e6-51643a19c881)

On human/orc themes:
![image](https://github.com/user-attachments/assets/3488e353-ff4d-4cde-bb3f-1fee31f55399)
![image](https://github.com/user-attachments/assets/b221893d-c08f-4121-b7e2-8930af157b41)


- Overrode the tooltip styles, no longer has transparency, has themed BG colors and contrast appropriate text color. Makes it possible to use green/red color in the tooltip without it looking bad.

Before & After human
![image](https://github.com/user-attachments/assets/6ff7b356-3bfb-4934-b666-4177c27c0294)
![image](https://github.com/user-attachments/assets/d6d4884e-d557-4635-ba15-73cbb466538f)

Before & After orc
![image](https://github.com/user-attachments/assets/e0e2a6d2-a25a-47a7-8b1d-6514c09188cc)
![image](https://github.com/user-attachments/assets/0ad7dc2b-5676-4f4b-826c-bccbb66ac15e)

Before & After night elf
![image](https://github.com/user-attachments/assets/914d9f25-e471-473b-9f0d-1a52284c4a0b)
![image](https://github.com/user-attachments/assets/98dd5f8d-a3e4-4cff-bb92-c8529a303438)

Before & After undead
![image](https://github.com/user-attachments/assets/ecfa60d8-5de1-4780-9d28-3a81ea0369f6)
![image](https://github.com/user-attachments/assets/ccf327bc-d1df-4dcc-ab7f-bb542fa48008)

Elsewhere with no colored text
![image](https://github.com/user-attachments/assets/dd999766-5786-4e75-84a6-64c474c2b890)
![image](https://github.com/user-attachments/assets/16eb9993-acf3-4d2e-9489-c4e78edaa748)


- Improved map/hero stats tooltips with `win - loss  total:` across the board (instead of W-L and W/T), with green/red color.

![image](https://github.com/user-attachments/assets/e811a9e5-b702-4b3d-b21c-e3b005b7e847)

![image](https://github.com/user-attachments/assets/11f377d7-5f35-4247-b7a9-bf330b501351)

- Increase page size for heroes to fit all standard heroes instead of having like only 1-2 heroes on the second page, also hide pagination when there's only one page (showing the pagination buttons which aren't interactible isn't useful)

- Normalized the column and tab ordering across the board so that it's in order Total > Human > Orc > Night Elf > Undead > Random. It wasn't consistent which looked odd.
- Sorted hero win rates table by most played heroes, sort maps by most played.
- Right aligned all the number columns so that the % symbols and decimals all line up.

![image](https://github.com/user-attachments/assets/505957a6-e26a-4e08-9895-d2e13f273e90)


- Added W/L colors for hero winrates table, like the maps table.

![image](https://github.com/user-attachments/assets/7cfd770e-8aee-498a-a0e4-4d61bcc84797)


- Show hours for ongoing matches on the profile page (was only showing the minutes modulo 60, so it chopped off the hours part for long matches).

Before & After (before shot taken 2 minutes later lol)
![image](https://github.com/user-attachments/assets/c48ed305-7abf-4b43-8ca3-d7234bec50e2)
![image](https://github.com/user-attachments/assets/8da7894d-bce7-4685-83a5-c780a4a493d3)

- Fix a significant bug with the profile page not updating the profile pic/games/socials when switching players (e.g. via search or via match history).