### PR TITLE
Add inline match details to player history

### DIFF
--- a/src/components/match-details/MatchDetailContent.vue
+++ b/src/components/match-details/MatchDetailContent.vue
@@ -1,0 +1,343 @@
+<template>
+  <div class="match-detail-content">
+    <div v-if="isJubileeGame" class="jubilee"></div>
+    <v-card tile class="pb-5 pt-1">
+      <v-card-title class="justify-center">
+        <v-row justify="space-around">
+          <v-col cols="1" class="pl-0 pr-0">
+            <v-card-subtitle class="pa-0 text-uppercase opacity-100">
+              <div>{{ $t(`gatewayNames.${gateWay}`) }}</div>
+              <div>{{ $t(`views_matchdetail.season`) }}: {{ season }}</div>
+            </v-card-subtitle>
+            <host-icon
+              v-if="match.serverInfo && match.serverInfo.provider"
+              :host="match.serverInfo"
+              style="padding-right: 0px"
+            />
+          </v-col>
+          <v-col v-if="!matchIsFFA" cols="4" align-self="center">
+            <team-match-info
+              :big-race-icon="true"
+              :left="true"
+              :team="match.teams[0]"
+            />
+          </v-col>
+          <v-col cols="1" class="text-center" align-self="center">
+            <span v-if="!matchIsFFA">{{ $t(`views_matchdetail.vs`) }}</span>
+          </v-col>
+          <v-col v-if="!matchIsFFA" cols="4" align-self="center">
+            <team-match-info :big-race-icon="true" :team="match.teams[1]" />
+          </v-col>
+          <v-col v-if="matchIsFFA" cols="6" align-self="center">
+            <team-match-info
+              class="ma-1"
+              :big-race-icon="true"
+              :team="match.teams[0]"
+            />
+            <team-match-info
+              class="ma-1"
+              :big-race-icon="true"
+              :team="match.teams[1]"
+            />
+            <team-match-info
+              class="ma-1"
+              :big-race-icon="true"
+              :team="match.teams[2]"
+            />
+            <team-match-info
+              class="ma-1"
+              :big-race-icon="true"
+              :team="match.teams[3]"
+            />
+          </v-col>
+          <v-col cols="1" />
+          <div v-if="showReplayDownload" class="subicon">
+            <download-replay-icon :gameId="matchId" />
+          </div>
+        </v-row>
+      </v-card-title>
+      <div class="pb-2">
+        <v-card-title v-if="isJubileeGame" class="d-flex justify-center">
+          {{ $t(`views_matchdetail.jubileeGameNumber`, { gameNumber }) }}
+        </v-card-title>
+        <v-card-title v-if="isJubileeGame" class="d-flex justify-center">
+          {{ $t(`views_matchdetail.jubileeGameMessage`) }}
+        </v-card-title>
+        <v-card-title class="d-flex justify-center">
+          {{ `${mapNameFromMatch(match)} (${matchDuration}) | ${playedDate}` }}
+        </v-card-title>
+      </div>
+      <div v-if="isCompleteGame">
+        <match-detail-hero-row
+          v-for="(player, index) in scoresOfWinners"
+          :key="index"
+          :heroes-of-winner="scoresOfWinners[index]?.heroes"
+          :heroes-of-loser="scoresOfLosers[index]?.heroes"
+          :scores-of-winner="scoresOfWinners[index]?.heroScore"
+          :scores-of-loser="scoresOfLosers[index]?.heroScore"
+        />
+      </div>
+      <match-detail-hero-row
+        v-if="matchIsFFA && isCompleteGame"
+        :not-color-winner="true"
+        :heroes-of-winner="ffaLoser2?.heroes"
+        :heroes-of-loser="ffaLoser3?.heroes"
+        :scores-of-winner="ffaLoser2?.heroScore"
+        :scores-of-loser="ffaLoser3?.heroScore"
+      />
+      <v-row v-if="!isCompleteGame" class="justify-center">
+        <v-card-subtitle>
+          {{ $t(`views_matchdetail.incompletedata`) }}
+        </v-card-subtitle>
+      </v-row>
+      <v-row v-if="isCompleteGame && !matchIsFFA" class="justify-center">
+        <v-col cols="5" class="mr-7">
+          <player-performance-on-match
+            class="mt-4"
+            :unit-score="scoresOfWinners.map((h) => h.unitScore)"
+            :resource-score="scoresOfWinners.map((h) => h.resourceScore)"
+            :unit-score-opponent="scoresOfLosers.map((h) => h.unitScore)"
+            :resource-score-opponent="scoresOfLosers.map((h) => h.resourceScore)"
+            :left="true"
+          />
+        </v-col>
+        <v-col cols="5" class="ml-7">
+          <player-performance-on-match
+            class="mt-4"
+            :unit-score="scoresOfLosers.map((h) => h.unitScore)"
+            :resource-score="scoresOfLosers.map((h) => (h.resourceScore))"
+            :unit-score-opponent="scoresOfWinners.map((h) => h.unitScore)"
+            :resource-score-opponent="scoresOfWinners.map((h) => h.resourceScore)"
+          />
+        </v-col>
+      </v-row>
+      <v-row v-if="isCompleteGame && matchIsFFA" class="mb-3">
+        <v-col cols="2" />
+        <v-col>
+          <v-row v-for="(label, index) in rowLabels" :key="label" dense>
+            <v-col>
+              {{ label }}
+            </v-col>
+            <v-col v-for="player in ffaPlayers" :key="player?.battleTag">
+              <div v-if="index === 0">
+                {{ battleTagToName(player?.battleTag) }}
+              </div>
+              <div v-if="index === 1">
+                {{ player?.unitScore.unitsKilled }}
+              </div>
+              <div v-if="index === 2">
+                {{ player?.unitScore.unitsProduced }}
+              </div>
+              <div v-if="index === 3">
+                {{ player?.resourceScore.goldCollected }}
+              </div>
+              <div v-if="index === 4">
+                {{ player?.resourceScore.lumberCollected }}
+              </div>
+              <div v-if="index === 5">
+                {{ player?.resourceScore.goldUpkeepLost }}
+              </div>
+              <div v-if="index === 6">
+                {{ player?.unitScore.largestArmy }}
+              </div>
+            </v-col>
+          </v-row>
+        </v-col>
+        <v-col cols="1" />
+      </v-row>
+    </v-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType } from "vue";
+import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
+import PlayerPerformanceOnMatch from "@/components/match-details/PlayerPerformanceOnMatch.vue";
+import MatchDetailHeroRow from "@/components/match-details/MatchDetailHeroRow.vue";
+import { Match, MatchDetail, PlayerInTeam, PlayerScore, Team } from "@/store/types";
+import { Gateways } from "@/store/ranking/types";
+import HostIcon from "@/components/matches/HostIcon.vue";
+import { mapNameFromMatch } from "@/composables/MatchMixin";
+import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
+import { formatSecondsToDuration, formatTimestampStringToDateTime } from "@/helpers/date-functions";
+import { battleTagToName } from "@/helpers/profile";
+import { GAME_MODES_FFA } from "@/store/constants";
+
+export default defineComponent({
+  name: "MatchDetailContent",
+  components: {
+    MatchDetailHeroRow,
+    PlayerPerformanceOnMatch,
+    TeamMatchInfo,
+    HostIcon,
+    DownloadReplayIcon,
+  },
+  props: {
+    matchDetail: {
+      type: Object as PropType<MatchDetail>,
+      required: true,
+    },
+    matchId: {
+      type: String,
+      required: true,
+    },
+    showReplayDownload: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+  },
+  setup(props) {
+    const match = computed<Match>(() => props.matchDetail.match);
+    const matchDuration = computed<string>(() => formatSecondsToDuration(match.value.durationInSeconds));
+    const playedDate = computed<string>(() => formatTimestampStringToDateTime(match.value.startTime));
+    const gateWay = computed<string>(() => Gateways[match.value.gateWay]);
+    const season = computed<number>(() => match.value.season ?? 1);
+    const isCompleteGame = computed<PlayerScore[]>(() => props.matchDetail.playerScores);
+
+    const matchIsFFA = computed<boolean>(() => {
+      return GAME_MODES_FFA.includes(match.value.gameMode);
+    });
+
+    const isJubileeGame = computed<boolean>(() => {
+      if (!match.value?.number) return false;
+      return match.value.number !== 0 && match.value?.number % 1000000 === 0;
+    });
+
+    const playerScores = computed<PlayerScore[]>(() => {
+      const { playerScores, match } = props.matchDetail;
+      if (matchIsFFA.value) {
+        return playerScores.map((playerScore) => {
+          const battleTag = match.serverInfo.playerServerInfos[playerScore.teamIndex].battleTag;
+          return {
+            ...playerScore,
+            battleTag,
+          };
+        });
+      }
+      return playerScores ?? [];
+    });
+
+    const scoresOfWinners = computed<PlayerScore[]>(() => {
+      const winningTeam = match.value.teams[0];
+      return getPlayerScores(winningTeam);
+    });
+
+    const scoresOfLosers = computed<PlayerScore[]>(() => {
+      const losingTeam = match.value.teams[1];
+      return getPlayerScores(losingTeam);
+    });
+
+    const ffaWinner = computed<PlayerScore>(() => playerScores.value.find(
+      (s) => s.battleTag === match.value.teams[0].players[0].battleTag
+    )!);
+
+    const ffaLosers = computed<PlayerScore[]>(() => playerScores.value.filter(
+      (s) => s.battleTag !== match.value.teams[0].players[0].battleTag
+    ));
+
+    const ffaLoser2 = computed<PlayerScore>(() => playerScores.value.find(
+      (s) => s.battleTag === match.value.teams[2].players[0].battleTag
+    )!);
+
+    const ffaLoser3 = computed<PlayerScore>(() => playerScores.value.find(
+      (s) => s.battleTag === match.value.teams[3].players[0].battleTag
+    )!);
+
+    const ffaPlayers = computed<PlayerScore[]>(() => [ffaWinner.value, ...ffaLosers.value]);
+
+    const gameNumber = computed<string>(() => {
+      const number = match.value.number / 1000000;
+      switch (number) {
+        case 1:
+          return "one";
+        case 2:
+          return "two";
+        case 3:
+          return "three";
+        case 4:
+          return "four";
+        case 5:
+          return "five";
+        case 6:
+          return "six";
+        case 7:
+          return "seven";
+        case 8:
+          return "eight";
+        case 9:
+          return "nine";
+        default:
+          return "bazillion";
+      }
+    });
+
+    function getPlayerScores(team: Team): PlayerScore[] {
+      return team.players.map((p: PlayerInTeam) => {
+        const playerInTeamBattleTag = p.battleTag.toLowerCase();
+        const score = playerScores.value.find((score) => score.battleTag.toLowerCase() === playerInTeamBattleTag) ||
+          playerScores.value.find((score) => score.battleTag.toLowerCase().includes(playerInTeamBattleTag.split("#", 1)[0])) ||
+          playerScores.value.find((score) => score.battleTag === p.inviteName);
+
+        return {
+          ...score ?? {} as PlayerScore,
+          battleTag: p.battleTag,
+        };
+      });
+    }
+
+    const rowLabels = [
+      "",
+      "Units killed",
+      "Units produced",
+      "Gold mined",
+      "Lumber harvested",
+      "Upkeep lost",
+      "Largest army",
+    ];
+
+    return {
+      mapNameFromMatch,
+      isJubileeGame,
+      gateWay,
+      season,
+      match,
+      matchIsFFA,
+      gameNumber,
+      matchDuration,
+      playedDate,
+      isCompleteGame,
+      scoresOfWinners,
+      scoresOfLosers,
+      ffaLoser2,
+      ffaLoser3,
+      rowLabels,
+      ffaPlayers,
+      battleTagToName,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.match-detail-content {
+  position: relative;
+}
+
+.jubilee {
+  position: absolute;
+  width: 80%;
+  height: 80%;
+  left: 10%;
+  z-index: 100;
+  background-image: url("/assets/giphy.gif") !important;
+  background-size: cover !important;
+}
+
+.subicon {
+  display: block;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+</style>

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -25,7 +25,8 @@
             <tr>
               <td
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 <div
                   v-if="isFfa(item.gameMode)"
@@ -90,7 +91,8 @@
               <td
                 class="text-center"
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 <span>{{ gameModeTranslation(item.gameMode) }}</span>
                 <br />
@@ -99,14 +101,16 @@
               <td
                 class="text-right"
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 {{ getStartTime(item) }}
               </td>
               <td
                 class="text-right"
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 <div class="d-flex flex-column text-right align-end">
                   <span class="number-text">{{ getDuration(item) }}</span>
@@ -117,7 +121,8 @@
                 v-if="!unfinished"
                 class="text-center match-page-cell"
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 <v-tooltip location="top" content-class="w3-tooltip elevation-1">
                   <template v-slot:activator="{ props }">
@@ -140,7 +145,8 @@
                 v-if="!unfinished"
                 class="text-center"
                 :class="{ 'cursor-pointer': isAccordionCellActive() }"
-                @click="onAccordionCellSelected(item)"
+                @click.exact="onMatchSelected(item)"
+                @click.ctrl="openMatchDetailPageInNewTab(item)"
               >
                 <span v-if="showReplayDownload(item)" @click.stop>
                   <download-replay-icon :gameId="item.id" />
@@ -328,14 +334,15 @@ export default defineComponent({
       return props.inlineDetails && !props.unfinished;
     }
 
-    async function onAccordionCellSelected(match: Match): Promise<void> {
-      if (!isAccordionCellActive()) return;
-
-      await onMatchSelected(match);
-    }
-
     function goToMatchDetailPage(match: Match): void {
       router.push({ path: `/match/${match.id}` });
+    }
+
+    function openMatchDetailPageInNewTab(match: Match): void {
+      if (props.unfinished) return;
+
+      const route = router.resolve({ path: `/match/${match.id}` });
+      window.open(route.href, "_blank");
     }
 
     async function loadInlineMatchDetail(matchId: string): Promise<void> {
@@ -470,9 +477,9 @@ export default defineComponent({
       onPageChanged,
       getTotalPages,
       onMatchSelected,
-      onAccordionCellSelected,
       isAccordionCellActive,
       goToMatchDetailPage,
+      openMatchDetailPageInNewTab,
       getWinner,
       getLoser,
       getPlayerTeam,

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -12,96 +12,155 @@
             >
               {{ header.text }}
             </td>
+            <td v-if="!unfinished" class="text-center text-medium-emphasis match-page-cell">
+              {{ $t("components_matches_matchesgrid.match") }}
+            </td>
             <td v-if="!unfinished" class="text-center text-medium-emphasis">
               {{ $t("components_matches_matchesgrid.replay") }}
             </td>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in matches" :key="item.id">
-            <td>
-              <div
-                v-if="isFfa(item.gameMode)"
-                :class="{ 'cursor-pointer': !unfinished }"
-                class="my-3"
-                @click="goToMatchDetailPage(item)"
+          <template v-for="item in matches" :key="item.id">
+            <tr>
+              <td
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
               >
-                <v-row v-if="alwaysLeftName" justify="center">
-                  <v-col offset="4" class="py-1">
+                <div
+                  v-if="isFfa(item.gameMode)"
+                  class="my-3"
+                >
+                  <v-row v-if="alwaysLeftName" justify="center">
+                    <v-col offset="4" class="py-1">
+                      <team-match-info
+                        :not-clickable="unfinished"
+                        :team="getPlayerTeam(item)"
+                        :unfinishedMatch="unfinished"
+                        :is-anonymous="true"
+                        :highlightedPlayer="alwaysLeftName"
+                        :show-heroes="showHeroes"
+                        :selectedHeroes="selectedHeroes"
+                      />
+                    </v-col>
+                  </v-row>
+                  <v-row v-for="(team, index) in getOpponentTeams(item)" :key="index" justify="center">
+                    <v-col offset="4" class="py-1">
+                      <team-match-info
+                        :not-clickable="unfinished"
+                        :team="team"
+                        :unfinishedMatch="unfinished"
+                        :is-anonymous="true"
+                        :show-heroes="showHeroes"
+                        :selectedHeroes="selectedHeroes"
+                      />
+                    </v-col>
+                  </v-row>
+                </div>
+                <v-row
+                  v-if="!isFfa(item.gameMode)"
+                  class="force-no-wrap"
+                >
+                  <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
                     <team-match-info
-                      :not-clickable="!unfinished"
-                      :team="getPlayerTeam(item)"
+                      :not-clickable="unfinished"
+                      :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
                       :unfinishedMatch="unfinished"
-                      :is-anonymous="true"
-                      :highlightedPlayer="alwaysLeftName"
+                      :left="true"
+                      :highlightedPlayer="nameIfNonSolo(item)"
+                      :show-heroes="showHeroes"
+                      :selectedHeroes="selectedHeroes"
+                    />
+                  </v-col>
+                  <v-col cols="1" class="py-2 d-flex flex-column justify-center align-center">
+                    <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
+                    <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo" />
+                  </v-col>
+                  <v-col cols="5.5" class="team-match-info-container" align-self="center">
+                    <team-match-info
+                      :not-clickable="unfinished"
+                      :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
+                      :unfinishedMatch="unfinished"
                       :show-heroes="showHeroes"
                       :selectedHeroes="selectedHeroes"
                     />
                   </v-col>
                 </v-row>
-                <v-row v-for="(team, index) in getOpponentTeams(item)" :key="index" justify="center">
-                  <v-col offset="4" class="py-1">
-                    <team-match-info
-                      :not-clickable="!unfinished"
-                      :team="team"
-                      :unfinishedMatch="unfinished"
-                      :is-anonymous="true"
-                      :show-heroes="showHeroes"
-                      :selectedHeroes="selectedHeroes"
-                    />
-                  </v-col>
-                </v-row>
-              </div>
-              <v-row
-                v-if="!isFfa(item.gameMode)"
-                :class="{ 'cursor-pointer': !unfinished }"
-                class="force-no-wrap"
-                @click="goToMatchDetailPage(item)"
+              </td>
+              <td
+                class="text-center"
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
               >
-                <v-col cols="5.5" class="team-match-info-container left-side" align-self="center">
-                  <team-match-info
-                    :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getPlayerTeam(item) : getWinner(item)"
-                    :unfinishedMatch="unfinished"
-                    :left="true"
-                    :highlightedPlayer="nameIfNonSolo(item)"
-                    :show-heroes="showHeroes"
-                    :selectedHeroes="selectedHeroes"
-                  />
-                </v-col>
-                <v-col cols="1" class="py-2 d-flex flex-column justify-center align-center">
-                  <span class="text-no-wrap">{{ $t(`views_matchdetail.vs`) }}</span>
-                  <host-icon v-if="item.serverInfo && item.serverInfo.provider" :host="item.serverInfo" />
-                </v-col>
-                <v-col cols="5.5" class="team-match-info-container" align-self="center">
-                  <team-match-info
-                    :not-clickable="!unfinished"
-                    :team="alwaysLeftName ? getOpponentTeam(item) : getLoser(item)"
-                    :unfinishedMatch="unfinished"
-                    :show-heroes="showHeroes"
-                    :selectedHeroes="selectedHeroes"
-                  />
-                </v-col>
-              </v-row>
-            </td>
-            <td class="text-center">
-              <span>{{ gameModeTranslation(item.gameMode) }}</span>
-              <br />
-              <span class="text-caption">{{ mapNameFromMatch(item) }}</span>
-            </td>
-            <td class="text-right">
-              {{ getStartTime(item) }}
-            </td>
-            <td class="text-right">
-              <div class="d-flex flex-column text-right align-end">
-                <span class="number-text">{{ getDuration(item) }}</span>
-                <div v-show="!unfinished" class="duration-bar" :style="{ width: getDurationBarWidth(item) }"></div>
-              </div>
-            </td>
-            <td v-if="showReplayDownload(item)" class="text-center">
-              <download-replay-icon :gameId="item.id" />
-            </td>
-          </tr>
+                <span>{{ gameModeTranslation(item.gameMode) }}</span>
+                <br />
+                <span class="text-caption">{{ mapNameFromMatch(item) }}</span>
+              </td>
+              <td
+                class="text-right"
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
+              >
+                {{ getStartTime(item) }}
+              </td>
+              <td
+                class="text-right"
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
+              >
+                <div class="d-flex flex-column text-right align-end">
+                  <span class="number-text">{{ getDuration(item) }}</span>
+                  <div v-show="!unfinished" class="duration-bar" :style="{ width: getDurationBarWidth(item) }"></div>
+                </div>
+              </td>
+              <td
+                v-if="!unfinished"
+                class="text-center match-page-cell"
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
+              >
+                <v-tooltip location="top" content-class="w3-tooltip elevation-1">
+                  <template v-slot:activator="{ props }">
+                    <span v-bind="props">
+                      <v-btn
+                        class="ma-2 w3-gray-gold-text"
+                        icon
+                        variant="outlined"
+                        size="small"
+                        @click.stop="goToMatchDetailPage(item)"
+                      >
+                        <v-icon size="x-large">{{ mdiOpenInNew }}</v-icon>
+                      </v-btn>
+                    </span>
+                  </template>
+                  <span>{{ $t("components_matches_matchesgrid.openMatch") }}</span>
+                </v-tooltip>
+              </td>
+              <td
+                v-if="!unfinished"
+                class="text-center"
+                :class="{ 'cursor-pointer': isAccordionCellActive() }"
+                @click="onAccordionCellSelected(item)"
+              >
+                <span v-if="showReplayDownload(item)" @click.stop>
+                  <download-replay-icon :gameId="item.id" />
+                </span>
+              </td>
+            </tr>
+            <tr v-if="isExpanded(item)" class="match-detail-row">
+              <td :colspan="matchDetailColspan" class="pa-0">
+                <div v-if="isLoadingMatchDetail(item.id)" class="text-center pa-6">
+                  <v-progress-circular indeterminate color="primary" />
+                </div>
+                <match-detail-content
+                  v-else-if="matchDetailsById[item.id]"
+                  :match-detail="matchDetailsById[item.id]"
+                  :match-id="item.id"
+                  :show-replay-download="false"
+                />
+              </td>
+            </tr>
+          </template>
           <tr v-if="!matches || matches.length == 0">
             <td colspan="4" class="text-center">
               {{ $t("components_matches_matchesgrid.nomatchesfound") }}
@@ -121,19 +180,22 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, StyleValue, PropType } from "vue";
+import { computed, defineComponent, StyleValue, PropType, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { EGameMode, Match, PlayerInTeam, Team } from "@/store/types";
+import { EGameMode, Match, MatchDetail, PlayerInTeam, Team } from "@/store/types";
 import { GAME_MODES_FFA } from "@/store/constants";
 import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
 import HostIcon from "@/components/matches/HostIcon.vue";
 import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
+import MatchDetailContent from "@/components/match-details/MatchDetailContent.vue";
 import { mapNameFromMatch } from "@/composables/MatchMixin";
 import { TranslateResult } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { formatSecondsToDuration, formatTimestampStringToDateTime, formatTimestampStringToUnixTime } from "@/helpers/date-functions";
 import { useMatchStore } from "@/store/match/store";
 import { usePlayerStore } from "@/store/player/store";
+import MatchService from "@/services/MatchService";
+import { mdiOpenInNew } from "@mdi/js";
 
 interface MatchesGridHeader {
   name: string;
@@ -149,6 +211,7 @@ export default defineComponent({
     TeamMatchInfo,
     HostIcon,
     DownloadReplayIcon,
+    MatchDetailContent,
   },
   props: {
     modelValue: {
@@ -187,6 +250,11 @@ export default defineComponent({
       required: false,
       default: () => [],
     },
+    inlineDetails: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props, context) {
     const { t } = useI18n();
@@ -195,8 +263,12 @@ export default defineComponent({
     const playerStore = usePlayerStore();
     const gameModeTranslation = (gameMode: EGameMode) => t(`gameModes.${EGameMode[gameMode]}`);
     const isFfa = (gameMode: EGameMode) => GAME_MODES_FFA.includes(gameMode);
+    const expandedMatchId = ref<string>("");
+    const matchDetailsById = ref<Record<string, MatchDetail>>({});
+    const loadingMatchDetailsById = ref<Record<string, boolean>>({});
 
     const matches = computed<Match[]>(() => props.modelValue);
+    const matchDetailColspan = computed<number>(() => headers.length + (props.unfinished ? 0 : 2));
 
     const currentMatchesLowRange = computed<number>(() => {
       if (props.totalMatches === 0) return 0;
@@ -215,6 +287,7 @@ export default defineComponent({
     });
 
     function onPageChanged(page: number): void {
+      expandedMatchId.value = "";
       context.emit("pageChanged", page);
     }
 
@@ -231,9 +304,65 @@ export default defineComponent({
       },
     });
 
-    function goToMatchDetailPage(match: Match): void {
+    watch(matches, (): void => {
+      expandedMatchId.value = "";
+    });
+
+    async function onMatchSelected(match: Match): Promise<void> {
       if (props.unfinished) return;
+      if (!props.inlineDetails) {
+        goToMatchDetailPage(match);
+        return;
+      }
+
+      if (expandedMatchId.value === match.id) {
+        expandedMatchId.value = "";
+        return;
+      }
+
+      expandedMatchId.value = match.id;
+      await loadInlineMatchDetail(match.id);
+    }
+
+    function isAccordionCellActive(): boolean {
+      return props.inlineDetails && !props.unfinished;
+    }
+
+    async function onAccordionCellSelected(match: Match): Promise<void> {
+      if (!isAccordionCellActive()) return;
+
+      await onMatchSelected(match);
+    }
+
+    function goToMatchDetailPage(match: Match): void {
       router.push({ path: `/match/${match.id}` });
+    }
+
+    async function loadInlineMatchDetail(matchId: string): Promise<void> {
+      if (matchDetailsById.value[matchId] || loadingMatchDetailsById.value[matchId]) return;
+
+      loadingMatchDetailsById.value = {
+        ...loadingMatchDetailsById.value,
+        [matchId]: true,
+      };
+
+      const matchDetail = await MatchService.retrieveMatchDetail(matchId);
+      matchDetailsById.value = {
+        ...matchDetailsById.value,
+        [matchId]: matchDetail,
+      };
+      loadingMatchDetailsById.value = {
+        ...loadingMatchDetailsById.value,
+        [matchId]: false,
+      };
+    }
+
+    function isExpanded(match: Match): boolean {
+      return expandedMatchId.value === match.id;
+    }
+
+    function isLoadingMatchDetail(matchId: string): boolean {
+      return loadingMatchDetailsById.value[matchId] === true;
     }
 
     const getWinner = (match: Match): Team => match.teams[0];
@@ -340,6 +469,9 @@ export default defineComponent({
       currentMatchesHighRange,
       onPageChanged,
       getTotalPages,
+      onMatchSelected,
+      onAccordionCellSelected,
+      isAccordionCellActive,
       goToMatchDetailPage,
       getWinner,
       getLoser,
@@ -351,6 +483,11 @@ export default defineComponent({
       getDuration,
       getDurationBarWidth,
       showReplayDownload,
+      isExpanded,
+      isLoadingMatchDetail,
+      matchDetailsById,
+      matchDetailColspan,
+      mdiOpenInNew,
     };
   },
 });
@@ -377,4 +514,9 @@ export default defineComponent({
 .force-no-wrap {
   flex-wrap: nowrap !important;
 }
+
+.match-page-cell {
+  padding-right: 0 !important;
+}
+
 </style>

--- a/src/components/matches/PlayerMatchInfo.vue
+++ b/src/components/matches/PlayerMatchInfo.vue
@@ -20,9 +20,9 @@
               class="truncated-text text-primary cursor-pointer"
               :class="[won, $props.highlighted ? 'font-weight-bold' : '']"
               v-bind="props"
-              @click="notClickable ? null : goToPlayer()"
-              @click.middle="openProfileInNewTab()"
-              @click.right="openProfileInNewTab()"
+              @click.stop="notClickable ? null : goToPlayer()"
+              @click.middle.stop="openProfileInNewTab()"
+              @click.right.stop="openProfileInNewTab()"
             >
               {{ nameWithoutBtag }}<span v-if="currentRating !== null"> ({{ currentRating }})<span v-if="mmrChange !== 0" class="number-text rating-text" :class="won">
                 <span v-if="mmrChange > 0">+</span>{{ mmrChange }}

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -89,6 +89,7 @@
       :is-player-profile="true"
       :show-heroes="showHeroIcons"
       :selectedHeroes="selectedHeroes"
+      inline-details
       @pageChanged="onPageChanged"
     />
   </div>

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -311,6 +311,8 @@ const data = {
       starttime: "Start time",
       duration: "Duration",
       replay: "Replay",
+      match: "Match",
+      openMatch: "Open match page",
       showHeroIcons: "Show Heroes",
       hideHeroIcons: "Hide Heroes",
     },

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -1,182 +1,23 @@
 <template>
   <v-container class="w3-container-width">
-    <div v-if="isJubileeGame" class="jubilee"></div>
-    <v-row v-if="!loading">
+    <v-row v-if="!loading && matchDetail.match">
       <v-col cols="12">
-        <v-card tile class="pb-5 pt-1">
-          <v-card-title class="justify-center">
-            <v-row justify="space-around">
-              <v-col cols="1" class="pl-0 pr-0">
-                <v-card-subtitle class="pa-0 text-uppercase opacity-100">
-                  <div>{{ $t(`gatewayNames.${gateWay}`) }}</div>
-                  <div>{{ $t(`views_matchdetail.season`) }}: {{ season }}</div>
-                </v-card-subtitle>
-                <host-icon
-                  v-if="match.serverInfo && match.serverInfo.provider"
-                  :host="match.serverInfo"
-                  style="padding-right: 0px"
-                />
-              </v-col>
-              <v-col v-if="!matchIsFFA" cols="4" align-self="center">
-                <team-match-info
-                  :big-race-icon="true"
-                  :left="true"
-                  :team="match.teams[0]"
-                />
-              </v-col>
-              <v-col cols="1" class="text-center" align-self="center">
-                <span v-if="!matchIsFFA">{{ $t(`views_matchdetail.vs`) }}</span>
-              </v-col>
-              <v-col v-if="!matchIsFFA" cols="4" align-self="center">
-                <team-match-info :big-race-icon="true" :team="match.teams[1]" />
-              </v-col>
-              <v-col v-if="matchIsFFA" cols="6" align-self="center">
-                <team-match-info
-                  class="ma-1"
-                  :big-race-icon="true"
-                  :team="match.teams[0]"
-                />
-                <team-match-info
-                  class="ma-1"
-                  :big-race-icon="true"
-                  :team="match.teams[1]"
-                />
-                <team-match-info
-                  class="ma-1"
-                  :big-race-icon="true"
-                  :team="match.teams[2]"
-                />
-                <team-match-info
-                  class="ma-1"
-                  :big-race-icon="true"
-                  :team="match.teams[3]"
-                />
-              </v-col>
-              <v-col cols="1" />
-              <div class="subicon">
-                <download-replay-icon :gameId="matchId" />
-              </div>
-            </v-row>
-          </v-card-title>
-          <div class="pb-2">
-            <v-card-title v-if="isJubileeGame" class="d-flex justify-center">
-              {{ $t(`views_matchdetail.jubileeGameNumber`, { gameNumber }) }}
-            </v-card-title>
-            <v-card-title v-if="isJubileeGame" class="d-flex justify-center">
-              {{ $t(`views_matchdetail.jubileeGameMessage`) }}
-            </v-card-title>
-            <v-card-title class="d-flex justify-center">
-              {{ `${mapNameFromMatch(match)} (${matchDuration}) | ${playedDate}` }}
-            </v-card-title>
-          </div>
-          <div v-if="isCompleteGame">
-            <match-detail-hero-row
-              v-for="(player, index) in scoresOfWinners"
-              :key="index"
-              :heroes-of-winner="scoresOfWinners[index]?.heroes"
-              :heroes-of-loser="scoresOfLosers[index]?.heroes"
-              :scores-of-winner="scoresOfWinners[index]?.heroScore"
-              :scores-of-loser="scoresOfLosers[index]?.heroScore"
-            />
-          </div>
-          <match-detail-hero-row
-            v-if="matchIsFFA && isCompleteGame"
-            :not-color-winner="true"
-            :heroes-of-winner="ffaLoser2?.heroes"
-            :heroes-of-loser="ffaLoser3?.heroes"
-            :scores-of-winner="ffaLoser2?.heroScore"
-            :scores-of-loser="ffaLoser3?.heroScore"
-          />
-          <v-row v-if="!isCompleteGame" class="justify-center">
-            <v-card-subtitle>
-              {{ $t(`views_matchdetail.incompletedata`) }}
-            </v-card-subtitle>
-          </v-row>
-          <v-row v-if="isCompleteGame && !matchIsFFA" class="justify-center">
-            <v-col cols="5" class="mr-7">
-              <player-performance-on-match
-                class="mt-4"
-                :unit-score="scoresOfWinners.map((h) => h.unitScore)"
-                :resource-score="scoresOfWinners.map((h) => h.resourceScore)"
-                :unit-score-opponent="scoresOfLosers.map((h) => h.unitScore)"
-                :resource-score-opponent="scoresOfLosers.map((h) => h.resourceScore)"
-                :left="true"
-              />
-            </v-col>
-            <v-col cols="5" class="ml-7">
-              <player-performance-on-match
-                class="mt-4"
-                :unit-score="scoresOfLosers.map((h) => h.unitScore)"
-                :resource-score="scoresOfLosers.map((h) => (h.resourceScore))"
-                :unit-score-opponent="scoresOfWinners.map((h) => h.unitScore)"
-                :resource-score-opponent="scoresOfWinners.map((h) => h.resourceScore)"
-              />
-            </v-col>
-          </v-row>
-          <v-row v-if="isCompleteGame && matchIsFFA" class="mb-3">
-            <v-col cols="2" />
-            <v-col>
-              <v-row v-for="(label, index) in rowLabels" :key="label" dense>
-                <v-col>
-                  {{ label }}
-                </v-col>
-                <v-col v-for="player in ffaPlayers" :key="player?.battleTag">
-                  <div v-if="index === 0">
-                    {{ battleTagToName(player?.battleTag) }}
-                  </div>
-                  <div v-if="index === 1">
-                    {{ player?.unitScore.unitsKilled }}
-                  </div>
-                  <div v-if="index === 2">
-                    {{ player?.unitScore.unitsProduced }}
-                  </div>
-                  <div v-if="index === 3">
-                    {{ player?.resourceScore.goldCollected }}
-                  </div>
-                  <div v-if="index === 4">
-                    {{ player?.resourceScore.lumberCollected }}
-                  </div>
-                  <div v-if="index === 5">
-                    {{ player?.resourceScore.goldUpkeepLost }}
-                  </div>
-                  <div v-if="index === 6">
-                    {{ player?.unitScore.largestArmy }}
-                  </div>
-                </v-col>
-              </v-row>
-            </v-col>
-            <v-col cols="1" />
-          </v-row>
-        </v-card>
+        <match-detail-content :match-detail="matchDetail" :match-id="matchId" />
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted } from "vue";
-import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
-import PlayerPerformanceOnMatch from "@/components/match-details/PlayerPerformanceOnMatch.vue";
-import MatchDetailHeroRow from "@/components/match-details/MatchDetailHeroRow.vue";
-import { Match, PlayerInTeam, PlayerScore, Team } from "@/store/types";
-import { Gateways } from "@/store/ranking/types";
-import HostIcon from "@/components/matches/HostIcon.vue";
-import { mapNameFromMatch } from "@/composables/MatchMixin";
-import DownloadReplayIcon from "@/components/matches/DownloadReplayIcon.vue";
-import { formatSecondsToDuration, formatTimestampStringToDateTime } from "@/helpers/date-functions";
+import { computed, defineComponent, onMounted, watch } from "vue";
+import MatchDetailContent from "@/components/match-details/MatchDetailContent.vue";
+import { MatchDetail } from "@/store/types";
 import { useMatchStore } from "@/store/match/store";
-import _keyBy from "lodash/keyBy";
-import { battleTagToName } from "@/helpers/profile";
-import { GAME_MODES_FFA } from "@/store/constants";
 
 export default defineComponent({
   name: "MatchDetailView",
   components: {
-    MatchDetailHeroRow,
-    PlayerPerformanceOnMatch,
-    TeamMatchInfo,
-    HostIcon,
-    DownloadReplayIcon,
+    MatchDetailContent,
   },
   props: {
     matchId: {
@@ -186,113 +27,14 @@ export default defineComponent({
   },
   setup(props) {
     const matchStore = useMatchStore();
-    const match = computed<Match>(() => matchStore.matchDetail.match);
-    const matchDuration = computed<string>(() => formatSecondsToDuration(match.value.durationInSeconds));
-    const playedDate = computed<string>(() => formatTimestampStringToDateTime(match.value.startTime));
-    const ffaPlayers = computed<PlayerScore[]>(() => [ffaWinner.value, ...ffaLosers.value]);
-    const gateWay = computed<string>(() => Gateways[matchStore.matchDetail.match.gateWay]);
-    const season = computed<number>(() => matchStore.matchDetail.match.season ?? 1);
-    const isCompleteGame = computed<PlayerScore[]>(() => matchStore.matchDetail.playerScores);
+    const matchDetail = computed<MatchDetail>(() => matchStore.matchDetail);
     const loading = computed<boolean>(() => matchStore.loadingMatchDetail);
 
-    const matchIsFFA = computed<boolean>(() => {
-      return GAME_MODES_FFA.includes(matchStore.matchDetail.match.gameMode);
-    });
-
-    const isJubileeGame = computed<boolean>(() => {
-      if (!match.value?.number) return false;
-      return match.value.number !== 0 && match.value?.number % 1000000 === 0;
-    });
-
-    const playerScores = computed<PlayerScore[]>(() => {
-      const { playerScores, match } = matchStore.matchDetail;
-      if (matchIsFFA.value) {
-        const ffaMappedPlayerScores = playerScores.map((playerScore) => {
-          const battleTag = match.serverInfo.playerServerInfos[playerScore.teamIndex].battleTag;
-          return {
-            ...playerScore,
-            battleTag,
-          };
-        });
-        matchStore.setPlayerScores(ffaMappedPlayerScores);
-        return ffaMappedPlayerScores ?? [];
-      }
-      return playerScores ?? [];
-    });
-
-    const scoresOfWinners = computed<PlayerScore[]>(() => {
-      const winningTeam = match.value.teams[0];
-      return getPlayerScores(winningTeam);
-    });
-
-    const scoresOfLosers = computed<PlayerScore[]>(() => {
-      const losingTeam = match.value.teams[1];
-      return getPlayerScores(losingTeam);
-    });
-
-    const ffaWinner = computed<PlayerScore>(() => playerScores.value.find(
-      (s) => s.battleTag === match.value.teams[0].players[0].battleTag
-    )!);
-
-    const ffaLosers = computed<PlayerScore[]>(() => playerScores.value.filter(
-      (s) => s.battleTag !== match.value.teams[0].players[0].battleTag
-    ));
-
-    const ffaLoser1 = computed<PlayerScore>(() => playerScores.value.find(
-      (s) => s.battleTag === match.value.teams[1].players[0].battleTag
-    )!);
-
-    const ffaLoser2 = computed<PlayerScore>(() => playerScores.value.find(
-      (s) => s.battleTag === match.value.teams[2].players[0].battleTag
-    )!);
-
-    const ffaLoser3 = computed<PlayerScore>(() => playerScores.value.find(
-      (s) => s.battleTag === match.value.teams[3].players[0].battleTag
-    )!);
-
-    const gameNumber = computed<string>(() => {
-      const number = match.value.number / 1000000;
-      switch (number) {
-        case 1:
-          return "one";
-        case 2:
-          return "two";
-        case 3:
-          return "three";
-        case 4:
-          return "four";
-        case 5:
-          return "five";
-        case 6:
-          return "six";
-        case 7:
-          return "seven";
-        case 8:
-          return "eight";
-        case 9:
-          return "nine";
-        default:
-          return "bazillion";
-      }
-    });
-
-    function getPlayerScores(team: Team): PlayerScore[] {
-      return team.players.map((p: PlayerInTeam) => {
-        const playerInTeamBattleTag = p.battleTag.toLowerCase();
-        const score = playerScores.value.find((score) => score.battleTag.toLowerCase() === playerInTeamBattleTag) || // Check exact match
-          playerScores.value.find((score) => score.battleTag.toLowerCase().includes(playerInTeamBattleTag.split("#", 1)[0])) || // Check without tag numbers
-          playerScores.value.find((score) => score.battleTag === p.inviteName); // Check inviteName match
-
-        return {
-          ...score ?? {} as PlayerScore,
-          battleTag: p.battleTag, // Use the battleTag from the Match (PlayerInTeam) record, since it is sometimes incorrect on the PlayerScore record
-        };
-      });
-    }
-
-    // watch(matchIdRef, init);
-
     onMounted((): void => {
+      init();
+    });
+
+    watch(() => props.matchId, (): void => {
       init();
     });
 
@@ -300,61 +42,10 @@ export default defineComponent({
       await matchStore.loadMatchDetail(props.matchId);
     }
 
-    const rowLabels = [
-      "",
-      "Units killed",
-      "Units produced",
-      "Gold mined",
-      "Lumber harvested",
-      "Upkeep lost",
-      "Largest army",
-    ];
-
     return {
-      mapNameFromMatch,
-      isJubileeGame,
       loading,
-      gateWay,
-      season,
-      match,
-      matchIsFFA,
-      gameNumber,
-      matchDuration,
-      playedDate,
-      isCompleteGame,
-      scoresOfWinners,
-      scoresOfLosers,
-      ffaLoser1,
-      ffaLoser2,
-      ffaLoser3,
-      rowLabels,
-      ffaPlayers,
-      battleTagToName
+      matchDetail,
     };
   },
 });
 </script>
-
-<style lang="scss" scoped>
-.small-title {
-  margin-top: -25px !important;
-  margin-bottom: -25px !important;
-}
-
-.jubilee {
-  position: absolute;
-  width: 80%;
-  height: 80%;
-  left: 10%;
-  z-index: 100;
-  background-image: url("/assets/giphy.gif") !important;
-  background-size: cover !important;
-}
-
-.subicon {
-  display: block;
-  position: absolute;
-  top: 8px;
-  right: 8px;
-}
-</style>


### PR DESCRIPTION
## Summary

Adds inline match details to player match history.

## Changes

- Extracts match detail rendering into `MatchDetailContent.vue` so it can be reused by both the standalone match page and inline match history rows.
- Enables expandable inline match details in `PlayerMatchesTab`.
- Updates `MatchesGrid` so finished match rows can expand inline while preserving:
  - player name navigation
  - match page button behavior
  - replay download behavior
- Adds Match/Open Match localization labels.

## Verification

- `npm run lint`
- `npm run build`
- local manual testing

<img width="1280" height="584" alt="Screenshot_3" src="https://github.com/user-attachments/assets/921e6b6a-9375-4201-bf68-8cfd5d9e5340" />

