### PR TITLE
fix: H2H load more was silently dropping new matches

### DIFF
--- a/src/components/match-details/MatchHeadToHead.vue
+++ b/src/components/match-details/MatchHeadToHead.vue
@@ -146,6 +146,10 @@ export default defineComponent({
       type: Number as PropType<Gateways>,
       required: true,
     },
+    gameMode: {
+      type: Number as PropType<EGameMode>,
+      required: true,
+    },
   },
   setup(props) {
     const router = useRouter();
@@ -231,7 +235,7 @@ export default defineComponent({
         0,
         props.playerBattleTag,
         props.opponentBattleTag,
-        EGameMode.GM_1ON1,
+        props.gameMode,
         ERaceEnum.TOTAL,
         ERaceEnum.TOTAL,
         props.gateway,

--- a/src/components/match-details/MatchHeadToHead.vue
+++ b/src/components/match-details/MatchHeadToHead.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!matchIsFFA && hasData" class="mt-8 mb-4">
+  <div v-if="hasData" class="mt-8 mb-4">
     <v-card-title class="d-flex justify-center">
       {{ $t("components_matchdetails_matchheadtohead.headToHead") }}
     </v-card-title>
@@ -22,8 +22,7 @@
             <span class="text-body-2 text-medium-emphasis score-name text-left">{{ opponentName }}</span>
           </div>
           <div class="text-caption text-medium-emphasis mt-1">
-            <template v-if="isCapped">{{ $t("components_matchdetails_matchheadtohead.last50") }}</template>
-            <template v-else>{{ stats.totalGames }} {{ $t("components_matchdetails_matchheadtohead.gamesPlayed") }}</template>
+            {{ stats.totalGames }} {{ $t("components_matchdetails_matchheadtohead.gamesPlayed") }}
           </div>
           <RecentPerformance v-if="recentFormStrings.length > 1" :last-ten-matches-performance="recentFormStrings" />
         </v-col>
@@ -147,10 +146,6 @@ export default defineComponent({
       type: Number as PropType<Gateways>,
       required: true,
     },
-    matchIsFFA: {
-      type: Boolean,
-      default: false,
-    },
   },
   setup(props) {
     const router = useRouter();
@@ -202,8 +197,6 @@ export default defineComponent({
       hasData.value = allMatches.length > 1;
     }
 
-    const isCapped = computed(() => h2hMatches.value.length >= MatchService.pageSize);
-
     const rankingStore = useRankingStore();
     const currentSeason = computed(() =>
       rankingStore.seasons.length > 0 ? rankingStore.seasons[0].id : props.season,
@@ -238,7 +231,7 @@ export default defineComponent({
         0,
         props.playerBattleTag,
         props.opponentBattleTag,
-        EGameMode.UNDEFINED,
+        EGameMode.GM_1ON1,
         ERaceEnum.TOTAL,
         ERaceEnum.TOTAL,
         props.gateway,
@@ -384,7 +377,6 @@ export default defineComponent({
       loading,
       loadingMore,
       hasData,
-      isCapped,
       canLoadMore,
       nextSeasonToLoad,
       loadMore,

--- a/src/components/match-details/MatchHeadToHead.vue
+++ b/src/components/match-details/MatchHeadToHead.vue
@@ -102,7 +102,6 @@ import { formatSecondsToDuration } from "@/helpers/date-functions";
 import { formatDistanceToNow, parseJSON } from "date-fns";
 
 const MAX_DURATION_BAR = 1800;
-const MAX_GROUPED_MATCHES = 15;
 
 interface H2HStats {
   wins: number;
@@ -356,8 +355,7 @@ export default defineComponent({
 
     const groupedMatches = computed(() => {
       const groups: { season: number; matches: Match[] }[] = [];
-      const filtered = h2hMatches.value.slice(0, MAX_GROUPED_MATCHES);
-      for (const match of filtered) {
+      for (const match of h2hMatches.value) {
         const last = groups[groups.length - 1];
         if (last && last.season === match.season) {
           last.matches.push(match);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -488,7 +488,6 @@ const en = {
   components_matchdetails_matchheadtohead: {
     headToHead: "Head-to-Head History",
     gamesPlayed: "games played",
-    last50: "Last 50 games",
     noGames: "No matches between these players",
     loadMore: "Load more",
     noMoreMatches: "No more matches found",

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -141,6 +141,7 @@
             :current-match-id="matchId"
             :season="season"
             :gateway="match.gateWay"
+            :game-mode="match.gameMode"
           />
           <v-row v-if="isCompleteGame && matchIsFFA" class="mb-3">
             <v-col cols="2" />

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -141,7 +141,6 @@
             :current-match-id="matchId"
             :season="season"
             :gateway="match.gateWay"
-            :match-is-f-f-a="matchIsFFA"
           />
           <v-row v-if="isCompleteGame && matchIsFFA" class="mb-3">
             <v-col cols="2" />


### PR DESCRIPTION
The 15-match cap in MatchHeadToHead was leftover from an early
exploration where "load more" was going to fetch in chunks of 15
matches at a time. We ended up going per-season instead and I
forgot to remove the cap, so loaded matches got appended to the
data but sliced out before rendering — count went up, rows didn't.

Reproduced on https://w3champions.com/match/69fbb53b6e63ce402f27c5ec
and confirmed fixed.

~Mark (thehighnotes)