### PR TITLE
Rename Europe gateway to Global

### DIFF
--- a/public/assets/flags/global.svg
+++ b/public/assets/flags/global.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="svg8" version="1.1" viewBox="0 0 256 256" height="256" width="256">
+  <g id="layer1">
+    <g id="g839">
+      <circle style="opacity:1;fill:#0000cc;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" r="128" cy="128" cx="128" id="path10"/>
+      <g id="g828">
+        <circle r="102" cy="128" cx="128" id="path10" style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        <path d="m 61,197 a 133,133 0 0 1 133,0" id="path823-1" style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+        <path d="m 195,59 a 133,133 0 0 1 -133,0" id="path823" style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+        <path d="M 128,230 A 127,127 0 0 1 77,128 A 127,127 0 0 1 128,27" id="path4522-9-4" style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        <path id="path833-7" d="M 128,27 V 230" style="opacity:1;fill:none;stroke:#ffffff;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        <path id="path833" d="M 26,128 H 230" style="opacity:1;fill:none;stroke:#ffffff;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        <path d="M 128,230 A 127,127 0 0 0 179,128 A 127,127 0 0 0 128,27" id="path4522-9-4-1" style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/components/common/SignInDialog.vue
+++ b/src/components/common/SignInDialog.vue
@@ -18,7 +18,7 @@
                 max-width="48"
                 min-height="32"
                 max-height="48"
-                :src="`/assets/flags/${gateway.id}.svg`"
+                :src="gateway.image"
               />
             </v-col>
             <v-col cols="2" align-self="center">
@@ -64,13 +64,15 @@ export default defineComponent({
     const gateways = [
       {
         id: BnetOAuthRegion.eu,
-        name: t("gatewayNames.Europe"),
+        name: t("gatewayNames.Global"),
         uri: "https://eu.battle.net",
+        image: "/assets/flags/global.svg",
       },
       {
         id: BnetOAuthRegion.cn,
         name: t("gatewayNames.China"),
         uri: "https://www.battlenet.com.cn",
+        image: "/assets/flags/cn.svg",
       },
     ];
 

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -529,6 +529,7 @@ const data = {
       GM_MINIDOTA_3ON3_AT: "MiniDota 3v3 AT",
     },
     gatewayNames: {
+      Global: "Global",
       Europe: "Europe",
       America: "America",
     },
@@ -1051,6 +1052,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "Глобальный",
       Europe: "Европа",
       America: "Америка",
     },
@@ -1507,6 +1509,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "글로벌",
       Europe: "유럽",
       America: "북미",
     },
@@ -2025,6 +2028,7 @@ const data = {
       GM_DOTA_5ON5_AT: "Dota 5v5 AT",
     },
     gatewayNames: {
+      Global: "全球",
       Europe: "欧洲",
       America: "美洲",
     },
@@ -2485,6 +2489,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "Global",
       Europe: "Europa",
       America: "Amerika",
     },
@@ -3034,6 +3039,7 @@ const data = {
       GM_FROSTCRAFT_4ON4: "Frostcraft 4v4",
     },
     gatewayNames: {
+      Global: "Globalna",
       Europe: "Europa",
       America: "Ameryka",
     },
@@ -3555,6 +3561,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "Глобальний",
       Europe: "Європа",
       America: "Америка",
     },
@@ -4074,6 +4081,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "Global",
       Europe: "Europa",
       America: "América",
     },
@@ -4604,6 +4612,7 @@ const data = {
       GM_FFA: "FFA",
     },
     gatewayNames: {
+      Global: "Global",
       Europe: "Europe",
       America: "Amérique",
     },
@@ -5168,6 +5177,7 @@ const data = {
       GM_PTR_1ON1: "1 na 1 sa PTR balansiranjem",
     },
     gatewayNames: {
+      Global: "Globalno",
       Europe: "Evropa",
       America: "Amerika",
     },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -50,6 +50,7 @@ const en = {
   },
 
   gatewayNames: {
+    Global: "Global",
     Europe: "Europe",
     America: "America",
     China: "China",


### PR DESCRIPTION
Supersedes #888, Closes #887.

The Europe gateway actually means "everything except China", so showing it as Global instead is better.

<img width="650" height="338" alt="image" src="https://github.com/user-attachments/assets/6f8e3f1d-068d-48f4-bbb2-9f095a8cc57f" />
