### PR TITLE
Move player league info into the tooltip

### DIFF
--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -9,39 +9,45 @@
     <div class="details-column" :class="{ 'mr-2': left, 'ml-2': !left }">
       <span>
 
-        <span v-if="!left && (player.countryCode || player.location)" class="" style="height: 12px;">
+        <span v-if="!left && (player.countryCode || player.location)">
           <country-flag-extended
             :countryCode="player.countryCode"
             :location="player.location"
           />
         </span>
-        <a
-          class="truncated-text"
-          :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
-          @click="notClickable ? null : goToPlayer()"
-          @click.middle="openProfileInNewTab()"
-          @click.right="openProfileInNewTab()"
-        >
-          {{ nameWithoutBtag }} (<v-tooltip v-if="topPercentage !== null" top>
-            <template v-slot:activator="{ on, attrs }">
-              <span v-bind="attrs" v-on="on">{{ currentRating }}</span>
-            </template>
-            <span>{{ $t("common.top") }} {{ topPercentage }}%</span>
-          </v-tooltip><span v-else>{{ currentRating }}</span>)<span v-if="mmrChange !== 0" class="number-text rating-text" :class="won">
-            <span v-if="mmrChange > 0">+{{ mmrChange }}</span>
-            <span v-else>{{ mmrChange }}</span>
-          </span>
-        </a>
-
-        <span v-if="left && (player.countryCode || player.location)">
+        <v-tooltip top transition="none">
+          <template v-slot:activator="{ on, attrs }">
+            <a
+              class="truncated-text"
+              :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
+              v-bind="attrs"
+              v-on="on"
+              @click="notClickable ? null : goToPlayer()"
+              @click.middle="openProfileInNewTab()"
+              @click.right="openProfileInNewTab()"
+            >
+              {{ nameWithoutBtag }} ({{ currentRating }})<span v-if="mmrChange !== 0" class="number-text rating-text" :class="won">
+                <span v-if="mmrChange > 0">+</span>{{ mmrChange }}
+              </span>
+            </a>
+          </template>
+          <div>
+            <div>MMR: {{ currentRating }}<span v-if="mmrChange !== 0" class="number-text rating-text" :class="won">
+              <span v-if="mmrChange > 0">+</span>{{ mmrChange }}
+            </span></div>
+            <div v-if="topPercentage !== null">Top: {{ topPercentage }}%</div>
+            <div class="d-flex align-center">
+              <img v-if="leagueName !== null" :src="`/assets/leagueIcons/${player.ranking?.leagueOrder}.png`" style="width: 16px; height: 16px; margin-right: 4px;" />
+              <span>{{ leagueName !== null ? leagueName + ' ' + (leagueDivision !== null ? leagueDivision : '#' + leagueRank) : $t('views_rankings.unranked') }}</span>
+            </div>
+          </div>
+        </v-tooltip>
+        <span v-if="left && (player.countryCode || player.location)" class="ml-1">
           <country-flag-extended
             :countryCode="player.countryCode"
             :location="player.location"
           />
         </span>
-      </span>
-      <span class="secondary-line truncated-text">
-        <span class="number-text ranking-text"><span v-if="leagueName !== null" class="league-ranking-text">{{ leagueName }} <span v-if="leagueDivision !== null">{{ leagueDivision }}</span><span v-else>#{{ leagueRank }}</span></span></span>
       </span>
       <hero-icon-row :heroes="player.heroes" :left="left" :show="showHeroes" :size="24" :selectedHeroes="selectedHeroes" />
     </div>


### PR DESCRIPTION
The second line and white text made the players column look _really_ messy. Moving all the rank info into the tooltip makes it look much better. I also turned off animations on this tooltip in particular so that there's no lag when mousing over a lot of users in a row.

We could expand on this tooltip to show even more detail, about the player. One thought would be making hover on the entire row be one big tooltip where we can show side-by-side detail (rank + MMR + % for each player in the match, plus whatever else we might want to introduce) without harming grokability of the table view, but doing that would require a significant refactor due to the current component hierarchy. But it's an option.

Before:
<img width="617" height="545" alt="image" src="https://github.com/user-attachments/assets/453a9d5d-bcd7-4c35-893f-1f437886ef46" />

After:
<img width="626" height="486" alt="image" src="https://github.com/user-attachments/assets/c53d35f4-7c43-4d66-85c9-004d3ff201cb" />

<img width="641" height="379" alt="image" src="https://github.com/user-attachments/assets/fed87df7-54e4-40a4-8a52-d7cce9ad7c74" />

<img width="748" height="505" alt="image" src="https://github.com/user-attachments/assets/b3131fa3-8df9-43a1-acef-80a06252afea" />


