### PR TITLE
Fix map filter on finished matches

### DIFF
--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -10,7 +10,7 @@ export default class MatchService {
     page: number,
     gateway: number,
     gameMode: EGameMode,
-    map: string,
+    mapName: string,
     mmr: Mmr,
     duration: { min: number; max: number },
     season: number,
@@ -26,7 +26,17 @@ export default class MatchService {
     const heroQuery = Array.isArray(heroes) && heroes.length > 0
       ? heroes.filter((h) => h > 0).map((h) => `&hero=${h}`).join("")
       : "";
-    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&map=${map}${minMmr}${maxMmr}${_durationQuery}&season=${season}${heroQuery}`;
+    const url = `${API_URL}api/matches?offset=${offset}&gateway=${gateway}&pageSize=${this.pageSize}&gameMode=${gameMode}&mapName=${mapName}${minMmr}${maxMmr}${_durationQuery}&season=${season}${heroQuery}`;
+
+    const response = await fetch(url);
+    return await response.json();
+  }
+
+  public static async retrieveMapNames(
+    season: number,
+    gameMode: EGameMode,
+  ): Promise<string[]> {
+    const url = `${API_URL}api/matches/map-names?season=${season}&gameMode=${gameMode}`;
 
     const response = await fetch(url);
     return await response.json();

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -15,6 +15,7 @@ export const useMatchStore = defineStore("match", {
     allOngoingMatches: [] as Match[],
     matchDetail: {} as MatchDetail,
     mapNames: [],
+    mapNamesCache: {},
     status: MatchStatus.onGoing,
     gameMode: EGameMode.GM_1ON1,
     map: "Overall",
@@ -96,7 +97,14 @@ export const useMatchStore = defineStore("match", {
         return;
       }
 
+      const cacheKey = `${this.selectedSeason.id}:${this.gameMode}`;
+      if (cacheKey in this.mapNamesCache) {
+        this.SET_MAP_NAMES(this.mapNamesCache[cacheKey]);
+        return;
+      }
+
       const mapNames = await MatchService.retrieveMapNames(this.selectedSeason.id, this.gameMode);
+      this.SET_MAP_NAMES_CACHE(cacheKey, mapNames);
       this.SET_MAP_NAMES(mapNames);
     },
     async setStatus(matchStatus: MatchStatus) {
@@ -169,6 +177,9 @@ export const useMatchStore = defineStore("match", {
     },
     SET_MAP_NAMES(mapNames: string[]): void {
       this.mapNames = mapNames;
+    },
+    SET_MAP_NAMES_CACHE(cacheKey: string, mapNames: string[]): void {
+      this.mapNamesCache[cacheKey] = mapNames;
     },
     SET_LOADING_MATCH_DETAIL(loading: boolean): void {
       this.loadingMatchDetail = loading;

--- a/src/store/match/store.ts
+++ b/src/store/match/store.ts
@@ -14,6 +14,7 @@ export const useMatchStore = defineStore("match", {
     matches: [] as Match[],
     allOngoingMatches: [] as Match[],
     matchDetail: {} as MatchDetail,
+    mapNames: [],
     status: MatchStatus.onGoing,
     gameMode: EGameMode.GM_1ON1,
     map: "Overall",
@@ -47,6 +48,13 @@ export const useMatchStore = defineStore("match", {
           return;
         }
       } else {
+        // If the selected map isn't available in this season, reset the map filter
+        const map = this.mapNames.includes(this.map) ? this.map : "Overall";
+
+        if (map !== this.map) {
+          this.SET_MAP(map);
+        }
+
         response = await MatchService.retrieveMatches(
           this.page - 1,
           rootStateStore.gateway,
@@ -82,15 +90,27 @@ export const useMatchStore = defineStore("match", {
       this.SET_MATCH_DETAIL(response);
       this.SET_LOADING_MATCH_DETAIL(false);
     },
+    async loadMapNames() {
+      if (this.status === MatchStatus.onGoing) {
+        this.SET_MAP_NAMES([]);
+        return;
+      }
+
+      const mapNames = await MatchService.retrieveMapNames(this.selectedSeason.id, this.gameMode);
+      this.SET_MAP_NAMES(mapNames);
+    },
     async setStatus(matchStatus: MatchStatus) {
       this.SET_STATUS(matchStatus);
+      this.SET_MAP("Overall");
       this.SET_PAGE(1);
+      await this.loadMapNames();
       await this.loadMatches();
     },
     async setGameMode(gameMode: EGameMode) {
       this.SET_GAME_MODE(gameMode);
       this.SET_MAP("Overall");
       this.SET_PAGE(1);
+      await this.loadMapNames();
       await this.loadMatches();
     },
     async setMap(map: string) {
@@ -116,6 +136,7 @@ export const useMatchStore = defineStore("match", {
     async setSeason(season: Season) {
       this.SET_SEASON(season);
       this.SET_PAGE(1);
+      await this.loadMapNames();
       await this.loadMatches();
     },
     async setPlayerScores(playerScores: PlayerScore[]) {
@@ -145,6 +166,9 @@ export const useMatchStore = defineStore("match", {
     },
     SET_MATCH_DETAIL(matchDetail: MatchDetail): void {
       this.matchDetail = matchDetail;
+    },
+    SET_MAP_NAMES(mapNames: string[]): void {
+      this.mapNames = mapNames;
     },
     SET_LOADING_MATCH_DETAIL(loading: boolean): void {
       this.loadingMatchDetail = loading;

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -6,6 +6,7 @@ export type MatchState = {
   matches: Match[];
   allOngoingMatches: Match[];
   matchDetail: MatchDetail;
+  mapNames: string[];
   page: number;
   totalMatches: number;
   loadingMatchDetail: boolean;

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -7,6 +7,7 @@ export type MatchState = {
   allOngoingMatches: Match[];
   matchDetail: MatchDetail;
   mapNames: string[];
+  mapNamesCache: Record<string, string[]>;
   page: number;
   totalMatches: number;
   loadingMatchDetail: boolean;

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -90,6 +90,13 @@ export default defineComponent({
     const showHeroSelect = computed<boolean>(() => gameMode.value === EGameMode.GM_1ON1 || gameMode.value === EGameMode.GM_1ON1_TOURNAMENT);
 
     const maps = computed<Array<MapInfo>>(() => {
+      if (!unfinished.value) {
+        // Ongoing matches need map AND mapName, hence this object with both properties
+        // Finished matches only need mapName, so just pass mapName as the value for both.
+        // Kind of stupid but would be complicated to fix
+        return matchStore.mapNames.map((mapName) => ({ map: mapName, mapName }));
+      }
+
       if (!currentSeason.value) {
         return [];
       }


### PR DESCRIPTION
This fixes the map filter being broken for finished matches.

For seasons 10+, we have the MapName in the MatchUp collection.

In this PR we get the distinct MapNames for the season, offer them as dropdown options, and filter by them.

For seasons 1-10, we will stop offering the Map filter for now. Steps could be taken to make those work too, in a future PR.

This would benefit from an index on MatchUp.MapName.

<img width="1303" height="861" alt="image" src="https://github.com/user-attachments/assets/b7f885b5-df16-4629-88d5-7f903326f177" />

[website-backend pr](https://github.com/w3champions/website-backend/pull/513)
