### PR TITLE
Add "Overall" column for map winrates stats

### DIFF
--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -55,6 +55,13 @@
                   :winThreshold="0.51"
                   :lossThreshold="0.49"
                 />
+                <player-stats-race-versus-race-on-map-table-cell
+                  :stats="item.overall"
+                  :compareRace="item.race"
+                  :winThreshold="0.51"
+                  :lossThreshold="0.49"
+                  :ignoreCompareRace="true"
+                />
               </tr>
             </template>
           </v-data-table>
@@ -69,7 +76,7 @@ import { computed, defineComponent, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { TranslateResult } from "vue-i18n";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
-import { Ratio, StatsPerMapAndRace, StatsPerWinrate } from "@/store/overallStats/types";
+import { RaceWinLoss, Ratio, StatsPerMapAndRace, StatsPerWinrate } from "@/store/overallStats/types";
 import { ERaceEnum } from "@/store/types";
 import { useOverallStatsStore } from "@/store/overallStats/store";
 import { DataTableHeader } from "vuetify";
@@ -118,6 +125,11 @@ export default defineComponent({
         sortable: false,
         align: "end",
       },
+      {
+        title: t("common.overall"),
+        sortable: false,
+        align: "end",
+      },
     ];
 
     const mmrs = computed<{ league: TranslateResult; mmr: number }[]>(() => {
@@ -146,7 +158,7 @@ export default defineComponent({
       return a.race - b.race;
     };
 
-    const raceWinrate = computed<Ratio[]>(() => {
+    const raceWinrate = computed<(Ratio & { overall: RaceWinLoss })[]>(() => {
       if (!statsPerRaceAndMap.value || !statsPerRaceAndMap.value[0] || !statsPerRaceAndMap.value[0].patchToStatsPerModes[selectedPatch.value]) {
         return [];
       }
@@ -162,8 +174,30 @@ export default defineComponent({
       // Sort both the rows and columns by race.
       return statsPerMapAndRace.ratio
         .sort(sortByRaceWithRandomLast)
-        .map((item) => ({ ...item, winLosses: [...item.winLosses].sort(sortByRaceWithRandomLast) }));
+        .map((item) => {
+          const winLosses = [...item.winLosses].sort(sortByRaceWithRandomLast);
+
+          return {
+            ...item,
+            winLosses,
+            overall: buildOverallWinLoss(item.race, winLosses),
+          };
+        });
     });
+
+    function buildOverallWinLoss(race: ERaceEnum, winLosses: RaceWinLoss[]): RaceWinLoss {
+      const wins = winLosses.reduce((total, entry) => total + entry.wins, 0);
+      const losses = winLosses.reduce((total, entry) => total + entry.losses, 0);
+      const games = winLosses.reduce((total, entry) => total + entry.games, 0);
+
+      return {
+        race,
+        wins,
+        losses,
+        games,
+        winrate: games > 0 ? wins / games : 0,
+      };
+    }
 
     const patches = computed<string[]>(() => {
       if (statsPerRaceAndMap.value[0]) {

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue
@@ -6,11 +6,11 @@
       </td>
     </template>
     <div>
-      <span class="number-text w3-won">{{ stats.wins }}W</span>
+      <span class="number-text w3-won">{{ formatTooltipNumber(stats.wins) }}W</span>
       -
-      <span class="number-text w3-lost">{{ stats.losses }}L</span>
+      <span class="number-text w3-lost">{{ formatTooltipNumber(stats.losses) }}L</span>
       &nbsp;&nbsp;
-      {{ $t("common.total") }} <span class="number-text">{{ stats.games }}</span>
+      {{ $t("common.total") }} <span class="number-text">{{ formatTooltipNumber(stats.games) }}</span>
     </div>
   </v-tooltip>
 </template>
@@ -44,8 +44,15 @@ export default defineComponent({
       required: false,
       default: undefined,
     },
+    ignoreCompareRace: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props) {
+    const formatTooltipNumber = (value: number): string => Intl.NumberFormat().format(value);
+
     const toWinText = computed<string>(() => {
       if (isComparingSameRace.value || props.stats.games == 0) {
         return "-";
@@ -73,6 +80,10 @@ export default defineComponent({
     });
 
     const isComparingSameRace = computed<boolean>(() => {
+      if (props.ignoreCompareRace) {
+        return false;
+      }
+
       // We must explicitly check nil here because compareRace could be RANDOM and !0 is true
       if (isNil(props.compareRace) || !props.stats) {
         return false;
@@ -82,6 +93,7 @@ export default defineComponent({
     });
 
     return {
+      formatTooltipNumber,
       toWinClass,
       toWinText,
     };


### PR DESCRIPTION
In Grubby discord, Solstice suggested an Overall column for these stats to show winrates per map per race totalling all matchups. It's useful to give a sense of which maps are good to veto or not, regardless of specific matchup.

<img width="1205" height="499" alt="image" src="https://github.com/user-attachments/assets/dbca0711-e8b3-4a5b-b28c-fef76697158a" />
