### PR TITLE
feat(admin): render rich Patreon tier info with tier-id tooltip

### DIFF
--- a/src/components/admin/AdminDriftDetection.vue
+++ b/src/components/admin/AdminDriftDetection.vue
@@ -346,15 +346,30 @@ J<template>
                 class="elevation-0"
                 :header-props="{ class: ['text-medium-emphasis', 'font-weight-bold'] }"
               >
-                <template v-slot:item.entitledTierIds="{ item }">
-                  <v-chip
-                    v-for="tierId in item.entitledTierIds"
-                    :key="tierId"
-                    size="small"
-                    class="mr-1"
+                <template v-slot:item.entitledTiers="{ item }">
+                  <v-tooltip
+                    v-for="tier in item.entitledTiers"
+                    :key="tier.tierId"
+                    location="top"
+                    content-class="w3-tooltip elevation-1"
                   >
-                    {{ tierId }}
-                  </v-chip>
+                    <template v-slot:activator="{ props }">
+                      <v-chip
+                        size="small"
+                        color="orange"
+                        class="mr-1"
+                        v-bind="props"
+                      >
+                        {{ tierDisplayLabel(tier) }}
+                      </v-chip>
+                    </template>
+                    <div>
+                      <div><strong>ID:</strong> {{ tier.tierId }}</div>
+                      <div v-if="formatAmount(tier.amountCents)">
+                        <strong>Amount:</strong> {{ formatAmount(tier.amountCents) }}
+                      </div>
+                    </div>
+                  </v-tooltip>
                 </template>
               </v-data-table>
             </v-expansion-panel-text>
@@ -471,7 +486,7 @@ J<template>
 import { computed, defineComponent, onMounted, ref } from "vue";
 import { useOauthStore } from "@/store/oauth/store";
 import AdminService from "@/services/admin/AdminService";
