### PR TITLE
Show H2H when only one match

### DIFF
--- a/src/components/match-details/MatchHeadToHead.vue
+++ b/src/components/match-details/MatchHeadToHead.vue
@@ -198,7 +198,7 @@ export default defineComponent({
       oldestLoadedSeason.value = cache.oldestLoadedSeason;
       consecutiveEmpty.value = cache.consecutiveEmpty;
       exhausted.value = cache.exhausted;
-      hasData.value = allMatches.length > 1;
+      hasData.value = allMatches.length > 0;
     }
 
     const rankingStore = useRankingStore();
@@ -266,7 +266,7 @@ export default defineComponent({
       h2hMatches.value = [...current, ...previous];
       oldestLoadedSeason.value = prevSeason;
       cache.oldestLoadedSeason = prevSeason;
-      hasData.value = h2hMatches.value.length > 1;
+      hasData.value = h2hMatches.value.length > 0;
       loading.value = false;
       scrollHighlightIntoView();
     });


### PR DESCRIPTION
FYI @thehighnotes it was hiding H2H when only a single match is played, but since we have Load More we sometimes want to be able to load older seasons even if there was only one match, so I'm making it show when there's at least 1 game (i.e. always, really)