### PR TITLE
Dark-mode dropdown affordance + matches status toggle

### DIFF
--- a/src/components/common/DurationSelect.vue
+++ b/src/components/common/DurationSelect.vue
@@ -7,6 +7,7 @@
     <template v-slot:activator="{ props }">
       <v-btn
         tile
+        class="w3-dropdown-button"
         style="background-color: transparent; min-width: 180px;"
         v-bind="props"
       >

--- a/src/components/common/GameModeSelect.vue
+++ b/src/components/common/GameModeSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right" transition="fade-transition">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" start>{{ mdiControllerClassic }}</v-icon>
         {{ gameModeName() }}
       </v-btn>

--- a/src/components/common/GatewaySelect.vue
+++ b/src/components/common/GatewaySelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" style="margin-right: 5px">{{ mdiEarth }}</v-icon>
         {{ $t(gateway.name) }}
       </v-btn>

--- a/src/components/common/MapSelect.vue
+++ b/src/components/common/MapSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" start>{{ mdiMap }}</v-icon>
         {{ selected }}
       </v-btn>

--- a/src/components/common/MmrSelect.vue
+++ b/src/components/common/MmrSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right" :close-on-content-click="false" @update:model-value="onMenuToggled">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" start>{{ mdiChevronTripleUp }}</v-icon>
         {{ selected }}
       </v-btn>

--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         {{ $t("components_common_seasonselect.season") }} {{ selectedSeason.id }}
       </v-btn>
     </template>

--- a/src/components/matches/HeroIconToggle.vue
+++ b/src/components/matches/HeroIconToggle.vue
@@ -2,6 +2,7 @@
   <div v-if="!unfinished" style="margin-left: auto;">
     <v-btn
       tile
+      class="w3-dropdown-button"
       style="background-color: transparent"
       @click="toggle"
     >

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -19,6 +19,7 @@
       </v-btn>
       <v-btn
         v-else
+        class="w3-dropdown-button"
         style="background-color: transparent"
         v-bind="props"
       >

--- a/src/components/matches/MatchesStatusSelect.vue
+++ b/src/components/matches/MatchesStatusSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" start>{{ mdiControllerClassic }}</v-icon>
         {{ currentStatus.name }}
       </v-btn>

--- a/src/components/matches/MatchesStatusSelect.vue
+++ b/src/components/matches/MatchesStatusSelect.vue
@@ -1,31 +1,13 @@
 <template>
-  <v-menu location="right">
-    <template v-slot:activator="{ props }">
-      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
-        <v-icon size="x-large" start>{{ mdiControllerClassic }}</v-icon>
-        {{ currentStatus.name }}
-      </v-btn>
-    </template>
-    <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>
-            {{ $t("components_matches_matchesstatusselect.selectstatus") }}
-          </v-list-item-title>
-        </v-list>
-        <v-divider />
-        <v-list density="compact" max-height="400" class="overflow-y-auto">
-          <v-list-item
-            v-for="s in matchStatuses"
-            :key="s.status"
-            @click="currentStatus = s"
-          >
-            <v-list-item-title>{{ s.name }}</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
-  </v-menu>
+  <v-btn
+    tile
+    class="w3-dropdown-button"
+    style="background-color: transparent"
+    @click="toggleStatus"
+  >
+    <v-icon size="x-large" start>{{ mdiControllerClassic }}</v-icon>
+    {{ currentStatus.name }}
+  </v-btn>
 </template>
 
 <script lang="ts">
@@ -48,16 +30,6 @@ export default defineComponent({
     const { t } = useI18n();
     const matchStore = useMatchStore();
 
-    const currentStatus = computed<MatchStatusSelectData>({
-      get(): MatchStatusSelectData {
-        const selectedStatus = matchStore.status;
-        return matchStatuses.find((x) => x.status == selectedStatus)!;
-      },
-      set(val: MatchStatusSelectData): void {
-        matchStore.setStatus(val.status);
-      },
-    });
-
     const matchStatuses: MatchStatusSelectData[] = [
       {
         name: t("matchStatuses.onGoing"),
@@ -69,10 +41,21 @@ export default defineComponent({
       },
     ];
 
+    const currentStatus = computed<MatchStatusSelectData>(
+      () => matchStatuses.find((x) => x.status == matchStore.status)!,
+    );
+
+    const toggleStatus = (): void => {
+      const next = currentStatus.value.status === MatchStatus.onGoing
+        ? MatchStatus.past
+        : MatchStatus.onGoing;
+      matchStore.setStatus(next);
+    };
+
     return {
       mdiControllerClassic,
       currentStatus,
-      matchStatuses,
+      toggleStatus,
     };
   },
 });

--- a/src/components/matches/SortSelect.vue
+++ b/src/components/matches/SortSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu location="right">
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon size="x-large" start>{{ mdiSortAscending }}</v-icon>
         {{ currentSort.name }}
       </v-btn>

--- a/src/components/tournaments/TournamentSelect.vue
+++ b/src/components/tournaments/TournamentSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu>
     <template v-slot:activator="{ props }">
-      <v-btn tile style="background-color: transparent" v-bind="props">
+      <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
         <v-icon style="margin-right: 5px">{{ mdiTrophy }}</v-icon>
         {{ selectedTournamentText }}
       </v-btn>

--- a/src/scss/dark/index.scss
+++ b/src/scss/dark/index.scss
@@ -34,6 +34,26 @@
     }
   }
 
