### PR TITLE
fix(lag-reports): plot current RTT instead of rolling avg in ping chart

### DIFF
--- a/src/components/admin/lag-reports/LagReportContinuousMonitoring.vue
+++ b/src/components/admin/lag-reports/LagReportContinuousMonitoring.vue
@@ -196,7 +196,7 @@ export default defineComponent({
             label: `${playerName(player.battleTag)} client`,
             data: player.diagnostics.pingHistory.map((p) => ({
               x: new Date(p.timestamp).getTime(),
-              y: p.avg ?? 0,
+              y: p.current,
             })),
             borderColor: color,
             backgroundColor: "transparent",


### PR DESCRIPTION
## Summary
- Changes the client ping chart in lag report detail view to plot `p.current` (point-in-time last RTT) instead of `p.avg` (rolling window average)
- When `current` is `null` (ping timed out), Chart.js renders a gap in the line — correctly visualizing connectivity loss instead of hiding it with a fallback value

**Depends on:** w3champions/flo#117 (ping snapshot wiring — populates `pingHistory` data)

## Test plan
- [ ] `yarn lint` passes
- [ ] Open a lag report detail page with ping data and verify the chart renders correctly
- [ ] Verify that null/missing data points show as gaps, not zero-value points