### PR TITLE
Prompt login from chat modal if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "eslint-plugin-vue": "^10.9.1",
         "eslint-plugin-vuetify": "^2.7.2",
         "google-spreadsheet": "^5.2.0",
+        "jiti": "^2.7.0",
         "prettier": "2.8.8",
         "sass": "~1.99.0",
         "terser": "^5.29.2",
@@ -3038,6 +3039,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-vue": "^10.9.1",
     "eslint-plugin-vuetify": "^2.7.2",
     "google-spreadsheet": "^5.2.0",
+    "jiti": "^2.7.0",
     "prettier": "2.8.8",
     "sass": "~1.99.0",
     "terser": "^5.29.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -153,14 +153,14 @@
 </template>
 
 <script lang="ts">
-import { onBeforeMount, onMounted, defineComponent, computed, ref } from "vue";
+import { onBeforeMount, onBeforeUnmount, onMounted, defineComponent, computed, ref } from "vue";
 import { getProfileUrl } from "./helpers/url-functions";
 import SignInDialog from "@/components/common/SignInDialog.vue";
 import BrandLogo from "@/components/common/BrandLogo.vue";
 import GlobalSearch from "@/components/common/GlobalSearch.vue";
 import { useOauthStore } from "@/store/oauth/store";
 import { useRootStateStore } from "@/store/rootState/store";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import languages from "@/locales/languages";
 import { useI18n } from "vue-i18n";
 import noop from "lodash/noop";
