### PR TITLE
Reset player match filters on profile change

### DIFF
--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -8,6 +8,7 @@
         <v-spacer />
         <v-col cols="12" md="5" class="pt-0 px-4">
           <player-search
+            :key="battleTag"
             :setAutofocus="false"
             @playerFound="playerFound"
             @searchCleared="searchCleared"
@@ -94,7 +95,8 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from "vue";
+import { computed, defineComponent, onMounted, ref, watch } from "vue";
+import { onBeforeRouteLeave } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { loadActiveGameModes, activeGameModesWithAll } from "@/composables/GameModesMixin";
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
@@ -141,6 +143,21 @@ export default defineComponent({
       await loadActiveGameModes();
       await commonStore.loadHeroFilters();
     });
+
+    onBeforeRouteLeave((): void => {
+      resetProfileMatchFilters();
+    });
+
+    watch(battleTag, (newBattleTag: string, oldBattleTag: string | undefined): void => {
+      if (!oldBattleTag || newBattleTag === oldBattleTag) return;
+      resetProfileMatchFilters();
+    });
+
+    function resetProfileMatchFilters(): void {
+      foundPlayer.value = "";
+      rankingsStore.clearSearch();
+      playerStore.RESET_PROFILE_MATCH_FILTERS();
+    }
 
     async function playerFound(bTag: string): Promise<void> {
       foundPlayer.value = bTag;

--- a/src/store/player/store.ts
+++ b/src/store/player/store.ts
@@ -247,14 +247,22 @@ export const usePlayerStore = defineStore("player", {
     SET_PROFILE_STATISTICS_GAME_MODE(gameMode: EGameMode): void {
       this.profileStatisticsGameMode = gameMode;
     },
-    SET_PLAYER_RACE(playerRace: ERaceEnum): void {
+    SET_PLAYER_RACE(playerRace: ERaceEnum | undefined): void {
       this.playerRace = playerRace;
     },
-    SET_OPPONENT_RACE(opponentRace: ERaceEnum): void {
+    SET_OPPONENT_RACE(opponentRace: ERaceEnum | undefined): void {
       this.opponentRace = opponentRace;
     },
     SET_SELECTED_HEROES(heroes: number[]): void {
       this.selectedHeroes = heroes;
+    },
+    RESET_PROFILE_MATCH_FILTERS(): void {
+      this.SET_OPPONENT_TAG("");
+      this.SET_PROFILE_MATCHES_GAME_MODE(EGameMode.UNDEFINED);
+      this.SET_PLAYER_RACE(undefined);
+      this.SET_OPPONENT_RACE(undefined);
+      this.SET_SELECTED_HEROES([]);
+      this.SET_PAGE(1);
     },
     SET_ONGOING_MATCH(match: Match): void {
       this.ongoingMatch = match;


### PR DESCRIPTION
## Summary

Resets the player match filters when the selected profile changes.

This prevents filters from carrying over between different player profiles and showing stale or confusing match results.

## Changes

- Clear match filters when navigating to a different player profile
- Keep the match list state aligned with the currently selected player
- Avoid stale filter state affecting newly loaded profile data

## Testing

- Verified locally by switching between player profiles and confirming the match filters reset as expected
