### PR TITLE
Use button-style dropdowns for player match filters

### DIFF
--- a/src/components/common/DurationSelect.vue
+++ b/src/components/common/DurationSelect.vue
@@ -8,7 +8,7 @@
       <v-btn
         tile
         class="w3-dropdown-button"
-        style="background-color: transparent; min-width: 180px;"
+        style="background-color: transparent"
         v-bind="props"
       >
         <v-icon size="x-large" start>{{ mdiTimerSand }}</v-icon>

--- a/src/components/common/GameModeSelect.vue
+++ b/src/components/common/GameModeSelect.vue
@@ -7,14 +7,10 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item>
-            <v-list-item-title>
-              {{ $t("components_common_gamemodeselect.selectgamemode") }}
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">
+          {{ $t("components_common_gamemodeselect.selectgamemode") }}
+        </div>
         <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item

--- a/src/components/common/MapSelect.vue
+++ b/src/components/common/MapSelect.vue
@@ -7,10 +7,8 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>{{ $t("common.selectmap") }}</v-list-item-title>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">{{ $t("common.selectmap") }}</div>
         <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item v-for="(m, index) in maps" :key="index" @click="selectMap(m.key)">

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -7,7 +7,11 @@
       :class="classes"
       menu-icon=""
       :append-inner-icon="mdiMagnify"
-      label="Search BattleTag"
+      :label="showFloatingLabel ? searchLabel : undefined"
+      :placeholder="showFloatingLabel ? undefined : searchLabel"
+      :persistent-placeholder="!showFloatingLabel"
+      :single-line="!showFloatingLabel"
+      :density="density"
       :items="searchedPlayers"
       item-title="battleTag"
       :no-data-text="noDataText"
@@ -51,9 +55,24 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: true,
+    },
+    showFloatingLabel: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    density: {
+      type: String,
+      required: false,
+      default: "default",
+    },
+    searchLabel: {
+      type: String,
+      required: false,
+      default: "Search BattleTag",
     }
   },
-  setup: (_props, context) => {
+  setup: (props, context) => {
     const input = ref<string>("");
     const isLoading = ref<boolean>(false);
     const SEARCH_DELAY = 500;
@@ -109,6 +128,9 @@ export default defineComponent({
       isLoading,
       searchedPlayers,
       clearSearch,
+      showFloatingLabel: props.showFloatingLabel,
+      density: props.density,
+      searchLabel: props.searchLabel,
     };
   },
 });

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -31,12 +31,14 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, watch } from "vue";
+import { computed, defineComponent, ref, watch, PropType } from "vue";
 import debounce from "debounce";
 import ProfileService from "@/services/ProfileService";
 
 import { mdiMagnify } from "@mdi/js";
 import { PlayerProfile } from "@/store/player/types";
