### PR TITLE
fix CSS aliases rank display

### DIFF
--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -535,7 +535,8 @@ export default defineComponent({
 .rank-icon-container {
   display: flex;
   align-items: center;
-  width: 50%;
+  /*width: 50%;*/
+  /* fix aliases display */
   margin-left: 0 !important;
   min-height: 39px;
 }


### PR DESCRIPTION
Before
<img width="739" height="686" alt="image" src="https://github.com/user-attachments/assets/0a144d0f-1851-4f55-8715-039198f21074" />


After
<img width="777" height="751" alt="image" src="https://github.com/user-attachments/assets/46f5759b-f63d-4208-8e1a-e71168a4bfd4" />
