### PR TITLE
Fix MMR select visibility logic in Matches view

### DIFF
--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -10,7 +10,7 @@
             <matches-status-select />
             <game-mode-select :disabledModes="disabledGameModes" :gameMode="gameMode" @gameModeChanged="gameModeChanged" />
             <map-select :mapInfo="maps" :map="map" @mapChanged="mapChanged" />
-            <mmr-select v-if="unfinished" :mmr="mmr" @mmrChanged="mmrChanged" />
+            <mmr-select :mmr="mmr" @mmrChanged="mmrChanged" />
             <sort-select v-if="unfinished" />
             <season-select v-if="!unfinished" @seasonSelected="selectSeason" />
             <hero-select v-if="!unfinished && showHeroSelect" :selectedHeroes="selectedHeroes" @heroChanged="heroChanged" />


### PR DESCRIPTION
This pull request makes a small change to the `Matches.vue` view by always rendering the `mmr-select` component, regardless of whether the match is unfinished. Previously, `mmr-select` was only shown for unfinished matches. This simplifies the component's visibility logic.

- Always render the `mmr-select` component by removing the `v-if="unfinished"` condition in `Matches.vue`.