-import { DriftDetectionResult, ReconciliationResult, DriftSyncResult } from "@/store/admin/types";
+import { DriftDetectionResult, DriftSyncResult, EntitledTier, ReconciliationResult } from "@/store/admin/types";
 import {
   mdiPatreon, mdiAlert, mdiCheckCircle, mdiRefresh,
   mdiAccountMinus, mdiAccountPlus, mdiAccountAlert,
@@ -502,7 +517,7 @@ export default defineComponent({
       { title: "Patreon Member ID", value: "patreonMemberId", sortable: true },
       { title: "Email", value: "email", sortable: true },
       { title: "Patron Status", value: "patronStatus", sortable: true },
-      { title: "Entitled Tiers", value: "entitledTierIds", sortable: false },
+      { title: "Entitled Tiers", value: "entitledTiers", sortable: false },
       { title: "Reason", value: "reason", sortable: false },
     ];
 
@@ -580,6 +595,15 @@ export default defineComponent({
       } catch (error) {
         console.error("Error loading drift detection status:", error);
       }
+    };
+
+    const tierDisplayLabel = (tier: EntitledTier): string => {
+      return tier.title?.trim() || tier.tierId;
+    };
+
+    const formatAmount = (amountCents: number | null): string | null => {
+      if (amountCents == null) return null;
+      return `$${(amountCents / 100).toFixed(2)}/mo`;
     };
 
     const formatDateTime = (dateString: string): string => {
@@ -697,6 +721,8 @@ export default defineComponent({
       mismatchedTiersHeaders,
       reconciliationDetailsHeaders,
       reconciliationDetailsItems,
+      tierDisplayLabel,
+      formatAmount,
       runDriftDetection,
       runReconciliationPreview,
       runReconciliation,

--- a/src/components/admin/AdminDriftDetection.vue
+++ b/src/components/admin/AdminDriftDetection.vue
@@ -1,4 +1,4 @@
-J<template>
+<template>
   <div>
     <v-card-title class="pt-3">
       Drift Detection Dashboard

--- a/src/components/admin/AdminPatreonLinks.vue
+++ b/src/components/admin/AdminPatreonLinks.vue
@@ -287,7 +287,7 @@
           </div>
 
           <!-- Tier Information -->
-          <div v-if="memberDetails.found && memberDetails.entitledTierIds" class="mt-4">
+          <div v-if="memberDetails.found && memberDetails.entitledTiers" class="mt-4">
             <v-divider class="mb-4" />
             <div class="text-subtitle-1 text-medium-emphasis font-weight-bold mb-3">Tier Information</div>
 
@@ -295,16 +295,30 @@
               <v-col cols="12" md="6">
                 <v-card border class="pa-3">
                   <div class="text-caption text-medium-emphasis mb-2">Patreon Entitled Tiers</div>
-                  <v-chip
-                    v-for="tier in memberDetails.entitledTierIds"
-                    :key="tier"
-                    size="small"
-                    color="orange"
-                    class="mr-1 mb-1"
+                  <v-tooltip
+                    v-for="tier in memberDetails.entitledTiers"
+                    :key="tier.tierId"
+                    location="top"
+                    content-class="w3-tooltip elevation-1"
                   >
-                    {{ tier }}
-                  </v-chip>
-                  <div v-if="!memberDetails.entitledTierIds.length" class="text-caption">No tiers</div>
+                    <template v-slot:activator="{ props }">
+                      <v-chip
+                        size="small"
+                        color="orange"
+                        class="mr-1 mb-1"
+                        v-bind="props"
+                      >
+                        {{ tierDisplayLabel(tier) }}
+                      </v-chip>
+                    </template>
+                    <div>
+                      <div><strong>ID:</strong> {{ tier.tierId }}</div>
+                      <div v-if="formatAmount(tier.amountCents)">
+                        <strong>Amount:</strong> {{ formatAmount(tier.amountCents) }}
+                      </div>
+                    </div>
+                  </v-tooltip>
+                  <div v-if="!memberDetails.entitledTiers.length" class="text-caption">No tiers</div>
                 </v-card>
               </v-col>
               <v-col cols="12" md="6">
@@ -363,7 +377,7 @@
 import { defineComponent, onMounted, ref } from "vue";
 import { useOauthStore } from "@/store/oauth/store";
 import AdminService from "@/services/admin/AdminService";
-import { PatreonAccountLink } from "@/store/admin/types";
+import { EntitledTier, PatreonAccountLink, PatreonMemberDetails } from "@/store/admin/types";
 import PlayerSearch from "@/components/common/PlayerSearch.vue";
 import {
   mdiMagnify, mdiRefresh, mdiDelete, mdiAccountHeart, mdiAccount,
@@ -397,8 +411,7 @@ export default defineComponent({
     // Member details functionality
     const memberDetailsDialog = ref(false);
 
-    // eslint-disable-next-line
-    const memberDetails = ref<any>(null);
+    const memberDetails = ref<PatreonMemberDetails | null>(null);
 
     const loadingMemberDetails = ref(false);
     const selectedMemberBattleTag = ref<string>("");
@@ -502,6 +515,15 @@ export default defineComponent({
       }
     };
 
+    const tierDisplayLabel = (tier: EntitledTier): string => {
+      return tier.title?.trim() || tier.tierId;
+    };
+
+    const formatAmount = (amountCents: number | null): string | null => {
+      if (amountCents == null) return null;
+      return `$${(amountCents / 100).toFixed(2)}/mo`;
+    };
+
     const showSnackbar = (message: string, color: string): void => {
       snackbarMessage.value = message;
       snackbarColor.value = color;
@@ -602,6 +624,8 @@ export default defineComponent({
       headers,
 
       // Methods
+      tierDisplayLabel,
+      formatAmount,
       loadPatreonLinks,
       filterLinks,
       clearFilters,

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -1,5 +1,5 @@
 import { API_URL } from "@/main";
-import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
+import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
 import { authorizedFetch } from "@/helpers/general";
 import { SmurfDetectionResult } from "./smurf-detection/SmurfDetectionResponse";
 
@@ -372,8 +372,7 @@ export default class AdminService {
     return response.ok;
   }
 
-  // eslint-disable-next-line
-  public static async getPatreonMemberDetails(battleTag: string, token: string): Promise<any> {
+  public static async getPatreonMemberDetails(battleTag: string, token: string): Promise<PatreonMemberDetails> {
     const url = `${API_URL}api/rewards/admin/patreon/members/${encodeURIComponent(battleTag)}`;
     const response = await authorizedFetch("GET", url, token);
     if (!response.ok) {

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -538,3 +538,27 @@ export interface LauncherChatMessage {
   time: string;
   battleTag: string;
 }
+
+export interface EntitledTier {
+  tierId: string;
+  amountCents: number | null;
+  title: string | null;
+}
+
+export interface PatreonMemberDetails {
+  found: boolean;
+  battleTag?: string;
+  patreonUserId?: string;
+  patreonMemberId?: string;
+  email?: string;
+  patronStatus?: string;
+  isActivePatron?: boolean;
+  entitledTiers: EntitledTier[];
+  lastChargeDate?: string;
+  lastChargeStatus?: string;
+  pledgeRelationshipStart?: string;
+  activeAssociationCount: number;
+  activeAssociationTiers: string[];
+  message?: string;
+  error?: string;
+}

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -553,12 +553,12 @@ export interface PatreonMemberDetails {
   email?: string;
   patronStatus?: string;
   isActivePatron?: boolean;
-  entitledTiers: EntitledTier[];
+  entitledTiers?: EntitledTier[];
   lastChargeDate?: string;
   lastChargeStatus?: string;
   pledgeRelationshipStart?: string;
-  activeAssociationCount: number;
-  activeAssociationTiers: string[];
+  activeAssociationCount?: number;
+  activeAssociationTiers?: string[];
   message?: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary

Renders the rich \`EntitledTier\` shape (companion to website-backend rewards-correctness PRs #515 / #516) on the two admin pages that show Patreon tier chips.

Each chip now displays the human-readable **Title** (e.g. \`Gold Tier Supporter\`) instead of the opaque tier ID. Hovering the chip shows a tooltip with **ID + Amount** (e.g. \`ID: 6482070\` / \`Amount: $10.00/mo\`) so debugging information stays one hover away.

### Bug fix included

\`AdminDriftDetection.vue\` was silently broken before this PR: the \"Entitled Tiers\" data-table column bound to a non-existent \`entitledTierIds\` field (the backend's drift endpoint already emitted the rich shape under \`entitledTiers\`). Tier chips never rendered. Fixed by binding the slot key to the correct field.

### Lockstep with website-backend

Backend PRs #515 (data correctness) and #516 (canonicalization) are merged. The wire shape on \`AdminRewardController.GetPatreonMemberDetails\`, \`PatreonWebhookController\` ack, and \`RewardDriftDetectionController.DetectPatreonDrift.missingMembers\` is now \`entitledTiers: [{tierId, amountCents, title}]\` (camelCase). This PR is the lockstep deploy partner — brief deploy-window misalignment is acceptable per agreed rollout plan.

## What changes

- **\`src/store/admin/types.ts\`** — adds \`EntitledTier\` and \`PatreonMemberDetails\` interfaces. Optional fields (\`entitledTiers?\`, \`activeAssociationCount?\`, \`activeAssociationTiers?\`) match the backend's two response shapes (\`found: true\` full vs \`found: false\` thin error).
- **\`src/services/admin/AdminService.ts\`** — \`getPatreonMemberDetails\` now typed \`Promise<PatreonMemberDetails>\` (was \`Promise<any>\`).
- **\`src/components/admin/AdminPatreonLinks.vue\`** — chips iterate \`entitledTiers\`, wrapped in \`<v-tooltip>\` with ID + amount; \`tierDisplayLabel\` falls back to tier ID when Title is null/empty (KoFi case); \`formatAmount\` returns \`"$X.XX/mo"\` for non-null cents.
- **\`src/components/admin/AdminDriftDetection.vue\`** — same chip + tooltip pattern; column header value + slot key fixed from \`entitledTierIds\` → \`entitledTiers\` (the bug fix). Boyscout: stripped a stray byte at the head of the file.

### Tooltip pattern

Uses the existing repo convention (\`v-tooltip location=\"top\" content-class=\"w3-tooltip elevation-1\"\` with \`v-slot:activator=\"{ props }\"\` + \`v-bind=\"props\"\`). Confirmed canonical by audit of \`ClanOverview.vue\`, \`AdminBannedPlayers.vue\`, \`EditMap.vue\`.

### Currency formatting

No existing helper; inline \`formatAmount(cents)\` returns \`\$\${(cents/100).toFixed(2)}/mo\` for non-null, \`null\` (line hidden) for null. Free-tier (\`amountCents = 0\`) renders as \`\$0.00/mo\`.

## Test plan

- [x] \`vue-tsc --noEmit\` clean for the four changed files.
- [x] \`tierDisplayLabel\` cases: title set → title; title null/empty → tier ID (KoFi).
- [x] \`formatAmount\` cases: \`1000\` → \`\"$10.00/mo\"\`; \`null\` → null (line hidden); \`0\` → \`\"$0.00/mo\"\`.
- [x] Empty \`entitledTiers\` array: \`AdminPatreonLinks\` shows \"No tiers\" caption; \`AdminDriftDetection\` shows empty cell.
- [x] Optional fields on \`PatreonMemberDetails\` match the backend's \`found:false\` thin error shape.
- [ ] Post-deploy: open Admin → Patreon Links → magnify a multi-tier user → see chips with titles + tooltips.
- [ ] Post-deploy: open Admin → Drift Detection → expand Missing Members table → tier chips render (was broken pre-PR).

No test framework exists in this repo; visual verification will happen against staging backend.