### PR TITLE
Refactor profile loading for better UX, state desync fixes

### DIFF
--- a/src/components/overall-statistics/MmrDistributionChart.vue
+++ b/src/components/overall-statistics/MmrDistributionChart.vue
@@ -15,6 +15,7 @@ import clamp from "lodash/clamp";
 import maxBy from "lodash/maxBy";
 import minBy from "lodash/minBy";
 import { usePlayerStore } from "@/store/player/store";
+import { useOauthStore } from "@/store/oauth/store";
 import { ModeStat } from "@/store/player/types";
 
 export default defineComponent({
@@ -38,7 +39,14 @@ export default defineComponent({
   },
   setup(props) {
     const playerStore = usePlayerStore();
+    const oauthStore = useOauthStore();
     const gameModeStats = computed<ModeStat[]>(() => playerStore.gameModeStats);
+
+    const isLoggedInUserProfile = computed<boolean>(() => {
+      const isLoggedIn = Boolean(oauthStore.token);
+      const isOwnProfile = playerStore.battleTag === oauthStore.blizzardVerifiedBtag;
+      return isLoggedIn && isOwnProfile;
+    });
 
     const colors = computed(() => {
       const colors: string[] = [];
@@ -149,7 +157,8 @@ export default defineComponent({
     });
 
     const mmrDistributionChartOptions = computed<ChartOptions>(() => {
-      const annotations: { [key: string]: AnnotationOptions } = mmrGroupOfLoggedInPlayer.value
+      const isValidMMR = mmrGroupOfLoggedInPlayer.value > 0 && isLoggedInUserProfile.value;
+      const annotations: { [key: string]: AnnotationOptions } = isValidMMR
         ? {
           x: {
             type: "line",

--- a/src/components/overall-statistics/tabs/MmrDistributionTab.vue
+++ b/src/components/overall-statistics/tabs/MmrDistributionTab.vue
@@ -109,7 +109,7 @@ export default defineComponent({
               season: season.id,
             });
           } catch (error) {
-            console.warn('Failed to load profile for season change:', error);
+            console.warn("Failed to load profile for season change:", error);
           }
         }
         updateMMRDistribution();
@@ -125,7 +125,7 @@ export default defineComponent({
         };
         await overallStatsStore.loadMmrDistribution(payload);
       } catch (error) {
-        console.warn('Failed to load MMR distribution:', error);
+        console.warn("Failed to load MMR distribution:", error);
       } finally {
         loadingData.value = false;
       }
@@ -146,7 +146,7 @@ export default defineComponent({
     async function init() {
       await loadActiveGameModes();
       await rankingsStore.retrieveSeasons();
-      
+
       // If user is logged in and has a verified battle tag, ensure their profile is loaded
       if (authCode.value && verifiedBtag.value) {
         const needsProfileLoad = !player.battleTag || player.battleTag !== verifiedBtag.value;
@@ -160,11 +160,11 @@ export default defineComponent({
               await player.loadGameModeStats({});
             }
           } catch (error) {
-            console.warn('Failed to load user profile for MMR tab:', error);
+            console.warn("Failed to load user profile for MMR tab:", error);
           }
         }
       }
-      
+
       selectedSeason.value = seasons.value[0];
     }
 

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -412,8 +412,8 @@ export default defineComponent({
       return countries.value.find((c) => c.countryCode === code)?.country || "";
     };
 
-    const displayCountry = computed(() => props.isLoggedInPlayer ? selectedCountry.value : personalSetting.value.country || getCountryName(displayCountryCode.value));
-    const displayCountryCode = computed(() => props.isLoggedInPlayer ? selectedCountryCode.value : personalSetting.value.location || personalSetting.value.countryCode || "");
+    const displayCountryCode = computed(() => personalSetting.value.countryCode || "");
+    const displayCountry = computed(() => personalSetting.value.country || getCountryName(displayCountryCode.value));
 
     const userProfile = computed<ProfilePlayerSocials>(() => {
       return {

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -23,14 +23,14 @@
               @click="goToCountryRankings()"
             >
               <country-flag
-                v-if="selectedCountryCode != ''"
+                v-if="displayCountryCode != ''"
                 class="player-country"
-                :country="selectedCountryCode"
+                :country="displayCountryCode"
                 size="normal"
               />
             </div>
           </template>
-          <span>{{ selectedCountry }}</span>
+          <span>{{ displayCountry }}</span>
         </v-tooltip>
       </v-col>
     </v-row>
@@ -408,6 +408,13 @@ export default defineComponent({
     const selectedCountry = ref<string>("");
     const selectedCountryCode = ref<string>("");
 
+    const getCountryName = (code: string) => {
+      return countries.value.find(c => c.countryCode === code)?.country || "";
+    };
+
+    const displayCountry = computed(() => props.isLoggedInPlayer ? selectedCountry.value : personalSetting.value.country || getCountryName(displayCountryCode.value));
+    const displayCountryCode = computed(() => props.isLoggedInPlayer ? selectedCountryCode.value : personalSetting.value.location || personalSetting.value.countryCode || "");
+
     const userProfile = computed<ProfilePlayerSocials>(() => {
       return {
         twitch: twitch.value,
@@ -542,7 +549,7 @@ export default defineComponent({
     }
 
     function goToCountryRankings(): void {
-      router.push(`/Countries?country=${selectedCountryCode.value}`);
+      router.push(`/Countries?country=${displayCountryCode.value}`);
     }
 
     onMounted((): void => {
@@ -609,6 +616,8 @@ export default defineComponent({
       goToCountryRankings,
       selectedCountryCode,
       selectedCountry,
+      displayCountry,
+      displayCountryCode,
       userProfile,
       useClassicIcons,
       starterPicNumbers,

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -409,7 +409,7 @@ export default defineComponent({
     const selectedCountryCode = ref<string>("");
 
     const getCountryName = (code: string) => {
-      return countries.value.find(c => c.countryCode === code)?.country || "";
+      return countries.value.find((c) => c.countryCode === code)?.country || "";
     };
 
     const displayCountry = computed(() => props.isLoggedInPlayer ? selectedCountry.value : personalSetting.value.country || getCountryName(displayCountryCode.value));

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -412,7 +412,7 @@ export default defineComponent({
       return countries.value.find((c) => c.countryCode === code)?.country || "";
     };
 
-    const displayCountryCode = computed(() => personalSetting.value.countryCode || "");
+    const displayCountryCode = computed(() => personalSetting.value.countryCode || personalSetting.value.location || "");
     const displayCountry = computed(() => personalSetting.value.country || getCountryName(displayCountryCode.value));
 
     const userProfile = computed<ProfilePlayerSocials>(() => {

--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -271,13 +271,13 @@
                       :return-object="false"
                     >
                       <template v-slot:item="{ item }">
-                        <country-flag :country="item.countryCode" size="normal" />
+                        <country-flag :country="item.countryCode" size="normal" style="margin: 0;" />
                         {{ item.country }}
                         <v-spacer />
                       </template>
                       <template v-slot:selection="{ item }">
-                        <country-flag :country="item.countryCode" size="normal" />
-                        <span class="pr-2">{{ item.country }}</span>
+                        <country-flag :country="item.countryCode" size="normal" style="margin: 0;" />
+                        {{ item.country }}
                       </template>
                     </v-autocomplete>
                   </v-col>

--- a/src/store/player/store.ts
+++ b/src/store/player/store.ts
@@ -45,6 +45,7 @@ export const usePlayerStore = defineStore("player", {
           params.freshLogin ? oauthStore.token : null,
         );
         this.SET_PROFILE(profile);
+        this.SET_BATTLE_TAG(params.battleTag);
         this.SET_LOAD_PROFILE_ERROR(undefined);
         this.SET_SELECTED_SEASON(profile.participatedInSeasons[0]);
       } catch (err) {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -254,8 +254,6 @@ export default defineComponent({
         stopLoadingMatches();
       }
 
-      playerStore.SET_BATTLE_TAG(battleTag.value);
-
       _intervalRefreshHandle = setInterval(async () => {
         await playerStore.loadOngoingPlayerMatch(battleTag.value);
       }, AppConstants.ongoingMatchesRefreshInterval);

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -121,7 +121,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, onUnmounted, ref, watch } from "vue";
 import { PlayerProfile } from "@/store/player/types";
-import { EGameMode, ERaceEnum, Match, PlayerInTeam, Team } from "@/store/types";
+import { Match, PlayerInTeam, Team } from "@/store/types";
 import { Season } from "@/store/ranking/types";
 import GatewaySelect from "@/components/common/GatewaySelect.vue";
 import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
@@ -130,7 +130,6 @@ import HostIcon from "@/components/matches/HostIcon.vue";
 import SeasonBadge from "@/components/player/SeasonBadge.vue";
 import { mapNameFromMatch } from "@/mixins/MatchMixin";
 import { usePlayerStore } from "@/store/player/store";
-import { useRankingStore } from "@/store/ranking/store";
 import { GAME_MODES_FFA } from "@/store/constants";
 
 export default defineComponent({
@@ -154,7 +153,6 @@ export default defineComponent({
   },
   setup(props) {
     const playerStore = usePlayerStore();
-    const rankingsStore = useRankingStore();
     let _intervalRefreshHandle: NodeJS.Timeout;
     const tabsModel = ref<number>(0);
 


### PR DESCRIPTION
Closes https://github.com/w3champions/website/issues/868

Improves the user experience by refactoring profile loading to happen all together, preventing flickering and state desync. Also fixes a few related issues:

- Ensures the country icon switches correctly on profile change.
- Aligns the flag and country name in the "edit profile" country picker.
- Corrects the display of "Your MMR" line on the MMR graph by ensuring the logged in user's profile is loaded when opening that graph screen.