+  // Dropdown trigger buttons use a transparent bg, which strips Vuetify's
+  // default elevation shadow. Apply a light-RGBA shadow on dark themes so
+  // they read as buttons (parity with the affordance light themes get).
+  .w3-dropdown-button {
+    box-shadow:
+      0 3px 1px -2px rgba(255, 255, 255, 0.2),
+      0 2px 2px 0 rgba(255, 255, 255, 0.14),
+      0 1px 5px 0 rgba(255, 255, 255, 0.12);
+  }
+
+  // Floating overlays (menus, dialogs) blend into dark backgrounds because
+  // their card uses near-black bg and Vuetify's shadow is dark-RGBA. A subtle
+  // border defines the edge; a faint inverted shadow gives just enough lift.
+  .v-overlay__content {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow:
+      0 4px 6px -2px rgba(255, 255, 255, 0.08),
+      0 8px 12px 0 rgba(255, 255, 255, 0.06);
+  }
+
   &.v-application, &.v-overlay {
     .v-card-title, h3 {
       color: rgb(var(--v-theme-w3-gold));

--- a/src/scss/dark/index.scss
+++ b/src/scss/dark/index.scss
@@ -39,9 +39,9 @@
   // they read as buttons (parity with the affordance light themes get).
   .w3-dropdown-button {
     box-shadow:
-      0 3px 1px -2px rgba(255, 255, 255, 0.2),
-      0 2px 2px 0 rgba(255, 255, 255, 0.14),
-      0 1px 5px 0 rgba(255, 255, 255, 0.12);
+      0 2px 1px -2px rgba(200, 200, 200, 0.15),
+      0 1px 2px 0 rgba(200, 200, 200, 0.10),
+      0 1px 4px 0 rgba(200, 200, 200, 0.08);
   }
 
   // Floating overlays (menus, dialogs) blend into dark backgrounds because
@@ -50,8 +50,8 @@
   .v-overlay__content {
     border: 1px solid rgba(255, 255, 255, 0.12);
     box-shadow:
-      0 4px 6px -2px rgba(255, 255, 255, 0.08),
-      0 8px 12px 0 rgba(255, 255, 255, 0.06);
+      0 3px 6px -2px rgba(200, 200, 200, 0.06),
+      0 6px 12px 0 rgba(200, 200, 200, 0.04);
   }
 
   &.v-application, &.v-overlay {

--- a/src/views/CountryRankings.vue
+++ b/src/views/CountryRankings.vue
@@ -9,7 +9,7 @@
           <template v-slot:activator="{ props }">
             <v-btn
               tile
-              class="mr-3 bg-transparent"
+              class="mr-3 bg-transparent w3-dropdown-button"
               v-bind="props"
             >
               <h2 class="pa-0">Season {{ selectedSeason.id }}</h2>
@@ -44,7 +44,7 @@
         />
         <v-menu location="right">
           <template v-slot:activator="{ props }">
-            <v-btn tile style="background-color: transparent" v-bind="props">
+            <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
               <div
                 v-if="selectedCountry.countryCode"
                 class="mr-2"

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -7,7 +7,7 @@
       <v-card-text class="pt-2 pb-0 d-flex align-center flex-wrap">
         <v-menu location="right" transition="fade-transition">
           <template v-slot:activator="{ props }">
-            <v-btn tile class="ma-0 mr-3" style="background-color: transparent" v-bind="props">
+            <v-btn tile class="ma-0 mr-3 w3-dropdown-button" style="background-color: transparent" v-bind="props">
               <h2 class="pa-0">
                 {{ $t("views_rankings.season") }} {{ selectedSeason.id }}
               </h2>
@@ -46,7 +46,7 @@
         />
         <v-menu location="right" transition="fade-transition">
           <template v-slot:activator="{ props }">
-            <v-btn tile style="background-color: transparent" v-bind="props">
+            <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
               <league-icon :league="selectedLeagueOrder" />
               {{ selectedLeagueName }}
               {{ selectedLeague.division !== 0 ? selectedLeague.division : null }}


### PR DESCRIPTION
Sitewide dark-mode fix: transparent dropdown buttons looked like plain
text since the transparent bg strips Vuetify's elevation. Added a
`w3-dropdown-button` class and applied it across all Select components
plus the Rankings/CountryRankings menus. Floating menus had the same
problem on dark backgrounds, so `.v-overlay__content` gets a subtle
border and faint inverted shadow. Makes dark themes feel visually
consistent with the lighter ones.

Also turned the matches status filter into a single-button toggle since
it only ever had two options (Now Playing / Finished) and they're
unlikely to grow. Note: the
`components_matches_matchesstatusselect.selectstatus` i18n key is now
unused but I left it since I understand locales are managed via Google
Sheets.