### PR TITLE
fix: reload match detail on route param change

### DIFF
--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -154,7 +154,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted } from "vue";
+import { computed, defineComponent, watch, toRef } from "vue";
 import TeamMatchInfo from "@/components/matches/TeamMatchInfo.vue";
 import PlayerPerformanceOnMatch from "@/components/match-details/PlayerPerformanceOnMatch.vue";
 import MatchDetailHeroRow from "@/components/match-details/MatchDetailHeroRow.vue";
@@ -290,14 +290,13 @@ export default defineComponent({
       });
     }
 
-    // watch(matchIdRef, init);
-
-    onMounted((): void => {
-      init();
-    });
+    watch(toRef(props, "matchId"), init, { immediate: true });
 
     async function init(): Promise<void> {
-      await matchStore.loadMatchDetail(props.matchId);
+      matchStore.SET_LOADING_MATCH_DETAIL(true);
+      const requestedId = props.matchId;
+      await matchStore.loadMatchDetail(requestedId);
+      if (props.matchId !== requestedId) return;
     }
 
     const rowLabels = [


### PR DESCRIPTION
Hey! The H2H history feature (#1045) introduces clickable match links within the match detail page, which meant we needed a routing optimization for the following: currently navigating between match detail pages updates the URL but doesn't reload the match data, because Vue Router reuses the component when only the route param changes. This PR adds a `watch` on the `matchId` prop with `immediate: true`, which calls `loadMatchDetail()` for the new match ID whenever the route param changes, while also handling the initial page load.

- Match data now reloads via Vue Router instead of requiring a full page reload — no browser refresh, faster navigation, and client-side state (stores, component data, caches) is preserved across navigations
- Includes a guard against stale API responses — if a user navigates between matches quickly on a slow connection, out-of-order responses are discarded to prevent showing the wrong match data. Uses the `immediate: true` pattern, matching the existing approach in `Player.vue`.

These changes won't add any visible or noticeable changes for end-users, its mainly architectural to accommodate new match-clickthrough features.

~Mark (thehighnotes)