### PR TITLE
Stats > Winrates: Default latest patch, rework MMR as slider

### DIFF
--- a/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
+++ b/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
@@ -1,0 +1,262 @@
+<template>
+  <div class="w-100">
+    <v-card-text class="text-body-1 w3-mid-emphasis pt-0 pl-1 pb-0">{{ $t("components_common_mmrselect.selectmmr") }}</v-card-text>
+    <v-card-text class="pt-6">
+      <v-range-slider
+        v-if="isBucketMode"
+        v-model="bucketIndexRange"
+        color="primary"
+        thumb-color="primary"
+        :min="0"
+        :max="bucketOptions.length - 1"
+        :step="1"
+        show-ticks="always"
+        :tick-labels="bucketLabels"
+        thumb-label="always"
+        class="pt-2"
+        strict
+        track-size="1"
+        hide-details
+        @update:model-value="onSliderUpdated"
+      >
+        <template #thumb-label="{ modelValue }">
+          <span :class="['mmr-thumb-label', { 'mmr-thumb-label--combined': isCombinedBucketThumbLabel(modelValue) }]">
+            {{ formatBucketThumbLabel(modelValue) }}
+          </span>
+        </template>
+      </v-range-slider>
+      <v-range-slider
+        v-else
+        v-model="currentMinMax"
+        color="primary"
+        thumb-color="primary"
+        min="0"
+        max="3000"
+        step="100"
+        thumb-label="always"
+        class="pt-2"
+        strict
+        track-size="1"
+        hide-details
+        @update:model-value="onSliderUpdated"
+      />
+    </v-card-text>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType, ref, watch } from "vue";
+import { Mmr } from "@/store/match/types";
+
+export default defineComponent({
+  name: "WinratesMmrRangeSlider",
+  props: {
+    mmr: {
+      type: Object as PropType<Mmr>,
+      required: true,
+    },
+    mmrOptions: {
+      type: Array as PropType<number[]>,
+      default: () => [],
+    },
+  },
+  setup(props, context) {
+    let previousMinMax: number[] = [props.mmr.min, props.mmr.max];
+    const currentMinMax = ref<number[]>([props.mmr.min, props.mmr.max]);
+
+    const bucketOptions = computed<number[]>(() => {
+      const buckets = [...new Set(props.mmrOptions)].sort((a, b) => a - b);
+
+      // The backend's 1000 bucket represents <=1200, so omit it from the slider UI.
+      if (buckets.includes(0) && buckets.includes(1000) && buckets.includes(1200)) {
+        return buckets.filter((bucket) => bucket !== 1000);
+      }
+
+      return buckets;
+    });
+
+    const isBucketMode = computed<boolean>(() => bucketOptions.value.length > 1);
+
+    function clampBucketIndex(index: number): number {
+      return Math.min(Math.max(index, 0), bucketOptions.value.length - 1);
+    }
+
+    function findClosestBucketIndex(value: number): number {
+      if (!bucketOptions.value.length) {
+        return 0;
+      }
+
+      let closestIndex = 0;
+      let closestDistance = Math.abs(bucketOptions.value[0] - value);
+
+      for (let i = 1; i < bucketOptions.value.length; i++) {
+        const distance = Math.abs(bucketOptions.value[i] - value);
+        if (distance < closestDistance) {
+          closestDistance = distance;
+          closestIndex = i;
+        }
+      }
+
+      return closestIndex;
+    }
+
+    function findClosestBucketValue(value: number): number {
+      if (!bucketOptions.value.length) {
+        return value;
+      }
+
+      return bucketOptions.value[findClosestBucketIndex(value)];
+    }
+
+    function normalizeSelection(): void {
+      if (!isBucketMode.value) {
+        return;
+      }
+
+      const snappedMin = findClosestBucketValue(currentMinMax.value[0]);
+      const snappedMax = findClosestBucketValue(currentMinMax.value[1]);
+      const normalizedMin = Math.min(snappedMin, snappedMax);
+      let normalizedMax = Math.max(snappedMin, snappedMax);
+
+      currentMinMax.value = [normalizedMin, normalizedMax];
+    }
+
+    const bucketIndexRange = computed<number[]>({
+      get: () => {
+        if (!isBucketMode.value || bucketOptions.value.length === 0) {
+          return [0, 0];
+        }
+
+        const minIndex = findClosestBucketIndex(currentMinMax.value[0]);
+        const maxIndex = findClosestBucketIndex(currentMinMax.value[1]);
+        return [Math.min(minIndex, maxIndex), Math.max(minIndex, maxIndex)];
+      },
+      set: (indexRange) => {
+        if (!isBucketMode.value || bucketOptions.value.length === 0) {
+          return;
+        }
+
+        const minIndex = clampBucketIndex(indexRange[0] ?? 0);
+        const maxIndex = clampBucketIndex(indexRange[1] ?? minIndex);
+        const from = Math.min(minIndex, maxIndex);
+        let to = Math.max(minIndex, maxIndex);
+
+        currentMinMax.value = [bucketOptions.value[from], bucketOptions.value[to]];
+      },
+    });
+
+    function bucketLowerBoundLabel(index: number): string {
+      const buckets = bucketOptions.value;
+      if (!buckets.length) return "";
+      const value = buckets[index];
+      return `${value}`;
+    }
+
+    function bucketUpperBoundLabel(index: number): string {
+      const buckets = bucketOptions.value;
+      if (!buckets.length) return "";
+      const value = buckets[index];
+      if (index === buckets.length - 1) return `${value}+`;
+      return `${buckets[index + 1]}`;
+    }
+
+    function bucketRangeLabel(index: number): string {
+      const lowerBound = bucketLowerBoundLabel(index);
+      const upperBound = bucketUpperBoundLabel(index);
+      if (upperBound.endsWith("+")) {
+        return upperBound;
+      }
+      return `${lowerBound}-${upperBound}`;
+    }
+
+    const bucketLabels = computed<string[]>(() => {
+      return bucketOptions.value.map((_, index) => bucketRangeLabel(index));
+    });
+
+    watch(
+      () => props.mmr,
+      (nextMmr) => {
+        currentMinMax.value = [nextMmr.min, nextMmr.max];
+        normalizeSelection();
+        previousMinMax = [currentMinMax.value[0], currentMinMax.value[1]];
+      },
+      { deep: true }
+    );
+
+    watch(
+      () => bucketOptions.value,
+      () => {
+        currentMinMax.value = [props.mmr.min, props.mmr.max];
+        normalizeSelection();
+        previousMinMax = [currentMinMax.value[0], currentMinMax.value[1]];
+      },
+      { immediate: true }
+    );
+
+    function hasSelectedDifferentMmr(): boolean {
+      return currentMinMax.value[0] !== previousMinMax[0] || currentMinMax.value[1] !== previousMinMax[1];
+    }
+
+    function onSliderUpdated(): void {
+      if (!isBucketMode.value) {
+        normalizeSelection();
+      }
+
+      if (!hasSelectedDifferentMmr()) {
+        return;
+      }
+
+      previousMinMax = [currentMinMax.value[0], currentMinMax.value[1]];
+      context.emit("mmrFilterChanged", { min: currentMinMax.value[0], max: currentMinMax.value[1] } as Mmr);
+    }
+
+    function formatBucketThumbLabel(modelValue: number): string {
+      if (!bucketOptions.value.length) return "";
+
+      const minIndex = findClosestBucketIndex(Math.min(currentMinMax.value[0], currentMinMax.value[1]));
+      const maxIndex = findClosestBucketIndex(Math.max(currentMinMax.value[0], currentMinMax.value[1]));
+
+      if (minIndex === maxIndex) {
+        return bucketRangeLabel(minIndex);
+      }
+
+      const thumbIndex = clampBucketIndex(Number(modelValue));
+      const isLeftThumb = thumbIndex <= minIndex;
+
+      return isLeftThumb ? bucketLowerBoundLabel(minIndex) : bucketUpperBoundLabel(maxIndex);
+    }
+
+    function isCombinedBucketThumbLabel(modelValue: number): boolean {
+      return formatBucketThumbLabel(modelValue).includes("-");
+    }
+
+    return {
+      currentMinMax,
+      bucketOptions,
+      bucketIndexRange,
+      bucketLabels,
+      isBucketMode,
+      onSliderUpdated,
+      formatBucketThumbLabel,
+      isCombinedBucketThumbLabel,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+:deep(.v-slider-thumb__label) {
+  padding: 0 6px;
+  white-space: nowrap;
+}
+
+.mmr-thumb-label {
+  display: inline-block;
+  min-width: 40px;
+  text-align: center;
+}
+
+.mmr-thumb-label--combined {
+  min-width: 64px;
+}
+</style>

--- a/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
+++ b/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
@@ -3,7 +3,6 @@
     <v-card-text class="text-body-1 w3-mid-emphasis pt-0 pl-1 pb-0">{{ $t("components_common_mmrselect.selectmmr") }}</v-card-text>
     <v-card-text class="pt-6">
       <v-range-slider
-        v-if="isBucketMode"
         v-model="bucketIndexRange"
         color="primary"
         thumb-color="primary"
@@ -25,21 +24,6 @@
           </span>
         </template>
       </v-range-slider>
-      <v-range-slider
-        v-else
-        v-model="currentMinMax"
-        color="primary"
-        thumb-color="primary"
-        min="0"
-        max="3000"
-        step="100"
-        thumb-label="always"
-        class="pt-2"
-        strict
-        track-size="1"
-        hide-details
-        @update:model-value="onSliderUpdated"
-      />
     </v-card-text>
   </div>
 </template>
@@ -75,8 +59,6 @@ export default defineComponent({
       return buckets;
     });
 
-    const isBucketMode = computed<boolean>(() => bucketOptions.value.length > 1);
-
     function clampBucketIndex(index: number): number {
       return Math.min(Math.max(index, 0), bucketOptions.value.length - 1);
     }
@@ -109,10 +91,6 @@ export default defineComponent({
     }
 
     function normalizeSelection(): void {
-      if (!isBucketMode.value) {
-        return;
-      }
-
       const snappedMin = findClosestBucketValue(currentMinMax.value[0]);
       const snappedMax = findClosestBucketValue(currentMinMax.value[1]);
       const normalizedMin = Math.min(snappedMin, snappedMax);
@@ -123,7 +101,7 @@ export default defineComponent({
 
     const bucketIndexRange = computed<number[]>({
       get: () => {
-        if (!isBucketMode.value || bucketOptions.value.length === 0) {
+        if (bucketOptions.value.length === 0) {
           return [0, 0];
         }
 
@@ -132,7 +110,7 @@ export default defineComponent({
         return [Math.min(minIndex, maxIndex), Math.max(minIndex, maxIndex)];
       },
       set: (indexRange) => {
-        if (!isBucketMode.value || bucketOptions.value.length === 0) {
+        if (bucketOptions.value.length === 0) {
           return;
         }
 
@@ -198,10 +176,6 @@ export default defineComponent({
     }
 
     function onSliderUpdated(): void {
-      if (!isBucketMode.value) {
-        normalizeSelection();
-      }
-
       if (!hasSelectedDifferentMmr()) {
         return;
       }
@@ -231,11 +205,9 @@ export default defineComponent({
     }
 
     return {
-      currentMinMax,
       bucketOptions,
       bucketIndexRange,
       bucketLabels,
-      isBucketMode,
       onSliderUpdated,
       formatBucketThumbLabel,
       isCombinedBucketThumbLabel,

--- a/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
+++ b/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
@@ -50,10 +50,12 @@ export default defineComponent({
 
     const bucketOptions = computed<number[]>(() => {
       const buckets = [...new Set(props.mmrOptions)].sort((a, b) => a - b);
+      const hasZeroBucket = buckets.includes(0);
+      const firstNonZeroIndex = buckets.findIndex((bucket) => bucket > 0);
+      const hasNextBucketAfterFirstNonZero = firstNonZeroIndex >= 0 && firstNonZeroIndex + 1 < buckets.length;
 
-      // The backend's 1000 bucket represents <=1200, so omit it from the slider UI.
-      if (buckets.includes(0) && buckets.includes(1000) && buckets.includes(1200)) {
-        return buckets.filter((bucket) => bucket !== 1000);
+      if (hasZeroBucket && hasNextBucketAfterFirstNonZero) {
+        return buckets.filter((_, index) => index !== firstNonZeroIndex);
       }
 
       return buckets;

--- a/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
+++ b/src/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue
@@ -19,7 +19,7 @@
         hide-details
         @update:model-value="onSliderUpdated"
       >
-        <template #thumb-label="{ modelValue }">
+        <template v-slot:thumb-label="{ modelValue }">
           <span :class="['mmr-thumb-label', { 'mmr-thumb-label--combined': isCombinedBucketThumbLabel(modelValue) }]">
             {{ formatBucketThumbLabel(modelValue) }}
           </span>
@@ -116,7 +116,7 @@ export default defineComponent({
       const snappedMin = findClosestBucketValue(currentMinMax.value[0]);
       const snappedMax = findClosestBucketValue(currentMinMax.value[1]);
       const normalizedMin = Math.min(snappedMin, snappedMax);
-      let normalizedMax = Math.max(snappedMin, snappedMax);
+      const normalizedMax = Math.max(snappedMin, snappedMax);
 
       currentMinMax.value = [normalizedMin, normalizedMax];
     }
@@ -139,7 +139,7 @@ export default defineComponent({
         const minIndex = clampBucketIndex(indexRange[0] ?? 0);
         const maxIndex = clampBucketIndex(indexRange[1] ?? minIndex);
         const from = Math.min(minIndex, maxIndex);
-        let to = Math.max(minIndex, maxIndex);
+        const to = Math.max(minIndex, maxIndex);
 
         currentMinMax.value = [bucketOptions.value[from], bucketOptions.value[to]];
       },

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { TranslateResult } from "vue-i18n";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
@@ -93,7 +93,38 @@ export default defineComponent({
     const selectedPatch = ref<string>("All");
     const selectedMmr = ref<number>(0);
     const selectedMap = ref<TranslateResult>(t("common.overall"));
+    const hasAutoSelectedPatch = ref(false);
     const statsPerRaceAndMap = computed<StatsPerWinrate[]>(() => overallStatsStore.statsPerMapAndRace);
+
+    function isNumericPatch(patch: string): boolean {
+      return patch
+        .split(".")
+        .every((segment) => /^\d+$/.test(segment));
+    }
+
+    function comparePatchesDescending(a: string, b: string): number {
+      const aIsNumeric = isNumericPatch(a);
+      const bIsNumeric = isNumericPatch(b);
+
+      if (aIsNumeric && !bIsNumeric) return -1;
+      if (!aIsNumeric && bIsNumeric) return 1;
+      if (!aIsNumeric && !bIsNumeric) return a.localeCompare(b);
+
+      const aSegments = a.split(".").map((segment) => Number.parseInt(segment, 10));
+      const bSegments = b.split(".").map((segment) => Number.parseInt(segment, 10));
+      const maxLength = Math.max(aSegments.length, bSegments.length);
+
+      for (let i = 0; i < maxLength; i++) {
+        const aValue = aSegments[i] ?? 0;
+        const bValue = bSegments[i] ?? 0;
+
+        if (aValue !== bValue) {
+          return bValue - aValue;
+        }
+      }
+
+      return bSegments.length - aSegments.length;
+    }
 
     const headers: DataTableHeader[] = [
       {
@@ -147,7 +178,10 @@ export default defineComponent({
     const maps = computed<{ mapId: string; mapName: TranslateResult }[]>(() => {
       const stats = statsPerRaceAndMap.value[0];
       if (!stats) return [];
-      return stats.patchToStatsPerModes[selectedPatch.value].map((r) => {
+      const patchStats = stats.patchToStatsPerModes[selectedPatch.value];
+      if (!patchStats) return [];
+
+      return patchStats.map((r) => {
         return { mapId: r.mapName, mapName: t("mapNames." + r.mapName) };
       });
     });
@@ -214,10 +248,28 @@ export default defineComponent({
           }
         }
 
-        return allowedPatches;
+        const sortedPatches = allowedPatches
+          .filter((patch) => patch !== "All")
+          .sort(comparePatchesDescending);
+
+        return ["All", ...sortedPatches];
       }
       return [];
     });
+
+    watch(
+      patches,
+      (availablePatches) => {
+        if (hasAutoSelectedPatch.value || availablePatches.length === 0) {
+          return;
+        }
+
+        const latestNumericPatch = availablePatches.find((patch) => isNumericPatch(patch));
+        selectedPatch.value = latestNumericPatch ?? availablePatches[0];
+        hasAutoSelectedPatch.value = true;
+      },
+      { immediate: true }
+    );
 
     function getNumberOfMatches(patchStats: StatsPerMapAndRace[]) {
       const dict: { [key: string]: number } = {};

--- a/src/components/overall-statistics/tabs/WinratesTab.vue
+++ b/src/components/overall-statistics/tabs/WinratesTab.vue
@@ -4,6 +4,16 @@
       <v-col cols="md-4">
         <v-card-text>
           <v-select
+            v-model="selectedPatch"
+            :items="patches"
+            item-title="patchVersion"
+            item-value="patch"
+            :label="$t(`components_overall-statistics_tabs_winratestab.selectpatch`)"
+            variant="outlined"
+            color="primary"
+            @update:model-value="setSelectedPatch"
+          />
+          <v-select
             v-model="selectedMap"
             :items="maps"
             item-title="mapName"
@@ -13,25 +23,10 @@
             color="primary"
             @update:model-value="setSelectedMap"
           />
-          <v-select
-            v-model="selectedMmr"
-            :items="mmrs"
-            item-title="league"
-            item-value="mmr"
-            :label="$t(`components_overall-statistics_tabs_winratestab.selectmmr`)"
-            variant="outlined"
-            color="primary"
-            @update:model-value="setSelectedMmr"
-          />
-          <v-select
-            v-model="selectedPatch"
-            :items="patches"
-            item-title="patchVersion"
-            item-value="patch"
-            :label="$t(`components_overall-statistics_tabs_winratestab.selectpatch`)"
-            variant="outlined"
-            color="primary"
-            @update:model-value="setSelectedPatch"
+          <winrates-mmr-range-slider
+            :mmr="selectedMmrRange"
+            :mmrOptions="mmrBuckets"
+            @mmrFilterChanged="setSelectedMmrRange"
           />
         </v-card-text>
       </v-col>
@@ -75,15 +70,18 @@
 import { computed, defineComponent, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { TranslateResult } from "vue-i18n";
+import WinratesMmrRangeSlider from "@/components/overall-statistics/tabs/WinratesMmrRangeSlider.vue";
 import PlayerStatsRaceVersusRaceOnMapTableCell from "@/components/player/PlayerStatsRaceVersusRaceOnMapTableCell.vue";
 import { RaceWinLoss, Ratio, StatsPerMapAndRace, StatsPerWinrate } from "@/store/overallStats/types";
 import { ERaceEnum } from "@/store/types";
 import { useOverallStatsStore } from "@/store/overallStats/store";
+import { Mmr } from "@/store/match/types";
 import { DataTableHeader } from "vuetify";
 
 export default defineComponent({
   name: "WinratesTab",
   components: {
+    WinratesMmrRangeSlider,
     PlayerStatsRaceVersusRaceOnMapTableCell,
   },
   setup() {
@@ -91,10 +89,16 @@ export default defineComponent({
     const overallStatsStore = useOverallStatsStore();
     const raceEnums = ERaceEnum;
     const selectedPatch = ref<string>("All");
-    const selectedMmr = ref<number>(0);
+    const selectedMmrRange = ref<Mmr>({ min: 0, max: 3000 });
     const selectedMap = ref<TranslateResult>(t("common.overall"));
     const hasAutoSelectedPatch = ref(false);
+    const hasAutoSelectedMmrRange = ref(false);
+    const hasAutoSelectedMap = ref(false);
     const statsPerRaceAndMap = computed<StatsPerWinrate[]>(() => overallStatsStore.statsPerMapAndRace);
+
+    const mmrBuckets = computed<number[]>(() => {
+      return [...new Set(statsPerRaceAndMap.value.map((stats) => stats.mmrRange))].sort((a, b) => a - b);
+    });
 
     function isNumericPatch(patch: string): boolean {
       return patch
@@ -163,18 +167,6 @@ export default defineComponent({
       },
     ];
 
-    const mmrs = computed<{ league: TranslateResult; mmr: number }[]>(() => {
-      const mmrsSorted = statsPerRaceAndMap.value
-        .map((r) => r.mmrRange)
-        .sort()
-        .reverse();
-      const mapped = mmrsSorted.map((m) => ({
-        league: t("mmrLeagueRanges.MMR_" + m),
-        mmr: m,
-      }));
-      return mapped;
-    });
-
     const maps = computed<{ mapId: string; mapName: TranslateResult }[]>(() => {
       const stats = statsPerRaceAndMap.value[0];
       if (!stats) return [];
@@ -197,16 +189,89 @@ export default defineComponent({
         return [];
       }
 
-      const statsPerMapAndRace = statsPerRaceAndMap.value
-        .filter((r) => r.mmrRange === selectedMmr.value)[0]
-        .patchToStatsPerModes[selectedPatch.value].filter(
-          (r) => r.mapName === selectedMap.value
-        )[0];
+      const ratioByRace = new Map<ERaceEnum, Map<ERaceEnum, RaceWinLoss>>();
 
-      if (!statsPerMapAndRace) return [];
+      const selectedBuckets = mmrBuckets.value;
+      if (!selectedBuckets.length) {
+        return [];
+      }
+
+      const rangeMinBucket = selectedBuckets[0];
+      const highestBucket = selectedBuckets[selectedBuckets.length - 1];
+      const firstRealBucket = selectedBuckets.find((bucket) => bucket > 0);
+      const isFullRangeSelection = selectedMmrRange.value.min === rangeMinBucket && selectedMmrRange.value.max === highestBucket;
+      const isFirstVisibleBucketOnlySelection =
+        selectedMmrRange.value.min === rangeMinBucket &&
+        selectedMmrRange.value.max === rangeMinBucket &&
+        firstRealBucket !== undefined;
+
+      const selectedStats = statsPerRaceAndMap.value.filter((stats) => {
+        if (isFullRangeSelection) {
+          return stats.mmrRange === 0;
+        }
+
+        if (isFirstVisibleBucketOnlySelection) {
+          return stats.mmrRange === firstRealBucket;
+        }
+
+        if (stats.mmrRange === 0) {
+          return false;
+        }
+
+        if (selectedMmrRange.value.max === highestBucket) {
+          return stats.mmrRange >= selectedMmrRange.value.min;
+        }
+
+        return stats.mmrRange >= selectedMmrRange.value.min && stats.mmrRange <= selectedMmrRange.value.max;
+      });
+
+      for (const stats of selectedStats) {
+        const patchStats = stats.patchToStatsPerModes[selectedPatch.value];
+        if (!patchStats) {
+          continue;
+        }
+
+        const statsPerMapAndRace = patchStats.find((mapStats) => mapStats.mapName === selectedMap.value);
+        if (!statsPerMapAndRace) {
+          continue;
+        }
+
+        for (const ratio of statsPerMapAndRace.ratio) {
+          if (!ratioByRace.has(ratio.race)) {
+            ratioByRace.set(ratio.race, new Map<ERaceEnum, RaceWinLoss>());
+          }
+
+          const winLossByOpponentRace = ratioByRace.get(ratio.race)!;
+          for (const winLoss of ratio.winLosses) {
+            const existing = winLossByOpponentRace.get(winLoss.race);
+            if (existing) {
+              const wins = existing.wins + winLoss.wins;
+              const losses = existing.losses + winLoss.losses;
+              const games = existing.games + winLoss.games;
+
+              winLossByOpponentRace.set(winLoss.race, {
+                race: winLoss.race,
+                wins,
+                losses,
+                games,
+                winrate: games > 0 ? wins / games : 0,
+              });
+            } else {
+              winLossByOpponentRace.set(winLoss.race, {
+                ...winLoss,
+              });
+            }
+          }
+        }
+      }
+
+      const aggregatedRatios: Ratio[] = Array.from(ratioByRace.entries()).map(([race, winLossByOpponentRace]) => ({
+        race,
+        winLosses: Array.from(winLossByOpponentRace.values()),
+      }));
 
       // Sort both the rows and columns by race.
-      return statsPerMapAndRace.ratio
+      return aggregatedRatios
         .sort(sortByRaceWithRandomLast)
         .map((item) => {
           const winLosses = [...item.winLosses].sort(sortByRaceWithRandomLast);
@@ -271,6 +336,38 @@ export default defineComponent({
       { immediate: true }
     );
 
+    watch(
+      mmrBuckets,
+      (availableBuckets) => {
+        if (hasAutoSelectedMmrRange.value || availableBuckets.length === 0) {
+          return;
+        }
+
+        selectedMmrRange.value = {
+          min: availableBuckets[0],
+          max: availableBuckets[availableBuckets.length - 1],
+        };
+        hasAutoSelectedMmrRange.value = true;
+      },
+      { immediate: true }
+    );
+
+    watch(
+      maps,
+      (availableMaps) => {
+        if (!availableMaps.length) {
+          return;
+        }
+
+        const hasSelectedMap = availableMaps.some((map) => map.mapId === selectedMap.value);
+        if (!hasSelectedMap || !hasAutoSelectedMap.value) {
+          selectedMap.value = availableMaps[0].mapId;
+          hasAutoSelectedMap.value = true;
+        }
+      },
+      { immediate: true }
+    );
+
     function getNumberOfMatches(patchStats: StatsPerMapAndRace[]) {
       const dict: { [key: string]: number } = {};
       let total = 0;
@@ -309,8 +406,8 @@ export default defineComponent({
       selectedMap.value = map;
     }
 
-    function setSelectedMmr(mmr: number): void {
-      selectedMmr.value = mmr;
+    function setSelectedMmrRange(mmr: Mmr): void {
+      selectedMmrRange.value = mmr;
     }
 
     function setSelectedPatch(patch: string): void {
@@ -323,9 +420,9 @@ export default defineComponent({
       maps,
       selectedMap,
       setSelectedMap,
-      mmrs,
-      selectedMmr,
-      setSelectedMmr,
+      selectedMmrRange,
+      mmrBuckets,
+      setSelectedMmrRange,
       patches,
       selectedPatch,
       setSelectedPatch,


### PR DESCRIPTION
- Defaults to latest patch. Old default of "All" is pretty useless, people are more interested to see the balance _now_, not the balance over the entire lifetime of the platform, pretty sure.
- The MMR stuff was very misleading and broken.
  - The data is broken down into buckets called 0, 1000, 1200, 1400, 1600, 1800, 2000, 2200. The 0 bucket actually means "All", the 1000 bucket actually means "<= 1200", the 1200 bucket means "1200-1400" and so on, 2200 actually means "2200+". See https://github.com/w3champions/website-backend/blob/ef9a26f733e1016adf440302316397c7533d795d/W3ChampionsStatisticService/W3ChampionsStats/OverallRaceAndWinStats/OverallRaceAndWinStatHandler.cs#L75-L84 for the function.
  - The old picker used labels like ">1000" which was straight up wrong because the real value was "<=1200" :joy: 
  - It was also misleading to label it with `>` because it was only showing a single bucket's data at a time, not actually that bucket up to max.
- So now it's reworked as a smart MMR slider which shows the correct ranges. Can now display ranges like 0-1200, 1400-1800, 0-2200+, and so on. It will combine the numbers from the relevant buckets together. 

Examples:

<img width="1243" height="484" alt="image" src="https://github.com/user-attachments/assets/9ed2fa81-f7eb-4fa6-ab58-ba8238a14a9d" />

<img width="1243" height="484" alt="image" src="https://github.com/user-attachments/assets/a9a2c2fc-5858-4a76-b68c-12e130518d06" />

<img width="1243" height="484" alt="image" src="https://github.com/user-attachments/assets/b8837ef1-07ac-4e45-aa05-4b984223b4e5" />

<img width="1243" height="484" alt="image" src="https://github.com/user-attachments/assets/6c728f8a-8271-4790-b8e9-bebad957d6b2" />

<img width="1243" height="484" alt="image" src="https://github.com/user-attachments/assets/db4a2354-3588-4562-9fb9-4b176e6d7e12" />

