### PR TITLE
Handle replay download failures in-page

### DIFF
--- a/src/components/matches/DownloadReplayIcon.vue
+++ b/src/components/matches/DownloadReplayIcon.vue
@@ -17,6 +17,9 @@
     </template>
     <span>{{ tooltip }}</span>
   </v-tooltip>
+  <v-snackbar v-model="showError" color="error" timeout="4000" location="top">
+    {{ errorMessage }}
+  </v-snackbar>
 </template>
 
 <script setup lang="ts">
@@ -35,16 +38,46 @@ const { gameId } = defineProps({
 const { t } = useI18n();
 const downloading = ref(false);
 const tooltip = ref<string>(t("components_matches_replayicon.download"));
+const showError = ref(false);
+const errorMessage = ref("");
 
-function downloadReplay(): void {
+async function downloadReplay(): Promise<void> {
   downloading.value = true;
 
   try {
-    // Download the replay
     const url = `${API_URL}api/replays/${gameId}`;
-    window.open(url, "_self");
+    const response = await fetch(url);
+    const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+    if (response.status === 429) {
+      throw new Error(t("components_matches_replayicon.rateLimited"));
+    }
+
+    if (response.status === 404) {
+      throw new Error(t("components_matches_replayicon.notFound"));
+    }
+
+    if (!response.ok || contentType.includes("json")) {
+      throw new Error(t("components_matches_replayicon.unavailable"));
+    }
+
+    const blob = await response.blob();
+    const downloadUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = downloadUrl;
+    a.download = `${gameId}.w3g`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(downloadUrl);
   } catch (error) {
     console.error("Error downloading replay:", error);
+    errorMessage.value = error instanceof Error ? error.message : t("components_matches_replayicon.unavailable");
+    showError.value = true;
+    tooltip.value = errorMessage.value;
+    window.setTimeout(() => {
+      tooltip.value = t("components_matches_replayicon.download");
+    }, 4000);
   } finally {
     downloading.value = false;
   }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -500,6 +500,9 @@ const en = {
 
   components_matches_replayicon: {
     download: "Download Replay",
+    notFound: "Replay not found.",
+    rateLimited: "Too many replay downloads. Try again later.",
+    unavailable: "Replay unavailable",
   },
 
   components_matches_matchesgrid: {


### PR DESCRIPTION
## Summary
- fetch replay downloads before triggering the browser file save
- keep users on the match page when the replay API returns an error response
- show specific snackbar messages for rate limiting, missing replays, and generic replay failures

## Root cause
The replay button navigated directly to `/api/replays/{matchId}`. When the backend returned JSON errors from replay generation, the browser replaced the match page with the raw API error body.

## Validation
- `npm run type-check`
- `npm run build`
- local browser smoke test against a failing replay response confirmed the page stayed on the match detail view and showed the retry-later snackbar for 429 responses