+
+type SearchDensity = "default" | "comfortable" | "compact";
 
 export default defineComponent({
   name: "PlayerSearch",
@@ -62,7 +64,7 @@ export default defineComponent({
       default: true,
     },
     density: {
-      type: String,
+      type: String as PropType<SearchDensity>,
       required: false,
       default: "default",
     },
@@ -128,9 +130,6 @@ export default defineComponent({
       isLoading,
       searchedPlayers,
       clearSearch,
-      showFloatingLabel: props.showFloatingLabel,
-      density: props.density,
-      searchLabel: props.searchLabel,
     };
   },
 });

--- a/src/components/common/SeasonSelect.vue
+++ b/src/components/common/SeasonSelect.vue
@@ -6,10 +6,9 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>{{ $t("components_common_seasonselect.prevseasons") }}</v-list-item-title>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">{{ $t("components_common_seasonselect.prevseasons") }}</div>
+        <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item v-for="season in seasons" :key="season.id" @click="selectSeason(season)">
             <v-list-item-title>{{ $t("components_common_seasonselect.season") }} {{ season.id }}</v-list-item-title>

--- a/src/components/matches/HeroSelect.vue
+++ b/src/components/matches/HeroSelect.vue
@@ -28,10 +28,8 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>{{ $t("common.selecthero_highestlevel") }}</v-list-item-title>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">{{ $t("common.selecthero_highestlevel") }}</div>
         <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item

--- a/src/components/matches/SortSelect.vue
+++ b/src/components/matches/SortSelect.vue
@@ -7,10 +7,8 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>{{ $t("components_matches_sortselect.sortmatchesby") }}</v-list-item-title>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">{{ $t("components_matches_sortselect.sortmatchesby") }}</div>
         <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item v-for="sort in sortings" :key="sort.mode" @click="currentSort = sort">

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -52,12 +52,11 @@
 import { computed, defineComponent, PropType, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { TranslateResult } from "vue-i18n";
-import { EGameMode, ERaceEnum, Match } from "@/store/types";
+import { EGameMode, Match } from "@/store/types";
 import { ModeStat } from "@/store/player/types";
 import RecentPerformance from "@/components/player/RecentPerformance.vue";
 import { getProfileUrl } from "@/helpers/url-functions";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
-import MatchService from "@/services/MatchService";
 import { usePlayerStore } from "@/store/player/store";
 import { useRootStateStore } from "@/store/rootState/store";
 import { Gateways, PlayerId, Season } from "@/store/ranking/types";
@@ -115,18 +114,7 @@ export default defineComponent({
     async function init(): Promise<void> {
       if (!props.showPerformance) return;
 
-      const playerMatches = await MatchService.retrievePlayerMatches(
-        0,
-        battleTag.value,
-        "",
-        gameMode.value,
-        ERaceEnum.TOTAL,
-        ERaceEnum.TOTAL,
-        gateWay.value,
-        selectedSeason.value.id
-      );
-
-      matches.value = playerMatches.matches;
+      matches.value = await playerStore.loadRecentPerformanceMatches(gameMode.value);
     }
 
     function navigateToPartner(partner: PlayerId): void {

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -1,68 +1,136 @@
 <template>
   <div>
     <v-card-title class="pb-0 pt-3">
-      {{ $t("components_player_tabs_matchhistorytab.title") }}
-    </v-card-title>
-    <v-card-text class="pb-3">
-      <v-row>
+      <v-row no-gutters align="end">
+        <v-col cols="auto" class="pa-0">
+          {{ $t("components_player_tabs_matchhistorytab.title") }}
+        </v-col>
         <v-spacer />
-        <v-col cols="12" md="5" class="pt-0 px-4">
-          <player-search
-            :key="battleTag"
-            :setAutofocus="false"
-            @playerFound="playerFound"
-            @searchCleared="searchCleared"
-          />
+        <v-col cols="auto" class="pa-0 d-flex justify-end align-end player-match-title-search-col">
+          <div class="player-match-search-wrap">
+            <player-search
+              :key="battleTag"
+              :setAutofocus="false"
+              :showFloatingLabel="false"
+              density="compact"
+              searchLabel="Search Opponents"
+              @playerFound="playerFound"
+              @searchCleared="searchCleared"
+            />
+          </div>
         </v-col>
       </v-row>
-      <v-row>
-        <v-col cols="12" md="2">
-          <v-select
-            :items="activeGameModesWithAll()"
-            item-title="name"
-            item-value="id"
-            :model-value="profileMatchesGameMode"
-            label="Mode"
-            variant="outlined"
-            color="primary"
-            hide-details
-            @update:model-value="setSelectedGameModeForSearch"
-          />
+    </v-card-title>
+    <v-card-text class="pt-4 pb-3">
+      <v-row no-gutters align="end" class="player-match-controls-row">
+        <v-col cols="auto" class="pa-0">
+          <v-menu location="right" transition="fade-transition">
+            <template v-slot:activator="{ props }">
+              <v-btn tile class="w3-dropdown-button w-100" style="background-color: transparent" v-bind="props">
+                <v-icon size="x-large" start>{{ mdiControllerClassic }}</v-icon>
+                {{ selectedGameModeName }}
+              </v-btn>
+            </template>
+            <v-card>
+              <v-card-text class="dropdown-menu-content">
+                <div class="dropdown-menu-title">Mode</div>
+                <v-divider />
+                <v-list density="compact" max-height="400" class="overflow-y-auto">
+                  <v-list-item
+                    v-for="mode in activeGameModesWithAll()"
+                    :key="mode.id"
+                    @click="setSelectedGameModeForSearch(mode)"
+                  >
+                    <v-list-item-title>{{ mode.name }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-card-text>
+            </v-card>
+          </v-menu>
         </v-col>
-        <v-col cols="12" md="2">
-          <v-select
-            :items="races"
-            item-title="raceName"
-            item-value="raceId"
-            :model-value="playerRace"
-            label="Player Race"
-            variant="outlined"
-            color="primary"
-            hide-details
-            @update:model-value="setPlayerRaceForSearch"
-          />
+        <v-col cols="auto" class="pa-0">
+          <v-menu location="right">
+            <template v-slot:activator="{ props }">
+              <v-btn tile class="w3-dropdown-button w-100" style="background-color: transparent" v-bind="props">
+                {{ playerRaceButtonText }}
+                <img
+                  v-if="selectedPlayerRaceIcon"
+                  :src="selectedPlayerRaceIcon"
+                  :alt="playerRaceButtonText"
+                  class="race-filter-icon ml-2"
+                />
+              </v-btn>
+            </template>
+            <v-card>
+              <v-card-text class="dropdown-menu-content">
+                <div class="dropdown-menu-title">Player Race</div>
+                <v-divider />
+                <v-list density="compact" max-height="400" class="overflow-y-auto">
+                  <v-list-item
+                    v-for="race in races"
+                    :key="`player-race-${race.raceId}`"
+                    @click="setPlayerRaceForSearch(race.raceId)"
+                  >
+                    <template v-slot:prepend>
+                      <img
+                        v-if="race.icon"
+                        :src="race.icon"
+                        :alt="race.raceName"
+                        class="race-filter-icon mr-3"
+                      />
+                    </template>
+                    <v-list-item-title>{{ race.raceName }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-card-text>
+            </v-card>
+          </v-menu>
         </v-col>
-        <v-col cols="12" md="2">
-          <v-select
-            :items="races"
-            item-title="raceName"
-            item-value="raceId"
-            :model-value="opponentRace"
-            label="Opponent Race"
-            variant="outlined"
-            color="primary"
-            hide-details
-            @update:model-value="setOpponentRaceForSearch"
-          />
+        <v-col cols="auto" class="pa-0">
+          <v-menu location="right">
+            <template v-slot:activator="{ props }">
+              <v-btn tile class="w3-dropdown-button w-100" style="background-color: transparent" v-bind="props">
+                {{ opponentRaceButtonText }}
+                <img
+                  v-if="selectedOpponentRaceIcon"
+                  :src="selectedOpponentRaceIcon"
+                  :alt="opponentRaceButtonText"
+                  class="race-filter-icon ml-2"
+                />
+              </v-btn>
+            </template>
+            <v-card>
+              <v-card-text class="dropdown-menu-content">
+                <div class="dropdown-menu-title">Opponent Race</div>
+                <v-divider />
+                <v-list density="compact" max-height="400" class="overflow-y-auto">
+                  <v-list-item
+                    v-for="race in races"
+                    :key="`opponent-race-${race.raceId}`"
+                    @click="setOpponentRaceForSearch(race.raceId)"
+                  >
+                    <template v-slot:prepend>
+                      <img
+                        v-if="race.icon"
+                        :src="race.icon"
+                        :alt="race.raceName"
+                        class="race-filter-icon mr-3"
+                      />
+                    </template>
+                    <v-list-item-title>{{ race.raceName }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-card-text>
+            </v-card>
+          </v-menu>
         </v-col>
-        <v-col cols="12" md="3">
+        <v-col cols="auto" class="pa-0">
           <hero-select
-            :is-player-matches-tab="true"
             :selectedHeroes="selectedHeroes"
             @heroChanged="heroChanged"
           />
         </v-col>
-        <v-col class="pt-5 pl-0">
+        <v-col class="pa-0 d-flex justify-end align-end player-match-search-col">
           <hero-icon-toggle :showHeroes="showHeroIcons" @update:showHeroes="showHeroIcons = $event" />
         </v-col>
       </v-row>
@@ -80,7 +148,11 @@
         </v-col>
       </v-row>
     </v-card-text>
+    <v-card-text v-if="isMatchHistoryLoading" class="d-flex justify-center py-10">
+      <v-progress-circular indeterminate color="primary" size="40" />
+    </v-card-text>
     <matches-grid
+      v-else
       v-model="matches"
       :total-matches="totalMatches"
       :items-per-page="50"
@@ -107,6 +179,15 @@ import { useRankingStore } from "@/store/ranking/store";
 import HeroIconToggle from "@/components/matches/HeroIconToggle.vue";
 import HeroSelect from "@/components/matches/HeroSelect.vue";
 import { useCommonStore } from "@/store/common/store";
+import { getAsset } from "@/helpers/url-functions";
+import { TranslateResult } from "vue-i18n";
+import { mdiControllerClassic } from "@mdi/js";
+
+interface RaceFilterOption {
+  raceName: TranslateResult;
+  raceId: ERaceEnum;
+  icon?: string;
+}
 
 export default defineComponent({
   name: "PlayerMatchesTab",
@@ -130,18 +211,105 @@ export default defineComponent({
     const isLoadingMatches = ref<boolean>(false);
     const foundPlayer = ref<string>("");
     const showHeroIcons = ref<boolean>(false);
+    const hasResolvedInitialMatches = ref<boolean>(false);
 
     const battleTag = computed<string>(() => decodeURIComponent(props.id));
     const totalMatches = computed<number>(() => playerStore.totalMatches);
     const matches = computed<Match[]>(() => playerStore.matches);
-    const profileMatchesGameMode = computed<EGameMode>(() => playerStore.profileMatchesGameMode);
-    const playerRace = computed<ERaceEnum | undefined>(() => playerStore.playerRace);
-    const opponentRace = computed<ERaceEnum | undefined>(() => playerStore.opponentRace);
     const selectedHeroes = computed<number[]>(() => playerStore.selectedHeroes);
+
+    const selectedGameModeName = ref<string>("All Modes");
+
+    function syncSelectedGameModeLabel(): void {
+      const normalized = Number(playerStore.profileMatchesGameMode);
+      if (Number.isNaN(normalized) || normalized === EGameMode.UNDEFINED) {
+        selectedGameModeName.value = "All Modes";
+        return;
+      }
+
+      const selected = activeGameModesWithAll().find((mode) => Number(mode.id) === normalized);
+      selectedGameModeName.value = selected?.name?.toString() ?? "All Modes";
+    }
+
+    const races = computed<RaceFilterOption[]>(() => [
+      { raceName: "Any", raceId: ERaceEnum.TOTAL },
+      {
+        raceName: t(`races.${ERaceEnum[ERaceEnum.HUMAN]}`),
+        raceId: ERaceEnum.HUMAN,
+        icon: getAsset(`raceIcons/${ERaceEnum[ERaceEnum.HUMAN]}.png`),
+      },
+      {
+        raceName: t(`races.${ERaceEnum[ERaceEnum.ORC]}`),
+        raceId: ERaceEnum.ORC,
+        icon: getAsset(`raceIcons/${ERaceEnum[ERaceEnum.ORC]}.png`),
+      },
+      {
+        raceName: t(`races.${ERaceEnum[ERaceEnum.NIGHT_ELF]}`),
+        raceId: ERaceEnum.NIGHT_ELF,
+        icon: getAsset(`raceIcons/${ERaceEnum[ERaceEnum.NIGHT_ELF]}.png`),
+      },
+      {
+        raceName: t(`races.${ERaceEnum[ERaceEnum.UNDEAD]}`),
+        raceId: ERaceEnum.UNDEAD,
+        icon: getAsset(`raceIcons/${ERaceEnum[ERaceEnum.UNDEAD]}.png`),
+      },
+      {
+        raceName: t(`races.${ERaceEnum[ERaceEnum.RANDOM]}`),
+        raceId: ERaceEnum.RANDOM,
+        icon: getAsset(`raceIcons/${ERaceEnum[ERaceEnum.RANDOM]}.png`),
+      },
+    ]);
+
+    function getRaceOption(race: ERaceEnum | undefined): RaceFilterOption {
+      const selectedRace = race ?? ERaceEnum.TOTAL;
+      return races.value.find((raceOption) => raceOption.raceId === selectedRace) ?? races.value[0];
+    }
+
+    const playerRaceButtonText = computed<string>(() => {
+      const selected = getRaceOption(playerStore.playerRace);
+      if (selected.raceId === ERaceEnum.TOTAL) {
+        return "Player Race";
+      }
+
+      return `Player ${selected.raceName.toString()}`;
+    });
+
+    const opponentRaceButtonText = computed<string>(() => {
+      const selected = getRaceOption(playerStore.opponentRace);
+      if (selected.raceId === ERaceEnum.TOTAL) {
+        return "Opponent Race";
+      }
+
+      return `Opponent ${selected.raceName.toString()}`;
+    });
+
+    const selectedPlayerRaceIcon = computed<string | undefined>(() => {
+      return getRaceOption(playerStore.playerRace).icon;
+    });
+
+    const selectedOpponentRaceIcon = computed<string | undefined>(() => {
+      return getRaceOption(playerStore.opponentRace).icon;
+    });
+
+    const isMatchHistoryLoading = computed<boolean>(() => {
+      return !hasResolvedInitialMatches.value
+        || playerStore.loadingProfile
+        || playerStore.loadingRecentMatches
+        || isLoadingMatches.value;
+    });
 
     onMounted(async (): Promise<void> => {
       await loadActiveGameModes();
       await commonStore.loadHeroFilters();
+      syncSelectedGameModeLabel();
+
+      if (
+        playerStore.playerProfile?.battleTag === battleTag.value
+        && !playerStore.loadingProfile
+        && !playerStore.loadingRecentMatches
+      ) {
+        hasResolvedInitialMatches.value = true;
+      }
     });
 
     onBeforeRouteLeave((): void => {
@@ -150,7 +318,24 @@ export default defineComponent({
 
     watch(battleTag, (newBattleTag: string, oldBattleTag: string | undefined): void => {
       if (!oldBattleTag || newBattleTag === oldBattleTag) return;
+      hasResolvedInitialMatches.value = false;
       resetProfileMatchFilters();
+    });
+
+    watch(() => playerStore.loadingRecentMatches, (isLoading, wasLoading): void => {
+      if (wasLoading && !isLoading) {
+        hasResolvedInitialMatches.value = true;
+      }
+    });
+
+    watch(() => playerStore.loadingProfile, (isLoading, wasLoading): void => {
+      if (wasLoading && !isLoading) {
+        hasResolvedInitialMatches.value = true;
+      }
+    });
+
+    watch(() => playerStore.profileMatchesGameMode, () => {
+      syncSelectedGameModeLabel();
     });
 
     function resetProfileMatchFilters(): void {
@@ -172,22 +357,22 @@ export default defineComponent({
       await getMatches();
     }
 
-    const races = [
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.TOTAL]}`), raceId: ERaceEnum.TOTAL },
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.HUMAN]}`), raceId: ERaceEnum.HUMAN },
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.ORC]}`), raceId: ERaceEnum.ORC },
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.NIGHT_ELF]}`), raceId: ERaceEnum.NIGHT_ELF },
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.UNDEAD]}`), raceId: ERaceEnum.UNDEAD },
-      { raceName: t(`races.${ERaceEnum[ERaceEnum.RANDOM]}`), raceId: ERaceEnum.RANDOM },
-    ];
-
     const winRateVsOpponent = computed<string>(() => {
       if (opponentWins.value == 0) return "0";
       return ((opponentWins.value / matches.value.length) * 100).toFixed(1);
     });
 
-    function setSelectedGameModeForSearch(gameMode: EGameMode): void {
+    function setSelectedGameModeForSearch(mode: { id: EGameMode | string | number; name?: string | TranslateResult }): void {
+      const normalized = Number(mode.id);
+      const gameMode = Number.isNaN(normalized) ? EGameMode.UNDEFINED : normalized as EGameMode;
       playerStore.SET_PROFILE_MATCHES_GAME_MODE(gameMode);
+
+      if (gameMode === EGameMode.UNDEFINED) {
+        selectedGameModeName.value = "All Modes";
+      } else {
+        selectedGameModeName.value = mode.name?.toString() ?? selectedGameModeName.value;
+      }
+
       getMatches();
     }
 
@@ -262,8 +447,12 @@ export default defineComponent({
       }
 
       isLoadingMatches.value = true;
-      await playerStore.loadMatches(page);
-      isLoadingMatches.value = false;
+      try {
+        await playerStore.loadMatches(page);
+      } finally {
+        isLoadingMatches.value = false;
+        hasResolvedInitialMatches.value = true;
+      }
     }
 
     async function onPageChanged(page: number): Promise<void> {
@@ -272,19 +461,23 @@ export default defineComponent({
 
     return {
       activeGameModesWithAll,
-      profileMatchesGameMode,
-      playerRace,
-      opponentRace,
       playerFound,
       searchCleared,
       setSelectedGameModeForSearch,
       races,
       setPlayerRaceForSearch,
       setOpponentRaceForSearch,
+      selectedGameModeName,
+      playerRaceButtonText,
+      opponentRaceButtonText,
+      selectedPlayerRaceIcon,
+      selectedOpponentRaceIcon,
+      mdiControllerClassic,
       foundPlayer,
       opponentWins,
       totalMatchesAgainstOpponent,
       winRateVsOpponent,
+      isMatchHistoryLoading,
       matches,
       totalMatches,
       battleTag,
@@ -296,3 +489,35 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.race-filter-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.player-match-search-col {
+  margin-left: 12px;
+}
+
+.player-match-title-search-col {
+  width: 250px;
+  max-width: 100%;
+}
+
+.player-match-search-wrap {
+  width: 250px;
+  max-width: 100%;
+}
+
+.player-match-search-col :deep(.w3-autocomplete) {
+  width: 100%;
+}
+
+@media (min-width: 960px) {
+  .player-match-controls-row {
+    flex-wrap: nowrap;
+  }
+}
+</style>

--- a/src/components/player/tabs/PlayerStatisticTab.vue
+++ b/src/components/player/tabs/PlayerStatisticTab.vue
@@ -7,7 +7,7 @@
         </v-card-text>
       </v-row>
     </div>
-    <v-card-title>
+    <v-card-title class="pb-0 pt-3">
       {{ $t("components_player_tabs_playerstatistictab.title") }}
     </v-card-title>
     <v-row v-if="selectedSeason.id !== 0">

--- a/src/components/tournaments/TournamentSelect.vue
+++ b/src/components/tournaments/TournamentSelect.vue
@@ -7,12 +7,10 @@
       </v-btn>
     </template>
     <v-card>
-      <v-card-text>
-        <v-list>
-          <v-list-item-title>
-            {{ $t("components_tournaments_tournamentselect.selecttourney") }}
-          </v-list-item-title>
-        </v-list>
+      <v-card-text class="dropdown-menu-content">
+        <div class="dropdown-menu-title">
+          {{ $t("components_tournaments_tournamentselect.selecttourney") }}
+        </div>
         <v-divider />
         <v-list density="compact" max-height="400" class="overflow-y-auto">
           <v-list-item

--- a/src/scss/shared/overrides.scss
+++ b/src/scss/shared/overrides.scss
@@ -54,3 +54,13 @@ h3 {
   position: relative;
   z-index: 1;
 }
+
+.dropdown-menu-content {
+  padding-top: 16px;
+  padding-bottom: 8px;
+}
+
+.dropdown-menu-title {
+  padding: 0 8px 8px;
+  font-size: 1.05rem;
+}

--- a/src/store/common/store.ts
+++ b/src/store/common/store.ts
@@ -3,14 +3,29 @@ import { CommonState } from "./types";
 import { HeroFilter } from "../heroes";
 import HeroService from "@/services/HeroService";
 
+let heroFiltersRequest: Promise<HeroFilter[]> | null = null;
+
 export const useCommonStore = defineStore("commonState", {
   state: (): CommonState => ({
     heroFilters: [] as HeroFilter[],
   } as CommonState),
   actions: {
     async loadHeroFilters() {
-      const filters = await HeroService.retrieveHeroes();
-      this.SET_HERO_FILTERS(filters);
+      if (this.heroFilters.length > 0) {
+        return this.heroFilters;
+      }
+
+      if (!heroFiltersRequest) {
+        heroFiltersRequest = HeroService.retrieveHeroes();
+      }
+
+      try {
+        const filters = await heroFiltersRequest;
+        this.SET_HERO_FILTERS(filters);
+        return filters;
+      } finally {
+        heroFiltersRequest = null;
+      }
     },
     getDefaultHeroFilter(): HeroFilter | undefined {
       if (this.heroFilters.length > 0) {

--- a/src/store/player/store.ts
+++ b/src/store/player/store.ts
@@ -9,6 +9,52 @@ import ProfileService from "@/services/ProfileService";
 import MatchService from "@/services/MatchService";
 import { defineStore } from "pinia";
 
+type PlayerMatchesResponse = { count: number; matches: Match[] };
+
+const playerMatchesCache = new Map<string, PlayerMatchesResponse>();
+const playerMatchesInFlight = new Map<string, Promise<PlayerMatchesResponse>>();
+const recentPerformanceCache = new Map<string, Match[]>();
+const recentPerformanceInFlight = new Map<string, Promise<Match[]>>();
+
+function buildPlayerMatchesCacheKey(params: {
+  page: number;
+  battleTag: string;
+  opponentTag: string;
+  gameMode: EGameMode;
+  playerRace: ERaceEnum;
+  opponentRace: ERaceEnum;
+  gateway: number;
+  season: number;
+  heroes: number[];
+}): string {
+  const heroesKey = params.heroes.length ? params.heroes.join(",") : "none";
+  return [
+    params.page,
+    params.battleTag,
+    params.opponentTag,
+    params.gameMode,
+    params.playerRace,
+    params.opponentRace,
+    params.gateway,
+    params.season,
+    heroesKey,
+  ].join("|");
+}
+
+function buildRecentPerformanceCacheKey(params: {
+  battleTag: string;
+  gameMode: EGameMode;
+  gateway: number;
+  season: number;
+}): string {
+  return [
+    params.battleTag,
+    params.gameMode,
+    params.gateway,
+    params.season,
+  ].join("|");
+}
+
 export const usePlayerStore = defineStore("player", {
   state: (): PlayerState => ({
     playerStatsRaceVersusRaceOnMap: {} as PlayerStatsRaceOnMapVersusRace,
@@ -92,20 +138,48 @@ export const usePlayerStore = defineStore("player", {
       this.SET_PAGE(page ?? 1);
       this.SET_LOADING_RECENT_MATCHES(true);
       const rootStateStore = useRootStateStore();
-      const response = await MatchService.retrievePlayerMatches(
-        this.page - 1,
-        this.battleTag,
-        this.opponentTag,
-        this.profileMatchesGameMode,
-        this.playerRace ?? ERaceEnum.TOTAL,
-        this.opponentRace ?? ERaceEnum.TOTAL,
-        rootStateStore.gateway,
-        this.selectedSeason?.id ?? -1,
-        this.selectedHeroes,
-      );
-      this.SET_TOTAL_MATCHES(response.count);
-      this.SET_MATCHES(response.matches);
-      this.SET_LOADING_RECENT_MATCHES(false);
+      const key = buildPlayerMatchesCacheKey({
+        page: this.page - 1,
+        battleTag: this.battleTag,
+        opponentTag: this.opponentTag,
+        gameMode: this.profileMatchesGameMode,
+        playerRace: this.playerRace ?? ERaceEnum.TOTAL,
+        opponentRace: this.opponentRace ?? ERaceEnum.TOTAL,
+        gateway: rootStateStore.gateway,
+        season: this.selectedSeason?.id ?? -1,
+        heroes: this.selectedHeroes,
+      });
+
+      try {
+        let response = playerMatchesCache.get(key);
+
+        if (!response) {
+          let request = playerMatchesInFlight.get(key);
+          if (!request) {
+            request = MatchService.retrievePlayerMatches(
+              this.page - 1,
+              this.battleTag,
+              this.opponentTag,
+              this.profileMatchesGameMode,
+              this.playerRace ?? ERaceEnum.TOTAL,
+              this.opponentRace ?? ERaceEnum.TOTAL,
+              rootStateStore.gateway,
+              this.selectedSeason?.id ?? -1,
+              this.selectedHeroes,
+            );
+            playerMatchesInFlight.set(key, request);
+          }
+
+          response = await request;
+          playerMatchesCache.set(key, response);
+        }
+
+        this.SET_TOTAL_MATCHES(response.count);
+        this.SET_MATCHES(response.matches);
+      } finally {
+        playerMatchesInFlight.delete(key);
+        this.SET_LOADING_RECENT_MATCHES(false);
+      }
     },
     async loadOngoingPlayerMatch(playerId: string) {
       const response = await MatchService.retrieveOnGoingPlayerMatch(playerId);
@@ -134,6 +208,44 @@ export const usePlayerStore = defineStore("player", {
       );
       this.SET_MMR_RP_TIMELINE(mmrRpTimeline);
       this.SET_LOADING_MMR_TIMELINE(false);
+    },
+    async loadRecentPerformanceMatches(gameMode: EGameMode): Promise<Match[]> {
+      const rootStateStore = useRootStateStore();
+      const key = buildRecentPerformanceCacheKey({
+        battleTag: this.battleTag,
+        gameMode,
+        gateway: rootStateStore.gateway,
+        season: this.selectedSeason?.id ?? -1,
+      });
+
+      const cached = recentPerformanceCache.get(key);
+      if (cached) {
+        return cached;
+      }
+
+      let request = recentPerformanceInFlight.get(key);
+      if (!request) {
+        request = MatchService.retrievePlayerMatches(
+          0,
+          this.battleTag,
+          "",
+          gameMode,
+          ERaceEnum.TOTAL,
+          ERaceEnum.TOTAL,
+          rootStateStore.gateway,
+          this.selectedSeason?.id ?? -1,
+        ).then((response) => response.matches);
+
+        recentPerformanceInFlight.set(key, request);
+      }
+
+      try {
+        const matches = await request;
+        recentPerformanceCache.set(key, matches);
+        return matches;
+      } finally {
+        recentPerformanceInFlight.delete(key);
+      }
     },
     async loadPlayerGameLengths() {
       const playerGameLengthStats = await ProfileService.retrievePlayerGameLengthStats(
@@ -263,6 +375,12 @@ export const usePlayerStore = defineStore("player", {
       this.SET_OPPONENT_RACE(undefined);
       this.SET_SELECTED_HEROES([]);
       this.SET_PAGE(1);
+    },
+    invalidateMatchesCache(): void {
+      playerMatchesCache.clear();
+      playerMatchesInFlight.clear();
+      recentPerformanceCache.clear();
+      recentPerformanceInFlight.clear();
     },
     SET_ONGOING_MATCH(match: Match): void {
       this.ongoingMatch = match;

--- a/src/views/Matches.vue
+++ b/src/views/Matches.vue
@@ -4,18 +4,31 @@
       <v-col cols="12">
         <v-card tile>
           <v-card-title class="pt-3">
-            {{ $t("views_app.matches") }}
+            <v-row no-gutters align="start">
+              <v-col cols="auto">
+                {{ $t("views_app.matches") }}
+              </v-col>
+              <v-spacer />
+              <v-col cols="auto" class="d-flex align-start">
+                <div class="matches-season-slot" :class="{ 'matches-season-slot--hidden': unfinished }">
+                  <season-select @seasonSelected="selectSeason" />
+                </div>
+              </v-col>
+            </v-row>
           </v-card-title>
-          <v-card-text class="pt-2 d-flex align-center">
-            <matches-status-select />
-            <game-mode-select :disabledModes="disabledGameModes" :gameMode="gameMode" @gameModeChanged="gameModeChanged" />
-            <map-select :mapInfo="maps" :map="map" @mapChanged="mapChanged" />
-            <mmr-select :mmr="mmr" @mmrFilterChanged="mmrFilterChanged" />
-            <duration-select v-if="!unfinished" :duration="duration" @durationFilterChanged="durationFilterChanged" />
-            <sort-select v-if="unfinished" />
-            <season-select v-if="!unfinished" @seasonSelected="selectSeason" />
-            <hero-select v-if="!unfinished && showHeroSelect" :selectedHeroes="selectedHeroes" @heroChanged="heroChanged" />
-            <hero-icon-toggle :showHeroes="showHeroIcons" :unfinished="unfinished" @update:showHeroes="toggleShowHeroIcons" />
+          <v-card-text class="pt-2">
+            <div class="matches-filter-scroll">
+              <div class="matches-filter-row d-flex align-center">
+                <matches-status-select />
+                <game-mode-select :disabledModes="disabledGameModes" :gameMode="gameMode" @gameModeChanged="gameModeChanged" />
+                <map-select :mapInfo="maps" :map="map" @mapChanged="mapChanged" />
+                <mmr-select :mmr="mmr" @mmrFilterChanged="mmrFilterChanged" />
+                <duration-select v-if="!unfinished" :duration="duration" @durationFilterChanged="durationFilterChanged" />
+                <sort-select v-if="unfinished" />
+                <hero-select v-if="!unfinished && showHeroSelect" :selectedHeroes="selectedHeroes" @heroChanged="heroChanged" />
+                <hero-icon-toggle :showHeroes="showHeroIcons" :unfinished="unfinished" @update:showHeroes="toggleShowHeroIcons" />
+              </div>
+            </div>
           </v-card-text>
           <v-card-text v-if="isMatchesLoading" class="d-flex justify-center py-10">
             <v-progress-circular indeterminate color="primary" size="40" />
@@ -233,3 +246,25 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.matches-filter-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-top: 2px;
+  padding-bottom: 8px;
+  margin-top: -2px;
+  margin-bottom: -8px;
+}
+
+.matches-filter-row {
+  width: max-content;
+  min-width: 100%;
+  flex-wrap: nowrap;
+}
+
+.matches-season-slot--hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+</style>

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -275,7 +275,14 @@ export default defineComponent({
       }
 
       _intervalRefreshHandle = setInterval(async () => {
+        const hadOngoingMatch = !!playerStore.ongoingMatch?.id;
         await playerStore.loadOngoingPlayerMatch(battleTag.value);
+
+        // Keep recent performance data fresh when a live match ends while this profile is open.
+        if (hadOngoingMatch && !playerStore.ongoingMatch?.id) {
+          playerStore.invalidateMatchesCache();
+          await playerStore.loadMatches(1);
+        }
       }, AppConstants.ongoingMatchesRefreshInterval);
 
       await playerStore.loadOngoingPlayerMatch(battleTag.value);


### PR DESCRIPTION
Before:

<img width="1474" height="342" alt="image" src="https://github.com/user-attachments/assets/aa8a749f-b111-48f3-920f-791532f6cb43" />


After:

<img width="1459" height="277" alt="image" src="https://github.com/user-attachments/assets/7c68d93b-d294-44d6-a763-516010dda7f9" />


Also:
- Added loading spinner for matches tab
- Polishes up the dropdown contents to adjust padding
- Moved season on matches page to top-right corner like it is on player pages
- Removed min-width on duration filter
- Made filters horizontally scroll if it gets too wide (can happen with a lot of filters enabled)
- Fixed data fetching on profile and match history tabs to avoid refetching when unnecessary if data is already loaded (hero filters list, "recent performance" games)