### PR TITLE
fix(admin): correct rewards admin assignments search URL

### DIFF
--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -281,7 +281,7 @@ export default class AdminService {
   }
 
   public static async getUserAssignments(userId: string, token: string): Promise<RewardAssignment[]> {
-    const url = `${API_URL}api/rewards/assignments/${encodeURIComponent(userId)}`;
+    const url = `${API_URL}api/rewards/admin/assignments/${encodeURIComponent(userId)}`;
     const response = await authorizedFetch("GET", url, token);
     return await response.json();
   }


### PR DESCRIPTION
## Summary

- One-line fix in `src/services/admin/AdminService.ts:284`: `api/rewards/assignments/{userId}` → `api/rewards/admin/assignments/{userId}`. The per-user admin assignments search was 404'ing because the URL is missing the `/admin/` segment.

## Why

The backend route is defined at `AdminRewardController.cs:73` (`/api/rewards/admin`) + `[HttpGet(\"assignments/{userId}\")]` → full path `/api/rewards/admin/assignments/{userId}`. Compare to line 385 of `AdminService.ts` which correctly uses `/admin/assignments/all`.

Surfaced during a financial-correctness investigation in the backend repo (w3champions/website-backend#517 — orphan RewardAssignment bug). The admin tool was unreachable for per-user lookup, blocking diagnostic queries.

## Test plan

- [ ] Open the rewards admin page, search by BattleTag, confirm results render (no longer 404)
- [ ] Verify network tab shows `GET /api/rewards/admin/assignments/{encodedUserId}` returning 200