@@ -203,11 +203,13 @@ export default defineComponent({
   setup() {
     const { locale } = useI18n();
     const router = useRouter();
+    const route = useRoute();
     const oauthStore = useOauthStore();
     const rootStateStore = useRootStateStore();
     const savedLanguage = "en";
     const navigationDrawerOpen = ref(false);
     const theme = useTheme();
+    const loginReturnToKey = "w3-login-return-to";
 
     const showSignInDialog = ref(false);
     const selectedTheme = ref("human");
@@ -258,8 +260,20 @@ export default defineComponent({
       if (authCode.value) {
         openPlayerProfile();
       } else {
+        clearLoginReturnTo();
         showSignInDialog.value = true;
       }
+    }
+
+    function openSignInDialog(returnTo?: string): void {
+      if (returnTo) {
+        window.sessionStorage.setItem(loginReturnToKey, returnTo);
+      }
+      showSignInDialog.value = true;
+    }
+
+    function clearLoginReturnTo(): void {
+      window.sessionStorage.removeItem(loginReturnToKey);
     }
 
     function setNavigationDrawerOpen(val: boolean): void {
@@ -329,6 +343,11 @@ export default defineComponent({
       showSignInDialog.value = val;
     };
 
+    const handleOpenSignInDialog = (event: Event): void => {
+      const customEvent = event as CustomEvent<{ returnTo?: string }>;
+      openSignInDialog(customEvent.detail?.returnTo ?? route.fullPath);
+    };
+
     async function init() {
       rootStateStore.loadLocale();
       locale.value = savedLocale.get();
@@ -340,7 +359,12 @@ export default defineComponent({
     }
 
     onMounted(async () => {
+      window.addEventListener("w3-open-sign-in-dialog", handleOpenSignInDialog);
       await init();
+    });
+
+    onBeforeUnmount(() => {
+      window.removeEventListener("w3-open-sign-in-dialog", handleOpenSignInDialog);
     });
 
     onBeforeMount(() => {
@@ -367,6 +391,8 @@ export default defineComponent({
       rootStateStore,
       authCode,
       loginOrGoToProfile,
+      openSignInDialog,
+      clearLoginReturnTo,
       logout,
       loginName,
       battleTag,

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -5,6 +5,14 @@
       <v-row v-if="loading" justify="center" class="ma-1">
         <v-progress-circular indeterminate />
       </v-row>
+      <v-alert v-else-if="errorMessage" type="error" variant="tonal" class="ma-1">
+        <div class="d-flex align-center justify-space-between flex-wrap ga-2">
+          <span>{{ errorMessage }}</span>
+          <v-btn v-if="showLoginButton" variant="text" @click="promptLogin">
+            Log in again
+          </v-btn>
+        </div>
+      </v-alert>
       <v-row v-else-if="!messages || messages.length === 0" class="ma-1">
         <span class="text-medium-emphasis">This match had no chat messages.</span>
       </v-row>
@@ -29,6 +37,7 @@ import { computed, defineComponent, onMounted, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
 import { ReplayChatLog, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
+import { useRoute } from "vue-router";
 
 export default defineComponent({
   name: "AdminReplayChatLogMessages",
@@ -43,8 +52,11 @@ export default defineComponent({
   },
   setup(props) {
     const replayManagementStore = useReplayManagementStore();
+    const route = useRoute();
     const log = ref<ReplayChatLog>({} as ReplayChatLog);
     const loading = ref(false);
+    const errorMessage = ref<string>("");
+    const showLoginButton = ref(false);
 
     const messages = computed<ReplayMessage[]>(() => log.value.messages);
 
@@ -67,11 +79,42 @@ export default defineComponent({
       return name;
     }
 
+    function promptLogin(): void {
+      window.dispatchEvent(new CustomEvent("w3-open-sign-in-dialog", {
+        detail: {
+          returnTo: route.fullPath,
+        },
+      }));
+    }
+
+    function handleLoadError(error: unknown): void {
+      const status = typeof error === "object" && error !== null && "status" in error
+        ? (error as { status?: number }).status
+        : undefined;
+
+      if (status === 401) {
+        showLoginButton.value = true;
+        promptLogin();
+        errorMessage.value = "Your session expired while loading the chat log. Please log in again.";
+        return;
+      }
+
+      errorMessage.value = "We could not load the chat log right now. Please try again.";
+    }
+
     onMounted(async (): Promise<void> => {
       loading.value = true;
-      await replayManagementStore.loadChatLog(props.matchId);
-      log.value = replayManagementStore.chatLog;
-      loading.value = false;
+      errorMessage.value = "";
+      showLoginButton.value = false;
+
+      try {
+        await replayManagementStore.loadChatLog(props.matchId);
+        log.value = replayManagementStore.chatLog;
+      } catch (error) {
+        handleLoadError(error);
+      } finally {
+        loading.value = false;
+      }
     });
 
     return {
@@ -80,6 +123,9 @@ export default defineComponent({
       getSenderName,
       getTeam,
       getPrivateRecipientName,
+      errorMessage,
+      showLoginButton,
+      promptLogin,
     };
   },
 });

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -211,6 +211,12 @@ export default class AdminService {
     const url = `${API_URL}api/replays/${matchId}/chats`;
 
     const response = await authorizedFetch("GET", url, token);
+    if (!response.ok) {
+      const error = new Error("Failed to load chat log") as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+
     return response.json();
   }
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -30,20 +30,32 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const oauthStore = useOauthStore();
+    const loginReturnToKey = "w3-login-return-to";
 
     const account = computed<string>(() => oauthStore.blizzardVerifiedBtag);
     const authCode = computed<string>(() => oauthStore.token);
 
-    function openPlayerProfile() {
+    function openPlayerProfile(): void {
       router.push({
         path: getProfileUrl(account.value) + "?freshLogin=true",
       });
     }
 
+    function openRequestedReturnPath(): void {
+      const returnTo = window.sessionStorage.getItem(loginReturnToKey);
+      if (returnTo) {
+        window.sessionStorage.removeItem(loginReturnToKey);
+        router.replace(returnTo);
+        return;
+      }
+
+      openPlayerProfile();
+    }
+
     async function init(): Promise<void> {
       await oauthStore.authorizeWithCode(props.code);
       await oauthStore.loadBlizzardBtag(authCode.value);
-      openPlayerProfile();
+      openRequestedReturnPath();
     }
 
     onMounted((): void => {


### PR DESCRIPTION
- The new admin chat modal on match details pages was just showing "no messages" when there was an auth error which was misleading cause the games often do have messages. So we prompt the login flow now.
- Added a mechanism to return to the same page after login, used by the above.