### PR TITLE
Fix recent performance background CSS

### DIFF
--- a/src/scss/dark/nightelf.scss
+++ b/src/scss/dark/nightelf.scss
@@ -32,4 +32,10 @@
     position: absolute;
     z-index: 0;
   }
+
+  .recent-performance__results {
+    .v-chip__underlay {
+      background: transparent !important;
+    }
+  }
 }

--- a/src/scss/dark/undead.scss
+++ b/src/scss/dark/undead.scss
@@ -32,4 +32,10 @@
     position: absolute;
     z-index: 0;
   }
+
+  .recent-performance__results {
+    .v-chip__underlay {
+      background: transparent !important;
+    }
+  }
 }

--- a/src/scss/light/human.scss
+++ b/src/scss/light/human.scss
@@ -36,4 +36,10 @@
     position: absolute;
     z-index: 0;
   }
+
+  .recent-performance__results {
+    .v-chip__underlay {
+      background: transparent !important;
+    }
+  }
 }

--- a/src/scss/light/orc.scss
+++ b/src/scss/light/orc.scss
@@ -36,6 +36,12 @@
     position: absolute;
     z-index: 0;
   }
+
+  .recent-performance__results {
+    .v-chip__underlay {
+      background: transparent !important;
+    }
+  }
 }
 
 // #c12b12 orc red


### PR DESCRIPTION
Subtle but I realized my CSS changes for chips had a subtle background regression on the recent performance thing, so I need to add an exception for it

Bad:

<img width="264" height="91" alt="image" src="https://github.com/user-attachments/assets/0719b607-686e-40a9-9a46-5ddf6950900f" />

Good:

<img width="264" height="96" alt="image" src="https://github.com/user-attachments/assets/064068d8-a113-43f8-bc88-35384e067c6b" />
