### PR TITLE
feat: SSO handoff (/sso-continue), returnTo allowlist, Login.vue error UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -351,6 +351,18 @@ export default defineComponent({
     async function init() {
       rootStateStore.loadLocale();
       locale.value = savedLocale.get();
+
+      // Skip the auth bootstrap on /sso-continue: that view is the sole cookie
+      // authority there and validates the W3ChampionsJWT itself (it must keep the
+      // cookie on a transient user-info error and clear it on an expired/invalid
+      // one). Because this onMounted runs AFTER SsoContinueView's onMounted, the
+      // app-shell restore here would otherwise race it — deleting the cookie on a
+      // 5xx (getProfile maps it to null -> logout) or restoring a stale token.
+      // Locale setup above is still needed for the view's text, so guard only the
+      // bootstrap, not the whole init; the sign-in listener (onBeforeMount) is
+      // unaffected so the cold-login dialog still opens.
+      if (route.name === EMainRouteName.SSO_CONTINUE) return;
+
       oauthStore.loadAuthCodeToState();
 
       if (authCode.value) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -359,7 +359,6 @@ export default defineComponent({
     }
 
     onMounted(async () => {
-      window.addEventListener(OPEN_SIGN_IN_DIALOG_EVENT, handleOpenSignInDialog);
       await init();
     });
 
@@ -372,6 +371,13 @@ export default defineComponent({
       if (t && t.length > 0) {
         setTheme(t);
       }
+      // Register the sign-in dialog listener before any child component mounts.
+      // Vue mounts children before parents, so if a child (e.g. SsoContinueView)
+      // dispatches OPEN_SIGN_IN_DIALOG_EVENT from its own onMounted hook, it would
+      // fire before App's onMounted and the event would be dropped. onBeforeMount
+      // runs before the component's subtree is mounted, guaranteeing the listener
+      // is in place when any child dispatches the event.
+      window.addEventListener(OPEN_SIGN_IN_DIALOG_EVENT, handleOpenSignInDialog);
     });
 
     return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -167,6 +167,7 @@ import noop from "lodash/noop";
 import { useTheme } from "vuetify";
 import { battleTagToName } from "./helpers/profile";
 import { EMainRouteName } from "@/router/types";
+import { LOGIN_RETURN_TO_KEY, OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import LocaleIcon from "@/components/common/LocaleIcon.vue";
 
 import {
@@ -209,7 +210,6 @@ export default defineComponent({
     const savedLanguage = "en";
     const navigationDrawerOpen = ref(false);
     const theme = useTheme();
-    const loginReturnToKey = "w3-login-return-to";
 
     const showSignInDialog = ref(false);
     const selectedTheme = ref("human");
@@ -267,13 +267,13 @@ export default defineComponent({
 
     function openSignInDialog(returnTo?: string): void {
       if (returnTo) {
-        window.sessionStorage.setItem(loginReturnToKey, returnTo);
+        window.sessionStorage.setItem(LOGIN_RETURN_TO_KEY, returnTo);
       }
       showSignInDialog.value = true;
     }
 
     function clearLoginReturnTo(): void {
-      window.sessionStorage.removeItem(loginReturnToKey);
+      window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
     }
 
     function setNavigationDrawerOpen(val: boolean): void {
@@ -359,12 +359,12 @@ export default defineComponent({
     }
 
     onMounted(async () => {
-      window.addEventListener("w3-open-sign-in-dialog", handleOpenSignInDialog);
+      window.addEventListener(OPEN_SIGN_IN_DIALOG_EVENT, handleOpenSignInDialog);
       await init();
     });
 
     onBeforeUnmount(() => {
-      window.removeEventListener("w3-open-sign-in-dialog", handleOpenSignInDialog);
+      window.removeEventListener(OPEN_SIGN_IN_DIALOG_EVENT, handleOpenSignInDialog);
     });
 
     onBeforeMount(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -351,20 +351,16 @@ export default defineComponent({
     async function init() {
       rootStateStore.loadLocale();
       locale.value = savedLocale.get();
-
-      // Skip the auth bootstrap on /sso-continue: that view is the sole cookie
-      // authority there and validates the W3ChampionsJWT itself (it must keep the
-      // cookie on a transient user-info error and clear it on an expired/invalid
-      // one). Because this onMounted runs AFTER SsoContinueView's onMounted, the
-      // app-shell restore here would otherwise race it — deleting the cookie on a
-      // 5xx (getProfile maps it to null -> logout) or restoring a stale token.
-      // Locale setup above is still needed for the view's text, so guard only the
-      // bootstrap, not the whole init; the sign-in listener (onBeforeMount) is
-      // unaffected so the cold-login dialog still opens.
-      if (route.name === EMainRouteName.SSO_CONTINUE) return;
-
       oauthStore.loadAuthCodeToState();
 
+      // Runs on every route, including /sso-continue. loadBlizzardBtag is now
+      // status-aware (it only logs out on a definitive 401/403, never on a transient
+      // 5xx/network), so this bootstrap no longer races SsoContinue's keep-cookie
+      // intent: a transient error keeps the cookie, and an expired cookie is already
+      // cleared synchronously by SsoContinue's onMounted (which runs before this
+      // one), so loadAuthCodeToState reads empty there. Hydrating here means a valid
+      // session is restored app-wide even when SsoContinue exits via a cookie-
+      // preserving error path (invalid-return / transient "error").
       if (authCode.value) {
         await oauthStore.loadBlizzardBtag(authCode.value);
       }

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -37,6 +37,7 @@ import { computed, defineComponent, onMounted, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
 import { ReplayChatLog, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
+import { OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import { useRoute } from "vue-router";
 
 export default defineComponent({
@@ -80,7 +81,7 @@ export default defineComponent({
     }
 
     function promptLogin(): void {
-      window.dispatchEvent(new CustomEvent("w3-open-sign-in-dialog", {
+      window.dispatchEvent(new CustomEvent(OPEN_SIGN_IN_DIALOG_EVENT, {
         detail: {
           returnTo: route.fullPath,
         },

--- a/src/constants/sso.ts
+++ b/src/constants/sso.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared SSO / sign-in constants used across the login flow participants
+ * (App.vue, Login.vue, SsoContinue.vue, AdminReplayChatLogMessages.vue).
+ * Keep these values byte-identical to the historical string literals so the
+ * sessionStorage key and CustomEvent name stay compatible across the app.
+ */
+
+/** sessionStorage key holding the post-login return path. */
+export const LOGIN_RETURN_TO_KEY = "w3-login-return-to";
+
+/** CustomEvent name that asks App.vue to open the sign-in dialog. */
+export const OPEN_SIGN_IN_DIALOG_EVENT = "w3-open-sign-in-dialog";

--- a/src/helpers/sso.test.ts
+++ b/src/helpers/sso.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowedReturnUrl } from "./sso.ts";
+
+const PROD_ORIGIN = "https://identification-service.w3champions.com";
+const TEST_ORIGIN = "https://identification-service.test.w3champions.com";
+
+describe("isAllowedReturnUrl", () => {
+  it("allows exact prod-origin with path and query", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "https://identification-service.w3champions.com/connect/handoff?return=foo",
+        PROD_ORIGIN,
+      ),
+      true,
+    );
+  });
+
+  it("allows test-origin when configured as test", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "https://identification-service.test.w3champions.com/connect/handoff",
+        TEST_ORIGIN,
+      ),
+      true,
+    );
+  });
+
+  it("rejects prod-origin when configured as test", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "https://identification-service.w3champions.com/connect/handoff",
+        TEST_ORIGIN,
+      ),
+      false,
+    );
+  });
+
+  it("rejects different hostname", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "https://evil.com/connect/handoff",
+        PROD_ORIGIN,
+      ),
+      false,
+    );
+  });
+
+  it("rejects lookalike subdomain (open-redirect attempt)", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "https://identification-service.w3champions.com.evil.com/connect/handoff",
+        PROD_ORIGIN,
+      ),
+      false,
+    );
+  });
+
+  it("rejects http when allowed origin is https", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "http://identification-service.w3champions.com/connect/handoff",
+        PROD_ORIGIN,
+      ),
+      false,
+    );
+  });
+
+  it("rejects internal path string /player/...", () => {
+    assert.equal(
+      isAllowedReturnUrl(
+        "/player/SomePlayer%231234",
+        PROD_ORIGIN,
+      ),
+      false,
+    );
+  });
+
+  it("rejects empty string", () => {
+    assert.equal(
+      isAllowedReturnUrl("", PROD_ORIGIN),
+      false,
+    );
+  });
+
+  it("rejects javascript: URL", () => {
+    assert.equal(
+      isAllowedReturnUrl("javascript:alert(1)", PROD_ORIGIN),
+      false,
+    );
+  });
+});

--- a/src/helpers/sso.test.ts
+++ b/src/helpers/sso.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { isAllowedReturnUrl } from "./sso.ts";
+import { strict as assert } from "node:assert";
+import { isAllowedReturnUrl } from "./sso";
 
 const PROD_ORIGIN = "https://identification-service.w3champions.com";
 const TEST_ORIGIN = "https://identification-service.test.w3champions.com";

--- a/src/helpers/sso.test.ts
+++ b/src/helpers/sso.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
-import { isAllowedReturnUrl } from "./sso";
+import { isAllowedReturnUrl, isJwtExpired } from "./sso";
 
 const PROD_ORIGIN = "https://identification-service.w3champions.com";
 const TEST_ORIGIN = "https://identification-service.test.w3champions.com";
@@ -88,5 +88,38 @@ describe("isAllowedReturnUrl", () => {
       isAllowedReturnUrl("javascript:alert(1)", PROD_ORIGIN),
       false,
     );
+  });
+});
+
+// Build a JWT-shaped string ("header.payload.signature") whose payload is the
+// base64url encoding of the given claims. The signature is a dummy — isJwtExpired
+// only reads the payload and does not verify the signature.
+function makeJwt(claims: Record<string, unknown>): string {
+  const base64url = (obj: Record<string, unknown>): string =>
+    Buffer.from(JSON.stringify(obj))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${base64url({ alg: "HS256", typ: "JWT" })}.${base64url(claims)}.sig`;
+}
+
+describe("isJwtExpired", () => {
+  it("returns false for an unexpired token", () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600; // 1h in the future
+    assert.equal(isJwtExpired(makeJwt({ exp })), false);
+  });
+
+  it("returns true for an expired token", () => {
+    const exp = Math.floor(Date.now() / 1000) - 3600; // 1h in the past
+    assert.equal(isJwtExpired(makeJwt({ exp })), true);
+  });
+
+  it("returns true for a token with no exp claim", () => {
+    assert.equal(isJwtExpired(makeJwt({ sub: "someone" })), true);
+  });
+
+  it("returns true for a malformed / non-JWT string", () => {
+    assert.equal(isJwtExpired("not-a-jwt"), true);
   });
 });

--- a/src/helpers/sso.ts
+++ b/src/helpers/sso.ts
@@ -1,0 +1,26 @@
+/**
+ * SSO helpers for the /sso-continue handoff.
+ * The allowed return origin is the identification-service for THIS environment
+ * (prod vs test), derived from `window._env_.IDENTIFICATION_URL` — never hardcoded.
+ * `isAllowedReturnUrl` stays pure (origin passed in) so it is unit-testable without `window`.
+ */
+export function identificationOrigin(): string {
+  return new URL(window._env_.IDENTIFICATION_URL).origin;
+}
+
+export function handoffEndpoint(): string {
+  return `${identificationOrigin()}/connect/handoff`;
+}
+
+/**
+ * True only if `url` is an absolute URL whose exact origin equals `allowedOrigin`
+ * (pass `identificationOrigin()`). Prevents open redirects; since the IdP is always
+ * HTTPS, exact-origin match also enforces HTTPS.
+ */
+export function isAllowedReturnUrl(url: string, allowedOrigin: string): boolean {
+  try {
+    return new URL(url).origin === allowedOrigin;
+  } catch {
+    return false;
+  }
+}

--- a/src/helpers/sso.ts
+++ b/src/helpers/sso.ts
@@ -24,3 +24,25 @@ export function isAllowedReturnUrl(url: string, allowedOrigin: string): boolean 
     return false;
   }
 }
+
+/**
+ * True if the JWT is expired, cannot be parsed, or has no `exp` claim. Used to gate
+ * the SSO handoff, which enforces `exp` (HandoffJwtValidator, ValidateLifetime=true)
+ * — unlike the legacy `/api/oauth/user-info` endpoint, which validates the signature
+ * but NOT lifetime and so returns 200 for an expired-but-present cookie. Pure and
+ * dependency-free; it does NOT verify the signature (the server does that).
+ */
+export function isJwtExpired(jwt: string): boolean {
+  try {
+    const part = jwt.split(".")[1];
+    if (!part) return true;
+    // base64url -> base64, then pad to a multiple of 4 so atob accepts it.
+    const base64 = part.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+    const payload = JSON.parse(atob(padded)) as { exp?: number };
+    if (typeof payload.exp !== "number") return true; // no exp ⇒ unusable
+    return Date.now() >= payload.exp * 1000;
+  } catch {
+    return true; // undecodable ⇒ treat as unusable
+  }
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -541,6 +541,24 @@ const en = {
     africa_east_via_sg: "Africa East via Singapore",
     africa_east_via_sg_azure_via_simple_cloud: "Africa East via Singapore via simplecloud",
   },
+  views_login: {
+    loggingyouin: "Logging you in...",
+    error_title: "Login Failed",
+    error_cta: "Back to Home",
+    error_missing_warcraft3: "Your Battle.net account does not own Warcraft III. Please purchase the game to continue.",
+    error_missing_playable_titles_scope: "W3Champions requires access to your Warcraft III license. Please re-authorize and grant the required permissions.",
+    error_unsupported_version: "Your Warcraft III version is not supported. Please update the game.",
+    error_playable_titles_api_failed: "We could not verify your Warcraft III license due to a Battle.net service error. Please try again later.",
+    error_bnet_cancelled: "Battle.net login was cancelled. Please try again.",
+    error_generic: "An unexpected error occurred during login. Please try again.",
+  },
+
+  views_sso_continue: {
+    submitting: "Signing you in to the W3Champions feedback portal...",
+    error_title: "Sign-In Error",
+    error_invalid_return: "The sign-in request is invalid or has expired. Please return to the feedback portal and try again.",
+    error_cta: "Back to Home",
+  },
 };
 
 export default en;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -557,6 +557,7 @@ const en = {
     submitting: "Signing you in to the W3Champions feedback portal...",
     error_title: "Sign-In Error",
     error_invalid_return: "The sign-in request is invalid or has expired. Please return to the feedback portal and try again.",
+    error_generic: "Something went wrong while signing you in. Please try again.",
     error_cta: "Back to Home",
   },
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -19,6 +19,7 @@ import PlayerProfileTab from "@/components/player/tabs/PlayerProfileTab.vue";
 import TournamentDetail from "@/views/TournamentDetail.vue";
 import Rewards from "@/views/Rewards.vue";
 import PatreonCallback from "@/views/PatreonCallback.vue";
+import SsoContinue from "@/views/SsoContinue.vue";
 import PlayerStatisticTab from "@/components/player/tabs/PlayerStatisticTab.vue";
 import OverallStatistics from "@/views/OverallStatistics.vue";
 import PlayerActivityTab from "@/components/overall-statistics/tabs/PlayerActivityTab.vue";
@@ -290,6 +291,11 @@ const routes: RouteRecordRaw[] = [
     path: "/patreon/callback",
     name: EMainRouteName.PATREON_CALLBACK,
     component: PatreonCallback,
+  },
+  {
+    path: "/sso-continue",
+    name: EMainRouteName.SSO_CONTINUE,
+    component: SsoContinue,
   },
   {
     path: "/tournaments",

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -54,6 +54,7 @@ export enum EMainRouteName {
   PATREON_CALLBACK = "PatreonCallback",
   TOURNAMENTS = "Tournaments",
   TOURNAMENT = "Tournament",
+  SSO_CONTINUE = "SsoContinue",
 }
 
 export enum EPlayerRouteName {

--- a/src/services/AuthorizationService.ts
+++ b/src/services/AuthorizationService.ts
@@ -92,4 +92,33 @@ export default class AuthorizationService {
 
     return response.status === 200 ? await response.json() : null;
   }
+
+  /**
+   * Status-aware session check against the same /api/oauth/user-info endpoint as
+   * getProfile (which collapses every non-200 to null, hiding the difference
+   * between a genuinely invalid token and a transient outage). Distinguishes:
+   *   - "valid":   200 — the JWT is accepted.
+   *   - "invalid": 401/403 — genuine auth failure; the cookie is stale/revoked.
+   *   - "error":   5xx, any other non-ok status, or a thrown fetch (network/DNS/
+   *                CORS) — transient; the cookie must NOT be cleared on this.
+   * Caller decides what to do (e.g. only log out on "invalid").
+   */
+  public static async validateSession(jwt: string): Promise<"valid" | "invalid" | "error"> {
+    try {
+      const url = `${IDENTIFICATION_URL}api/oauth/user-info?jwt=${encodeURIComponent(jwt)}`;
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) return "valid";
+      if (response.status === 401 || response.status === 403) return "invalid";
+      return "error";
+    } catch {
+      return "error";
+    }
+  }
 }

--- a/src/services/AuthorizationService.ts
+++ b/src/services/AuthorizationService.ts
@@ -17,6 +17,17 @@ export default class AuthorizationService {
       },
     });
 
+    // fetch() does not reject on 4xx/5xx, so surface the IdP's error code (e.g.
+    // MISSING_WARCRAFT_3) as a thrown Error for the caller's try/catch. Without
+    // this the body would parse as an undefined token and the failure would be
+    // swallowed (hanging spinner). A non-JSON / shapeless error body maps to
+    // "GENERIC" so Login.vue falls back to the generic error message.
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      const code = body && typeof body.errorCode === "string" ? body.errorCode : "GENERIC";
+      throw new Error(code);
+    }
+
     return await response.json();
   }
 

--- a/src/services/AuthorizationService.ts
+++ b/src/services/AuthorizationService.ts
@@ -7,6 +7,15 @@ const w3CAuth = "W3ChampionsJWT";
 const w3CAuthRegion = "W3ChampionsAuthRegion";
 const IDENTIFICATION_URL = window._env_.IDENTIFICATION_URL;
 
+/**
+ * Outcome of a single /api/oauth/user-info check:
+ *   - "valid":   not expired AND 200 — the JWT is accepted.
+ *   - "invalid": expired OR 401/403 — genuine auth failure; the cookie is stale/revoked.
+ *   - "error":   5xx, any other non-ok status, a JSON parse failure on a 200, or a thrown
+ *                fetch (network/DNS/CORS) — transient; the cookie must NOT be cleared.
+ */
+export type SessionStatus = "valid" | "invalid" | "error";
+
 export default class AuthorizationService {
   public static async authorize(code: string, region: BnetOAuthRegion = BnetOAuthRegion.eu): Promise<W3cToken> {
     const url = `${IDENTIFICATION_URL}api/oauth/token?code=${code}&redirectUri=${REDIRECT_URL}&region=${region}`;
@@ -95,22 +104,15 @@ export default class AuthorizationService {
   }
 
   /**
-   * Status-aware session check. First enforces exp client-side (the user-info
-   * endpoint does not — see below), then queries the same /api/oauth/user-info
-   * endpoint as getProfile (which collapses every non-200 to null, hiding the
-   * difference between a genuinely invalid token and a transient outage). Distinguishes:
-   *   - "valid":   not expired AND 200 — the JWT is accepted.
-   *   - "invalid": expired OR 401/403 — genuine auth failure; the cookie is stale/revoked.
-   *   - "error":   5xx, any other non-ok status, or a thrown fetch (network/DNS/
-   *                CORS) — transient; the cookie must NOT be cleared on this.
-   * Caller decides what to do (e.g. only log out on "invalid").
+   * Single status-aware /api/oauth/user-info call returning BOTH the status and the
+   * parsed profile, so callers never need a second fetch (which would double the
+   * transient-failure surface and could throw or falsely report "valid"). Enforces
+   * exp client-side first (the endpoint validates the signature but NOT lifetime, so
+   * it returns 200 for an expired-but-present cookie; the handoff DOES enforce exp).
+   * A "valid" result always carries a parsed profile; "invalid"/"error" carry null.
    */
-  public static async validateSession(jwt: string): Promise<"valid" | "invalid" | "error"> {
-    // The legacy /api/oauth/user-info endpoint validates the signature but NOT the
-    // lifetime, so it returns 200 for an expired-but-present cookie. The handoff DOES
-    // enforce exp and would 401. Reject an expired token up front (→ "invalid" → the
-    // caller logs out + cold-logins) so it's never submitted to the handoff.
-    if (isJwtExpired(jwt)) return "invalid";
+  public static async getSessionProfile(jwt: string): Promise<{ status: SessionStatus; profile: W3cToken | null }> {
+    if (isJwtExpired(jwt)) return { status: "invalid", profile: null };
 
     try {
       const url = `${IDENTIFICATION_URL}api/oauth/user-info?jwt=${encodeURIComponent(jwt)}`;
@@ -122,11 +124,26 @@ export default class AuthorizationService {
         },
       });
 
-      if (response.ok) return "valid";
-      if (response.status === 401 || response.status === 403) return "invalid";
-      return "error";
+      if (response.ok) {
+        try {
+          return { status: "valid", profile: (await response.json()) as W3cToken };
+        } catch {
+          // 200 but the body didn't parse — treat as transient, not a hydrated session.
+          return { status: "error", profile: null };
+        }
+      }
+      if (response.status === 401 || response.status === 403) return { status: "invalid", profile: null };
+      return { status: "error", profile: null };
     } catch {
-      return "error";
+      return { status: "error", profile: null }; // network / CORS / DNS
     }
+  }
+
+  /**
+   * Status-only session check (SsoContinue needs the status, not the body). Thin
+   * wrapper over getSessionProfile so there is ONE user-info request implementation.
+   */
+  public static async validateSession(jwt: string): Promise<SessionStatus> {
+    return (await AuthorizationService.getSessionProfile(jwt)).status;
   }
 }

--- a/src/services/AuthorizationService.ts
+++ b/src/services/AuthorizationService.ts
@@ -1,5 +1,6 @@
 import { BnetOAuthRegion, type TwitchToken, type W3cToken } from "@/store/oauth/types";
 import { REDIRECT_URL } from "@/main";
+import { isJwtExpired } from "@/helpers/sso";
 import Cookies from "js-cookie";
 
 const w3CAuth = "W3ChampionsJWT";
@@ -94,16 +95,23 @@ export default class AuthorizationService {
   }
 
   /**
-   * Status-aware session check against the same /api/oauth/user-info endpoint as
-   * getProfile (which collapses every non-200 to null, hiding the difference
-   * between a genuinely invalid token and a transient outage). Distinguishes:
-   *   - "valid":   200 — the JWT is accepted.
-   *   - "invalid": 401/403 — genuine auth failure; the cookie is stale/revoked.
+   * Status-aware session check. First enforces exp client-side (the user-info
+   * endpoint does not — see below), then queries the same /api/oauth/user-info
+   * endpoint as getProfile (which collapses every non-200 to null, hiding the
+   * difference between a genuinely invalid token and a transient outage). Distinguishes:
+   *   - "valid":   not expired AND 200 — the JWT is accepted.
+   *   - "invalid": expired OR 401/403 — genuine auth failure; the cookie is stale/revoked.
    *   - "error":   5xx, any other non-ok status, or a thrown fetch (network/DNS/
    *                CORS) — transient; the cookie must NOT be cleared on this.
    * Caller decides what to do (e.g. only log out on "invalid").
    */
   public static async validateSession(jwt: string): Promise<"valid" | "invalid" | "error"> {
+    // The legacy /api/oauth/user-info endpoint validates the signature but NOT the
+    // lifetime, so it returns 200 for an expired-but-present cookie. The handoff DOES
+    // enforce exp and would 401. Reject an expired token up front (→ "invalid" → the
+    // caller logs out + cold-logins) so it's never submitted to the handoff.
+    if (isJwtExpired(jwt)) return "invalid";
+
     try {
       const url = `${IDENTIFICATION_URL}api/oauth/user-info?jwt=${encodeURIComponent(jwt)}`;
       const response = await fetch(url, {

--- a/src/store/oauth/store.ts
+++ b/src/store/oauth/store.ts
@@ -40,19 +40,39 @@ export const useOauthStore = defineStore("oauth", {
     async loadBlizzardBtag(bearerToken: string) {
       if (this.isLoadingBlizzardBtag) return;
       this.SET_IS_LOADING_BLIZZARD_BTAG(true);
-      const profile = await AuthorizationService.getProfile(bearerToken);
+      try {
+        // Status-aware so a transient backend blip (5xx / network) does NOT log the
+        // user out: getProfile collapses every non-200 to null, which previously
+        // triggered logout() on any error. Only a DEFINITIVE auth failure (401/403)
+        // means the token is stale and should be cleared; on a transient "error" we
+        // keep the existing session untouched (battletag fills on a later load).
+        const status = await AuthorizationService.validateSession(bearerToken);
 
-      if (profile) {
-        this.SET_PROFILE_NAME(profile.battleTag);
-        this.SET_IS_ADMIN(profile.isAdmin);
-        if (profile.isAdmin) {
-          this.SET_PERMISSIONS(profile.permissions);
+        if (status === "invalid") {
+          this.logout();
+          return;
         }
-        AuthorizationService.saveAuthToken(profile);
-      } else {
-        this.logout();
+
+        if (status === "error") {
+          // Transient — leave the session as-is, don't clear the cookie/state.
+          return;
+        }
+
+        // Valid token — fetch and apply the profile. (getProfile re-hits user-info;
+        // null here would only happen on a race where the token just became invalid,
+        // in which case we deliberately do nothing rather than log out on ambiguity.)
+        const profile = await AuthorizationService.getProfile(bearerToken);
+        if (profile) {
+          this.SET_PROFILE_NAME(profile.battleTag);
+          this.SET_IS_ADMIN(profile.isAdmin);
+          if (profile.isAdmin) {
+            this.SET_PERMISSIONS(profile.permissions);
+          }
+          AuthorizationService.saveAuthToken(profile);
+        }
+      } finally {
+        this.SET_IS_LOADING_BLIZZARD_BTAG(false);
       }
-      this.SET_IS_LOADING_BLIZZARD_BTAG(false);
     },
     saveLoginRegion(region: BnetOAuthRegion) {
       AuthorizationService.saveAuthRegion(region);

--- a/src/store/oauth/store.ts
+++ b/src/store/oauth/store.ts
@@ -15,24 +15,33 @@ export const useOauthStore = defineStore("oauth", {
   actions: {
     async authorizeWithCode(code: string) {
       const region = AuthorizationService.loadAuthRegionCookie();
+      // Only the exchange itself can fail the login: authorize() throws on !response.ok
+      // (surfacing the IdP error code). Once it resolves, the IdP issued a valid token.
       const bearer = await AuthorizationService.authorize(code, region);
 
       this.SET_BEARER(bearer.jwt);
 
-      // Persist the cookie as soon as the code exchange succeeds: the IdP issued a
-      // valid token, so persistence must NOT depend on the secondary profile fetch.
-      // Otherwise a transient 5xx during getProfile would leave the user with a valid
-      // session that was never saved -> a redirect to /sso-continue finds no cookie
-      // -> re-login loop. saveAuthToken only writes the cookie/region (no network).
+      // Persist the cookie immediately on a successful exchange — the login IS
+      // successful at this point; persistence must NOT depend on the secondary
+      // profile fetch. saveAuthToken only writes the cookie/region (no network).
       AuthorizationService.saveAuthToken(bearer);
 
-      const profile = await AuthorizationService.getProfile(bearer.jwt);
-      if (profile) {
-        this.SET_PROFILE_NAME(profile.battleTag);
-        this.SET_IS_ADMIN(profile.isAdmin);
-        if (profile.isAdmin) {
-          this.SET_PERMISSIONS(profile.permissions);
+      // The profile fetch is BEST-EFFORT: it only fills the in-memory battletag/admin
+      // state. A transient failure (5xx, network/CORS, JSON throw) must NOT reject
+      // authorizeWithCode and thereby fail a login whose session is already valid and
+      // saved. The battletag fills later via App.vue's status-aware bootstrap on the
+      // destination route. So swallow any error here and treat a null profile as a no-op.
+      try {
+        const profile = await AuthorizationService.getProfile(bearer.jwt);
+        if (profile) {
+          this.SET_PROFILE_NAME(profile.battleTag);
+          this.SET_IS_ADMIN(profile.isAdmin);
+          if (profile.isAdmin) {
+            this.SET_PERMISSIONS(profile.permissions);
+          }
         }
+      } catch {
+        // Best-effort — ignore; the session is already valid and persisted.
       }
     },
     async authorizeWithTwitch() {

--- a/src/store/oauth/store.ts
+++ b/src/store/oauth/store.ts
@@ -1,6 +1,6 @@
 import type { BnetOAuthRegion, OauthState, TwitchToken } from "@/store/oauth/types";
 import { defineStore } from "pinia";
-import AuthorizationService from "@/services/AuthorizationService";
+import AuthorizationService, { type SessionStatus } from "@/services/AuthorizationService";
 
 export const useOauthStore = defineStore("oauth", {
   state: (): OauthState => ({
@@ -52,41 +52,36 @@ export const useOauthStore = defineStore("oauth", {
       const bearer = AuthorizationService.loadAuthCookie();
       this.SET_BEARER(bearer);
     },
-    async loadBlizzardBtag(bearerToken: string): Promise<"valid" | "invalid" | "error"> {
+    async loadBlizzardBtag(bearerToken: string): Promise<SessionStatus> {
       // Already in flight — report transient so callers don't treat it as a verified
       // session (the in-flight call owns the real outcome).
       if (this.isLoadingBlizzardBtag) return "error";
       this.SET_IS_LOADING_BLIZZARD_BTAG(true);
       try {
-        // Status-aware so a transient backend blip (5xx / network) does NOT log the
-        // user out: getProfile collapses every non-200 to null, which previously
-        // triggered logout() on any error. Only a DEFINITIVE auth failure (401/403)
-        // means the token is stale and should be cleared; on a transient "error" we
-        // keep the existing session untouched (battletag fills on a later load).
-        const status = await AuthorizationService.validateSession(bearerToken);
+        // ONE status-aware user-info fetch that yields both status AND profile, so we
+        // never throw and never claim "valid" without a hydrated profile. A transient
+        // backend blip (5xx / network / 200-but-unparseable) must NOT log the user out;
+        // only a DEFINITIVE auth failure (401/403, or client-side expired) clears state.
+        const { status, profile } = await AuthorizationService.getSessionProfile(bearerToken);
 
         if (status === "invalid") {
           this.logout();
           return "invalid";
         }
 
-        if (status === "error") {
-          // Transient — leave the session as-is, don't clear the cookie/state.
+        if (status === "error" || !profile) {
+          // Transient (or no profile body) — leave the session untouched, don't hydrate,
+          // and don't claim valid. The cookie/state stay as-is; battletag fills later.
           return "error";
         }
 
-        // Valid token — fetch and apply the profile. (getProfile re-hits user-info;
-        // null here would only happen on a race where the token just became invalid,
-        // in which case we deliberately do nothing rather than log out on ambiguity.)
-        const profile = await AuthorizationService.getProfile(bearerToken);
-        if (profile) {
-          this.SET_PROFILE_NAME(profile.battleTag);
-          this.SET_IS_ADMIN(profile.isAdmin);
-          if (profile.isAdmin) {
-            this.SET_PERMISSIONS(profile.permissions);
-          }
-          AuthorizationService.saveAuthToken(profile);
+        // Valid AND profile present — hydrate.
+        this.SET_PROFILE_NAME(profile.battleTag);
+        this.SET_IS_ADMIN(profile.isAdmin);
+        if (profile.isAdmin) {
+          this.SET_PERMISSIONS(profile.permissions);
         }
+        AuthorizationService.saveAuthToken(profile);
         return "valid";
       } finally {
         this.SET_IS_LOADING_BLIZZARD_BTAG(false);

--- a/src/store/oauth/store.ts
+++ b/src/store/oauth/store.ts
@@ -19,6 +19,13 @@ export const useOauthStore = defineStore("oauth", {
 
       this.SET_BEARER(bearer.jwt);
 
+      // Persist the cookie as soon as the code exchange succeeds: the IdP issued a
+      // valid token, so persistence must NOT depend on the secondary profile fetch.
+      // Otherwise a transient 5xx during getProfile would leave the user with a valid
+      // session that was never saved -> a redirect to /sso-continue finds no cookie
+      // -> re-login loop. saveAuthToken only writes the cookie/region (no network).
+      AuthorizationService.saveAuthToken(bearer);
+
       const profile = await AuthorizationService.getProfile(bearer.jwt);
       if (profile) {
         this.SET_PROFILE_NAME(profile.battleTag);
@@ -26,7 +33,6 @@ export const useOauthStore = defineStore("oauth", {
         if (profile.isAdmin) {
           this.SET_PERMISSIONS(profile.permissions);
         }
-        AuthorizationService.saveAuthToken(bearer);
       }
     },
     async authorizeWithTwitch() {
@@ -37,8 +43,10 @@ export const useOauthStore = defineStore("oauth", {
       const bearer = AuthorizationService.loadAuthCookie();
       this.SET_BEARER(bearer);
     },
-    async loadBlizzardBtag(bearerToken: string) {
-      if (this.isLoadingBlizzardBtag) return;
+    async loadBlizzardBtag(bearerToken: string): Promise<"valid" | "invalid" | "error"> {
+      // Already in flight — report transient so callers don't treat it as a verified
+      // session (the in-flight call owns the real outcome).
+      if (this.isLoadingBlizzardBtag) return "error";
       this.SET_IS_LOADING_BLIZZARD_BTAG(true);
       try {
         // Status-aware so a transient backend blip (5xx / network) does NOT log the
@@ -50,12 +58,12 @@ export const useOauthStore = defineStore("oauth", {
 
         if (status === "invalid") {
           this.logout();
-          return;
+          return "invalid";
         }
 
         if (status === "error") {
           // Transient — leave the session as-is, don't clear the cookie/state.
-          return;
+          return "error";
         }
 
         // Valid token — fetch and apply the profile. (getProfile re-hits user-info;
@@ -70,6 +78,7 @@ export const useOauthStore = defineStore("oauth", {
           }
           AuthorizationService.saveAuthToken(profile);
         }
+        return "valid";
       } finally {
         this.SET_IS_LOADING_BLIZZARD_BTAG(false);
       }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -13,7 +13,7 @@
       </template>
 
       <template v-else>
-        <v-card-text>
+        <v-card-text role="alert" aria-live="assertive">
           <v-icon color="error" size="100" class="mb-4">
             {{ mdiAlertCircle }}
           </v-icon>
@@ -34,12 +34,19 @@ import { computed, defineComponent, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { getProfileUrl } from "@/helpers/url-functions";
 import { isAllowedReturnUrl, identificationOrigin } from "@/helpers/sso";
+import { LOGIN_RETURN_TO_KEY } from "@/constants/sso";
 import { useOauthStore } from "@/store/oauth/store";
 import { useRouter, useRoute } from "vue-router";
 import { EMainRouteName } from "@/router/types";
 import { mdiAlertCircle } from "@mdi/js";
 
-const ERROR_CODE_MAP: Record<string, string> = {
+type IdServiceErrorCode =
+  | "MISSING_WARCRAFT_3"
+  | "MISSING_PLAYABLE_TITLES_SCOPE"
+  | "UNSUPPORTED_VERSION"
+  | "PLAYABLE_TITLES_API_FAILED";
+
+const ERROR_CODE_MAP: Record<IdServiceErrorCode, string> = {
   MISSING_WARCRAFT_3: "views_login.error_missing_warcraft3",
   MISSING_PLAYABLE_TITLES_SCOPE: "views_login.error_missing_playable_titles_scope",
   UNSUPPORTED_VERSION: "views_login.error_unsupported_version",
@@ -60,7 +67,6 @@ export default defineComponent({
     const router = useRouter();
     const route = useRoute();
     const oauthStore = useOauthStore();
-    const loginReturnToKey = "w3-login-return-to";
 
     const errorMessage = ref("");
 
@@ -78,9 +84,9 @@ export default defineComponent({
     }
 
     function openRequestedReturnPath(): void {
-      const returnTo = window.sessionStorage.getItem(loginReturnToKey);
+      const returnTo = window.sessionStorage.getItem(LOGIN_RETURN_TO_KEY);
       if (returnTo) {
-        window.sessionStorage.removeItem(loginReturnToKey);
+        window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
         if (isAllowedReturnUrl(returnTo, identificationOrigin())) {
           window.location.href = returnTo;
           return;
@@ -92,13 +98,15 @@ export default defineComponent({
       openPlayerProfile();
     }
 
-    function setErrorFromCode(rawCode: string): void {
+    function mapErrorCode(rawCode: string): void {
       const upper = rawCode.trim().toUpperCase();
       if (upper === "BNET_CANCELLED") {
         errorMessage.value = t("views_login.error_bnet_cancelled");
         return;
       }
-      const i18nKey = ERROR_CODE_MAP[upper];
+      // Intentional generic fallback: unmapped codes (e.g. the IdP's UNKNOWN_ERROR,
+      // a "GENERIC" sentinel, or any future/renamed code) resolve to error_generic.
+      const i18nKey = ERROR_CODE_MAP[upper as IdServiceErrorCode];
       errorMessage.value = i18nKey ? t(i18nKey) : t("views_login.error_generic");
     }
 
@@ -106,7 +114,7 @@ export default defineComponent({
       // Handle Battle.net cancel or OAuth error passed as query param
       const queryError = route.query.error as string | undefined;
       if (queryError) {
-        setErrorFromCode("BNET_CANCELLED");
+        mapErrorCode("BNET_CANCELLED");
         return;
       }
 
@@ -116,7 +124,7 @@ export default defineComponent({
         openRequestedReturnPath();
       } catch (error: unknown) {
         const rawCode = error instanceof Error ? error.message.trim() : "";
-        setErrorFromCode(rawCode || "GENERIC");
+        mapErrorCode(rawCode || "GENERIC");
       }
     }
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,22 +1,50 @@
 <template>
   <v-container class="w3-container-width">
     <v-card class="text-center">
-      <v-progress-circular
-        :size="100"
-        color="primary"
-        indeterminate
-        class="loader"
-      >
-        <div class="inner-text">{{ $t("views_login.loggingyouin") }}</div>
-      </v-progress-circular>
+      <template v-if="!errorMessage">
+        <v-progress-circular
+          :size="100"
+          color="primary"
+          indeterminate
+          class="loader"
+        >
+          <div class="inner-text">{{ $t("views_login.loggingyouin") }}</div>
+        </v-progress-circular>
+      </template>
+
+      <template v-else>
+        <v-card-text>
+          <v-icon color="error" size="100" class="mb-4">
+            {{ mdiAlertCircle }}
+          </v-icon>
+          <h2 class="mb-2">{{ $t("views_login.error_title") }}</h2>
+          <p>{{ errorMessage }}</p>
+        </v-card-text>
+        <v-card-actions class="justify-center">
+          <v-btn variant="outlined" @click="goHome">
+            {{ $t("views_login.error_cta") }}
+          </v-btn>
+        </v-card-actions>
+      </template>
     </v-card>
   </v-container>
 </template>
 <script lang="ts">
-import { computed, defineComponent, onMounted } from "vue";
+import { computed, defineComponent, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { getProfileUrl } from "@/helpers/url-functions";
+import { isAllowedReturnUrl, identificationOrigin } from "@/helpers/sso";
 import { useOauthStore } from "@/store/oauth/store";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
+import { EMainRouteName } from "@/router/types";
+import { mdiAlertCircle } from "@mdi/js";
+
+const ERROR_CODE_MAP: Record<string, string> = {
+  MISSING_WARCRAFT_3: "views_login.error_missing_warcraft3",
+  MISSING_PLAYABLE_TITLES_SCOPE: "views_login.error_missing_playable_titles_scope",
+  UNSUPPORTED_VERSION: "views_login.error_unsupported_version",
+  PLAYABLE_TITLES_API_FAILED: "views_login.error_playable_titles_api_failed",
+};
 
 export default defineComponent({
   name: "LoginView",
@@ -28,12 +56,20 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const { t } = useI18n();
     const router = useRouter();
+    const route = useRoute();
     const oauthStore = useOauthStore();
     const loginReturnToKey = "w3-login-return-to";
 
+    const errorMessage = ref("");
+
     const account = computed<string>(() => oauthStore.blizzardVerifiedBtag);
     const authCode = computed<string>(() => oauthStore.token);
+
+    function goHome(): void {
+      router.replace({ name: EMainRouteName.HOME });
+    }
 
     function openPlayerProfile(): void {
       router.push({
@@ -45,6 +81,10 @@ export default defineComponent({
       const returnTo = window.sessionStorage.getItem(loginReturnToKey);
       if (returnTo) {
         window.sessionStorage.removeItem(loginReturnToKey);
+        if (isAllowedReturnUrl(returnTo, identificationOrigin())) {
+          window.location.href = returnTo;
+          return;
+        }
         router.replace(returnTo);
         return;
       }
@@ -52,10 +92,32 @@ export default defineComponent({
       openPlayerProfile();
     }
 
+    function setErrorFromCode(rawCode: string): void {
+      const upper = rawCode.trim().toUpperCase();
+      if (upper === "BNET_CANCELLED") {
+        errorMessage.value = t("views_login.error_bnet_cancelled");
+        return;
+      }
+      const i18nKey = ERROR_CODE_MAP[upper];
+      errorMessage.value = i18nKey ? t(i18nKey) : t("views_login.error_generic");
+    }
+
     async function init(): Promise<void> {
-      await oauthStore.authorizeWithCode(props.code);
-      await oauthStore.loadBlizzardBtag(authCode.value);
-      openRequestedReturnPath();
+      // Handle Battle.net cancel or OAuth error passed as query param
+      const queryError = route.query.error as string | undefined;
+      if (queryError) {
+        setErrorFromCode("BNET_CANCELLED");
+        return;
+      }
+
+      try {
+        await oauthStore.authorizeWithCode(props.code);
+        await oauthStore.loadBlizzardBtag(authCode.value);
+        openRequestedReturnPath();
+      } catch (error: unknown) {
+        const rawCode = error instanceof Error ? error.message.trim() : "";
+        setErrorFromCode(rawCode || "GENERIC");
+      }
     }
 
     onMounted((): void => {
@@ -63,6 +125,9 @@ export default defineComponent({
     });
 
     return {
+      errorMessage,
+      mdiAlertCircle,
+      goHome,
     };
   },
 });

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -82,9 +82,11 @@ export default defineComponent({
       });
     }
 
-    function openRequestedReturnPath(): void {
+    async function openRequestedReturnPath(): Promise<void> {
       const returnTo = window.sessionStorage.getItem(LOGIN_RETURN_TO_KEY);
       if (returnTo) {
+        // SSO / internal return path: only needs the cookie (already persisted), NOT
+        // the battletag. Redirect exactly as before — don't couple it to the profile.
         window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
         if (isAllowedReturnUrl(returnTo, identificationOrigin())) {
           window.location.href = returnTo;
@@ -94,7 +96,25 @@ export default defineComponent({
         return;
       }
 
-      openPlayerProfile();
+      // Default destination is the player profile, whose URL NEEDS the battletag.
+      // authorizeWithCode's profile load is best-effort, so a transient failure can
+      // leave it empty -> getProfileUrl("") would produce a broken /player/ route.
+      // Retry the load once (round-10 status-aware loadBlizzardBtag), then fall back
+      // to home if it's still missing rather than navigating to a broken profile URL.
+      if (!account.value) {
+        await oauthStore.loadBlizzardBtag(oauthStore.token);
+      }
+
+      if (account.value) {
+        openPlayerProfile();
+        return;
+      }
+
+      // Still no battletag (persistent transient failure). The user IS logged in
+      // (cookie persisted); land on home instead of a broken /player/ URL. The
+      // battletag hydrates later via App's status-aware bootstrap on navigation.
+      // replace() (matching goHome) so the login callback isn't left in history.
+      router.replace({ name: EMainRouteName.HOME });
     }
 
     function mapErrorCode(rawCode: string): void {
@@ -126,12 +146,11 @@ export default defineComponent({
         // cookie was persisted — the login IS successful. The profile load inside it
         // is best-effort, so a transient profile/validation blip does NOT fail the
         // login. Redirect unconditionally on success; only a genuine EXCHANGE failure
-        // (authorize() throwing) lands in the catch below. authorizeWithCode already
-        // loaded the profile best-effort, so we don't call loadBlizzardBtag again here
-        // (App.vue's status-aware bootstrap fills the battletag on the destination if
-        // that best-effort load blipped).
+        // (authorize() throwing) lands in the catch below. openRequestedReturnPath
+        // handles the two destinations' real needs (SSO return = cookie only; default
+        // player profile = battletag, retried + safe home fallback).
         await oauthStore.authorizeWithCode(props.code);
-        openRequestedReturnPath();
+        await openRequestedReturnPath();
       } catch (error: unknown) {
         // Login failed (id-service error code or generic). As above, clear the saved
         // return path so the abandoned SSO continuation can't redirect a future login.

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -82,28 +82,42 @@ export default defineComponent({
       });
     }
 
+    // Best-effort retry of the profile load, only when it didn't already load (so it's
+    // not a duplicate fetch in the normal case). authorizeWithCode's profile load is
+    // best-effort, so a transient failure can leave blizzardVerifiedBtag/isAdmin/
+    // permissions unset; this gives any in-SPA destination one more chance to hydrate.
+    // loadBlizzardBtag is status-aware (round-10): it won't throw or logout on a
+    // transient error, so this never blocks or fails the redirect.
+    async function ensureProfileLoaded(): Promise<void> {
+      if (!account.value) {
+        await oauthStore.loadBlizzardBtag(oauthStore.token);
+      }
+    }
+
     async function openRequestedReturnPath(): Promise<void> {
       const returnTo = window.sessionStorage.getItem(LOGIN_RETURN_TO_KEY);
       if (returnTo) {
-        // SSO / internal return path: only needs the cookie (already persisted), NOT
-        // the battletag. Redirect exactly as before — don't couple it to the profile.
         window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
         if (isAllowedReturnUrl(returnTo, identificationOrigin())) {
+          // External IdP handoff: a full page navigation that reloads the app, so
+          // App's bootstrap reruns and hydrates there. No hydration needed here.
           window.location.href = returnTo;
           return;
         }
+        // Internal SPA route (admin pages, /sso-continue, …): App's bootstrap already
+        // ran on /login and won't rerun after this router.replace, so the destination
+        // would render unhydrated (blank admin page) on a transient profile failure.
+        // Hydrate first. (/sso-continue only needs the cookie, so the extra best-effort
+        // load is harmless and doesn't block or loop the handoff.)
+        await ensureProfileLoaded();
         router.replace(returnTo);
         return;
       }
 
       // Default destination is the player profile, whose URL NEEDS the battletag.
-      // authorizeWithCode's profile load is best-effort, so a transient failure can
-      // leave it empty -> getProfileUrl("") would produce a broken /player/ route.
-      // Retry the load once (round-10 status-aware loadBlizzardBtag), then fall back
-      // to home if it's still missing rather than navigating to a broken profile URL.
-      if (!account.value) {
-        await oauthStore.loadBlizzardBtag(oauthStore.token);
-      }
+      // Hydrate, then redirect — or fall back to home rather than a broken /player/
+      // URL (getProfileUrl("") -> /player/) if the battletag is still missing.
+      await ensureProfileLoaded();
 
       if (account.value) {
         openPlayerProfile();

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -114,6 +114,10 @@ export default defineComponent({
       // Handle Battle.net cancel or OAuth error passed as query param
       const queryError = route.query.error as string | undefined;
       if (queryError) {
+        // The login was cancelled/failed, so the SSO continuation is abandoned. Drop
+        // any saved return path so it can't hijack a later unrelated login (only a
+        // successful login should consume it, via openRequestedReturnPath()).
+        window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
         mapErrorCode("BNET_CANCELLED");
         return;
       }
@@ -123,6 +127,9 @@ export default defineComponent({
         await oauthStore.loadBlizzardBtag(authCode.value);
         openRequestedReturnPath();
       } catch (error: unknown) {
+        // Login failed (id-service error code or generic). As above, clear the saved
+        // return path so the abandoned SSO continuation can't redirect a future login.
+        window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
         const rawCode = error instanceof Error ? error.message.trim() : "";
         mapErrorCode(rawCode || "GENERIC");
       }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -71,7 +71,6 @@ export default defineComponent({
     const errorMessage = ref("");
 
     const account = computed<string>(() => oauthStore.blizzardVerifiedBtag);
-    const authCode = computed<string>(() => oauthStore.token);
 
     function goHome(): void {
       router.replace({ name: EMainRouteName.HOME });
@@ -123,27 +122,16 @@ export default defineComponent({
       }
 
       try {
+        // A resolved authorizeWithCode means the code exchange succeeded and the
+        // cookie was persisted — the login IS successful. The profile load inside it
+        // is best-effort, so a transient profile/validation blip does NOT fail the
+        // login. Redirect unconditionally on success; only a genuine EXCHANGE failure
+        // (authorize() throwing) lands in the catch below. authorizeWithCode already
+        // loaded the profile best-effort, so we don't call loadBlizzardBtag again here
+        // (App.vue's status-aware bootstrap fills the battletag on the destination if
+        // that best-effort load blipped).
         await oauthStore.authorizeWithCode(props.code);
-
-        // Only redirect once the session is verified. authorizeWithCode already
-        // persisted the cookie on a successful exchange, so loadBlizzardBtag is the
-        // profile-load step: "valid" means the session is fully hydrated -> redirect.
-        // "error" is a transient backend blip (5xx/network) -> show a retryable error
-        // and DO NOT redirect, so we never bounce into /sso-continue mid-outage (which
-        // would otherwise loop). "invalid" means the just-issued token was rejected
-        // -> treat as a failed login. Both non-valid paths clear LOGIN_RETURN_TO_KEY
-        // like the other failure exits so a stale return path can't be consumed later.
-        const status = await oauthStore.loadBlizzardBtag(authCode.value);
-
-        if (status === "valid") {
-          openRequestedReturnPath();
-          return;
-        }
-
-        // Both "error" (transient) and "invalid" (rejected token) are unexpected here
-        // and map to the generic error card.
-        window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
-        mapErrorCode("GENERIC");
+        openRequestedReturnPath();
       } catch (error: unknown) {
         // Login failed (id-service error code or generic). As above, clear the saved
         // return path so the abandoned SSO continuation can't redirect a future login.

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -124,8 +124,26 @@ export default defineComponent({
 
       try {
         await oauthStore.authorizeWithCode(props.code);
-        await oauthStore.loadBlizzardBtag(authCode.value);
-        openRequestedReturnPath();
+
+        // Only redirect once the session is verified. authorizeWithCode already
+        // persisted the cookie on a successful exchange, so loadBlizzardBtag is the
+        // profile-load step: "valid" means the session is fully hydrated -> redirect.
+        // "error" is a transient backend blip (5xx/network) -> show a retryable error
+        // and DO NOT redirect, so we never bounce into /sso-continue mid-outage (which
+        // would otherwise loop). "invalid" means the just-issued token was rejected
+        // -> treat as a failed login. Both non-valid paths clear LOGIN_RETURN_TO_KEY
+        // like the other failure exits so a stale return path can't be consumed later.
+        const status = await oauthStore.loadBlizzardBtag(authCode.value);
+
+        if (status === "valid") {
+          openRequestedReturnPath();
+          return;
+        }
+
+        // Both "error" (transient) and "invalid" (rejected token) are unexpected here
+        // and map to the generic error card.
+        window.sessionStorage.removeItem(LOGIN_RETURN_TO_KEY);
+        mapErrorCode("GENERIC");
       } catch (error: unknown) {
         // Login failed (id-service error code or generic). As above, clear the saved
         // return path so the abandoned SSO continuation can't redirect a future login.

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -50,7 +50,7 @@ import { defineComponent, nextTick, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { EMainRouteName } from "@/router/types";
-import { handoffEndpoint, identificationOrigin, isAllowedReturnUrl } from "@/helpers/sso";
+import { handoffEndpoint, identificationOrigin, isAllowedReturnUrl, isJwtExpired } from "@/helpers/sso";
 import { LOGIN_RETURN_TO_KEY, OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import { useOauthStore } from "@/store/oauth/store";
 import AuthorizationService from "@/services/AuthorizationService";
@@ -91,10 +91,21 @@ export default defineComponent({
     }
 
     async function init(): Promise<void> {
+      // The first part of this function MUST stay synchronous (no await before the
+      // expired-cookie clear). Vue mounts children before parents, so this
+      // SsoContinue onMounted runs BEFORE App.vue's onMounted auth bootstrap
+      // (loadAuthCodeToState / loadBlizzardBtag). If we awaited before clearing an
+      // expired cookie, control would yield back to the event loop and App's
+      // bootstrap could read the stale cookie and — because /api/oauth/user-info
+      // accepts expired JWTs (200) — re-save it and unmount the sign-in dialog we
+      // just opened. Clearing the expired cookie synchronously here means App's
+      // later onMounted sees no cookie, so it never restores the stale token.
+      //
       // validateSession() handles its own fetch throw internally (returns "error"),
       // so a transient failure deterministically shows the error card without an
       // unhandled rejection. This outer try/catch is defense in depth for any other
-      // unexpected throw, so the error card renders instead of a hung spinner.
+      // unexpected throw (incl. a sync throw), so the error card renders instead of
+      // a hung spinner.
       try {
         const returnParam = route.query["return"] as string | undefined;
 
@@ -106,22 +117,31 @@ export default defineComponent({
         const cookieJwt = AuthorizationService.loadAuthCookie();
 
         if (!cookieJwt) {
-          // No session at all — send the user through the sign-in flow.
+          // No session at all — send the user through the sign-in flow (sync).
           startColdLogin(returnParam);
           return;
         }
 
-        // A W3ChampionsJWT cookie can still be expired or revoked. The id-service
-        // handoff validates exp + signature and returns 401, which would strand the
-        // user on a 401 error page. Validate the cookie first against the same
-        // /api/oauth/user-info endpoint, but status-aware so a transient outage
-        // (5xx / network) isn't mistaken for a stale cookie.
+        if (isJwtExpired(cookieJwt)) {
+          // Expired cookie (the most common stale case). Clear it SYNCHRONOUSLY —
+          // before any await — so App.vue's later onMounted bootstrap can't read it
+          // back. logout() deletes the cookie + resets oauth state; then cold-login.
+          oauthStore.logout();
+          startColdLogin(returnParam);
+          return;
+        }
+
+        // Cookie present and not yet expired. Only now is it safe to await: this is
+        // the normal logged-in case where App's bootstrap restoring the cookie is
+        // correct. Confirm the signature/validity against /api/oauth/user-info,
+        // status-aware so a transient outage (5xx / network) isn't mistaken for a
+        // stale cookie. (validateSession re-checks exp too — harmless belt-and-braces.)
         const sessionState = await AuthorizationService.validateSession(cookieJwt);
 
         if (sessionState === "invalid") {
-          // Genuine auth failure (401/403) — the cookie is stale. Clear it the way
-          // the app does (store logout deletes the cookie + resets oauth state),
-          // then fall through to the cold-login flow.
+          // Genuine auth failure (401/403, e.g. revoked/forged) — the cookie is
+          // stale. Clear it the way the app does (store logout deletes the cookie +
+          // resets oauth state), then fall through to the cold-login flow.
           oauthStore.logout();
           startColdLogin(returnParam);
           return;

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -89,8 +89,10 @@ export default defineComponent({
         await nextTick();
         formRef.value?.submit();
       } else {
-        // User is not logged in — store the return URL and open the sign-in dialog
-        const selfUrl = window.location.href;
+        // User is not logged in — store a PATH (not a full URL) so the post-login
+        // router.replace(returnTo) in Login.vue matches this route, then bring it
+        // back to /sso-continue to complete the handoff once the cookie is set.
+        const selfUrl = `/sso-continue?return=${encodeURIComponent(returnParam)}`;
         window.sessionStorage.setItem("w3-login-return-to", selfUrl);
         window.dispatchEvent(
           new CustomEvent("w3-open-sign-in-dialog", {

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -91,11 +91,10 @@ export default defineComponent({
     }
 
     async function init(): Promise<void> {
-      // getProfile() returns null on a 4xx (handled below as a stale cookie), but its
-      // underlying fetch can THROW on a network/DNS/CORS failure. Catch any thrown
-      // error so the error card renders instead of leaving the spinner hung with an
-      // unhandled rejection. The internal early-returns (allowlist reject, cold-login)
-      // don't throw, so they keep their existing behaviour.
+      // validateSession() handles its own fetch throw internally (returns "error"),
+      // so a transient failure deterministically shows the error card without an
+      // unhandled rejection. This outer try/catch is defense in depth for any other
+      // unexpected throw, so the error card renders instead of a hung spinner.
       try {
         const returnParam = route.query["return"] as string | undefined;
 
@@ -114,16 +113,25 @@ export default defineComponent({
 
         // A W3ChampionsJWT cookie can still be expired or revoked. The id-service
         // handoff validates exp + signature and returns 401, which would strand the
-        // user on a 401 error page. Validate the cookie first using the SAME check the
-        // app uses on startup (getProfile → null on invalid; the oauth store logs out
-        // on null). Only submit the handoff for a confirmed-valid cookie.
-        const profile = await AuthorizationService.getProfile(cookieJwt);
+        // user on a 401 error page. Validate the cookie first against the same
+        // /api/oauth/user-info endpoint, but status-aware so a transient outage
+        // (5xx / network) isn't mistaken for a stale cookie.
+        const sessionState = await AuthorizationService.validateSession(cookieJwt);
 
-        if (!profile) {
-          // Stale cookie — clear it the way the app does (store logout deletes the
-          // cookie + resets oauth state), then fall through to the cold-login flow.
+        if (sessionState === "invalid") {
+          // Genuine auth failure (401/403) — the cookie is stale. Clear it the way
+          // the app does (store logout deletes the cookie + resets oauth state),
+          // then fall through to the cold-login flow.
           oauthStore.logout();
           startColdLogin(returnParam);
+          return;
+        }
+
+        if (sessionState === "error") {
+          // Transient failure (5xx / network / CORS) — do NOT clear the cookie or
+          // start a login loop. Show the error card so the user can retry with
+          // their session intact.
+          errorMessage.value = t("views_sso_continue.error_generic");
           return;
         }
 
@@ -140,7 +148,7 @@ export default defineComponent({
         }
         formRef.value.submit();
       } catch (e) {
-        // Genuine thrown exception (e.g. getProfile's fetch failed on network/CORS).
+        // Unexpected thrown exception (validateSession already absorbs fetch throws).
         // Surface the generic error card so the user isn't stuck on the spinner.
         console.error("[sso-continue] init failed", e);
         errorMessage.value = t("views_sso_continue.error_generic");

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -91,48 +91,60 @@ export default defineComponent({
     }
 
     async function init(): Promise<void> {
-      const returnParam = route.query["return"] as string | undefined;
+      // getProfile() returns null on a 4xx (handled below as a stale cookie), but its
+      // underlying fetch can THROW on a network/DNS/CORS failure. Catch any thrown
+      // error so the error card renders instead of leaving the spinner hung with an
+      // unhandled rejection. The internal early-returns (allowlist reject, cold-login)
+      // don't throw, so they keep their existing behaviour.
+      try {
+        const returnParam = route.query["return"] as string | undefined;
 
-      if (!returnParam || !isAllowedReturnUrl(returnParam, identificationOrigin())) {
-        errorMessage.value = t("views_sso_continue.error_invalid_return");
-        return;
+        if (!returnParam || !isAllowedReturnUrl(returnParam, identificationOrigin())) {
+          errorMessage.value = t("views_sso_continue.error_invalid_return");
+          return;
+        }
+
+        const cookieJwt = AuthorizationService.loadAuthCookie();
+
+        if (!cookieJwt) {
+          // No session at all — send the user through the sign-in flow.
+          startColdLogin(returnParam);
+          return;
+        }
+
+        // A W3ChampionsJWT cookie can still be expired or revoked. The id-service
+        // handoff validates exp + signature and returns 401, which would strand the
+        // user on a 401 error page. Validate the cookie first using the SAME check the
+        // app uses on startup (getProfile → null on invalid; the oauth store logs out
+        // on null). Only submit the handoff for a confirmed-valid cookie.
+        const profile = await AuthorizationService.getProfile(cookieJwt);
+
+        if (!profile) {
+          // Stale cookie — clear it the way the app does (store logout deletes the
+          // cookie + resets oauth state), then fall through to the cold-login flow.
+          oauthStore.logout();
+          startColdLogin(returnParam);
+          return;
+        }
+
+        // Valid session — submit the handoff form.
+        jwt.value = cookieJwt;
+        validatedReturn.value = returnParam;
+        await nextTick();
+        if (!formRef.value) {
+          // The hidden form should exist once jwt + validatedReturn are set; if it
+          // is somehow missing (future regression), surface an error instead of
+          // silently doing nothing.
+          errorMessage.value = t("views_sso_continue.error_invalid_return");
+          return;
+        }
+        formRef.value.submit();
+      } catch (e) {
+        // Genuine thrown exception (e.g. getProfile's fetch failed on network/CORS).
+        // Surface the generic error card so the user isn't stuck on the spinner.
+        console.error("[sso-continue] init failed", e);
+        errorMessage.value = t("views_sso_continue.error_generic");
       }
-
-      const cookieJwt = AuthorizationService.loadAuthCookie();
-
-      if (!cookieJwt) {
-        // No session at all — send the user through the sign-in flow.
-        startColdLogin(returnParam);
-        return;
-      }
-
-      // A W3ChampionsJWT cookie can still be expired or revoked. The id-service
-      // handoff validates exp + signature and returns 401, which would strand the
-      // user on a 401 error page. Validate the cookie first using the SAME check the
-      // app uses on startup (getProfile → null on invalid; the oauth store logs out
-      // on null). Only submit the handoff for a confirmed-valid cookie.
-      const profile = await AuthorizationService.getProfile(cookieJwt);
-
-      if (!profile) {
-        // Stale cookie — clear it the way the app does (store logout deletes the
-        // cookie + resets oauth state), then fall through to the cold-login flow.
-        oauthStore.logout();
-        startColdLogin(returnParam);
-        return;
-      }
-
-      // Valid session — submit the handoff form.
-      jwt.value = cookieJwt;
-      validatedReturn.value = returnParam;
-      await nextTick();
-      if (!formRef.value) {
-        // The hidden form should exist once jwt + validatedReturn are set; if it
-        // is somehow missing (future regression), surface an error instead of
-        // silently doing nothing.
-        errorMessage.value = t("views_sso_continue.error_invalid_return");
-        return;
-      }
-      formRef.value.submit();
     }
 
     onMounted((): void => {

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-container>
+    <v-row justify="center" align="center" class="fill-height">
+      <v-col cols="12" md="6">
+        <v-card class="text-center pt-1 pb-2">
+          <v-card-text>
+            <div v-if="!errorMessage && !jwt">
+              <v-progress-circular
+                :size="100"
+                color="primary"
+                indeterminate
+                class="mb-4"
+              />
+              <p>{{ $t("views_sso_continue.submitting") }}</p>
+            </div>
+
+            <div v-else-if="errorMessage">
+              <v-icon color="error" size="100" class="mb-4">
+                {{ mdiAlertCircle }}
+              </v-icon>
+              <h2 class="mb-2">{{ $t("views_sso_continue.error_title") }}</h2>
+              <p>{{ errorMessage }}</p>
+            </div>
+          </v-card-text>
+
+          <v-card-actions v-if="errorMessage" class="justify-center">
+            <v-btn variant="outlined" @click="goHome">
+              {{ $t("views_sso_continue.error_cta") }}
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- Hidden POST form submitted programmatically once jwt + validatedReturn are ready -->
+    <form
+      v-if="jwt && validatedReturn"
+      ref="formRef"
+      method="POST"
+      :action="handoffUrl"
+      style="display: none"
+    >
+      <input type="hidden" name="jwt" :value="jwt" />
+      <input type="hidden" name="return" :value="validatedReturn" />
+    </form>
+  </v-container>
+</template>
+<script lang="ts">
+import { defineComponent, nextTick, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
+import { EMainRouteName } from "@/router/types";
+import { handoffEndpoint, identificationOrigin, isAllowedReturnUrl } from "@/helpers/sso";
+import AuthorizationService from "@/services/AuthorizationService";
+import { mdiAlertCircle } from "@mdi/js";
+
+export default defineComponent({
+  name: "SsoContinueView",
+  components: {},
+  setup() {
+    const { t } = useI18n();
+    const route = useRoute();
+    const router = useRouter();
+
+    const errorMessage = ref("");
+    const jwt = ref("");
+    const validatedReturn = ref("");
+    const formRef = ref<HTMLFormElement | null>(null);
+    const handoffUrl = handoffEndpoint();
+
+    function goHome(): void {
+      router.replace({ name: EMainRouteName.HOME });
+    }
+
+    async function init(): Promise<void> {
+      const returnParam = route.query["return"] as string | undefined;
+
+      if (!returnParam || !isAllowedReturnUrl(returnParam, identificationOrigin())) {
+        errorMessage.value = t("views_sso_continue.error_invalid_return");
+        return;
+      }
+
+      const cookieJwt = AuthorizationService.loadAuthCookie();
+
+      if (cookieJwt) {
+        // User is already logged in — submit the handoff form
+        jwt.value = cookieJwt;
+        validatedReturn.value = returnParam;
+        await nextTick();
+        formRef.value?.submit();
+      } else {
+        // User is not logged in — store the return URL and open the sign-in dialog
+        const selfUrl = window.location.href;
+        window.sessionStorage.setItem("w3-login-return-to", selfUrl);
+        window.dispatchEvent(
+          new CustomEvent("w3-open-sign-in-dialog", {
+            detail: { returnTo: selfUrl },
+          }),
+        );
+      }
+    }
+
+    onMounted((): void => {
+      init();
+    });
+
+    return {
+      errorMessage,
+      jwt,
+      validatedReturn,
+      formRef,
+      handoffUrl,
+      mdiAlertCircle,
+      goHome,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.fill-height {
+  min-height: 50vh;
+}
+</style>

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -14,7 +14,7 @@
               <p>{{ $t("views_sso_continue.submitting") }}</p>
             </div>
 
-            <div v-else-if="errorMessage">
+            <div v-else-if="errorMessage" role="alert" aria-live="assertive">
               <v-icon color="error" size="100" class="mb-4">
                 {{ mdiAlertCircle }}
               </v-icon>
@@ -51,6 +51,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { EMainRouteName } from "@/router/types";
 import { handoffEndpoint, identificationOrigin, isAllowedReturnUrl } from "@/helpers/sso";
+import { LOGIN_RETURN_TO_KEY, OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import AuthorizationService from "@/services/AuthorizationService";
 import { mdiAlertCircle } from "@mdi/js";
 
@@ -87,15 +88,22 @@ export default defineComponent({
         jwt.value = cookieJwt;
         validatedReturn.value = returnParam;
         await nextTick();
-        formRef.value?.submit();
+        if (!formRef.value) {
+          // The hidden form should exist once jwt + validatedReturn are set; if it
+          // is somehow missing (future regression), surface an error instead of
+          // silently doing nothing.
+          errorMessage.value = t("views_sso_continue.error_invalid_return");
+          return;
+        }
+        formRef.value.submit();
       } else {
         // User is not logged in — store a PATH (not a full URL) so the post-login
         // router.replace(returnTo) in Login.vue matches this route, then bring it
         // back to /sso-continue to complete the handoff once the cookie is set.
         const selfUrl = `/sso-continue?return=${encodeURIComponent(returnParam)}`;
-        window.sessionStorage.setItem("w3-login-return-to", selfUrl);
+        window.sessionStorage.setItem(LOGIN_RETURN_TO_KEY, selfUrl);
         window.dispatchEvent(
-          new CustomEvent("w3-open-sign-in-dialog", {
+          new CustomEvent(OPEN_SIGN_IN_DIALOG_EVENT, {
             detail: { returnTo: selfUrl },
           }),
         );

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -81,6 +81,15 @@ export default defineComponent({
     // Login.vue matches this route. Shared by the "no cookie" and the
     // "stale cookie" cases so the cold-login branch isn't duplicated.
     function startColdLogin(returnParam: string): void {
+      // Always clear the session first: logout() deletes any (stale) cookie AND
+      // resets the in-memory oauth store token. App.vue renders <sign-in-dialog>
+      // only under v-if="!authCode", so a leftover store token (e.g. cookie cleared
+      // in another tab but token still in memory) would keep the dialog unmounted
+      // and the OPEN_SIGN_IN_DIALOG_EVENT would flip showSignInDialog on nothing.
+      // Clearing it makes authCode falsy so the dialog mounts and actually opens.
+      // logout() is synchronous, so this preserves the expired-path's sync clear.
+      oauthStore.logout();
+
       const selfUrl = `/sso-continue?return=${encodeURIComponent(returnParam)}`;
       window.sessionStorage.setItem(LOGIN_RETURN_TO_KEY, selfUrl);
       window.dispatchEvent(
@@ -123,10 +132,10 @@ export default defineComponent({
         }
 
         if (isJwtExpired(cookieJwt)) {
-          // Expired cookie (the most common stale case). Clear it SYNCHRONOUSLY —
-          // before any await — so App.vue's later onMounted bootstrap can't read it
-          // back. logout() deletes the cookie + resets oauth state; then cold-login.
-          oauthStore.logout();
+          // Expired cookie (the most common stale case). Handle it SYNCHRONOUSLY —
+          // before any await. startColdLogin() calls oauthStore.logout() first
+          // (deletes the cookie + resets oauth state, all sync), so App.vue's later
+          // onMounted can't read the stale cookie back.
           startColdLogin(returnParam);
           return;
         }
@@ -140,9 +149,8 @@ export default defineComponent({
 
         if (sessionState === "invalid") {
           // Genuine auth failure (401/403, e.g. revoked/forged) — the cookie is
-          // stale. Clear it the way the app does (store logout deletes the cookie +
-          // resets oauth state), then fall through to the cold-login flow.
-          oauthStore.logout();
+          // stale. startColdLogin() clears it (logout deletes the cookie + resets
+          // oauth state), then opens the sign-in flow.
           startColdLogin(returnParam);
           return;
         }

--- a/src/views/SsoContinue.vue
+++ b/src/views/SsoContinue.vue
@@ -52,6 +52,7 @@ import { useRoute, useRouter } from "vue-router";
 import { EMainRouteName } from "@/router/types";
 import { handoffEndpoint, identificationOrigin, isAllowedReturnUrl } from "@/helpers/sso";
 import { LOGIN_RETURN_TO_KEY, OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
+import { useOauthStore } from "@/store/oauth/store";
 import AuthorizationService from "@/services/AuthorizationService";
 import { mdiAlertCircle } from "@mdi/js";
 
@@ -62,6 +63,7 @@ export default defineComponent({
     const { t } = useI18n();
     const route = useRoute();
     const router = useRouter();
+    const oauthStore = useOauthStore();
 
     const errorMessage = ref("");
     const jwt = ref("");
@@ -71,6 +73,21 @@ export default defineComponent({
 
     function goHome(): void {
       router.replace({ name: EMainRouteName.HOME });
+    }
+
+    // Bring the user through the Battle.net sign-in flow, then back to
+    // /sso-continue to complete the handoff once a fresh cookie is set. Store a
+    // PATH (not a full URL) so the post-login router.replace(returnTo) in
+    // Login.vue matches this route. Shared by the "no cookie" and the
+    // "stale cookie" cases so the cold-login branch isn't duplicated.
+    function startColdLogin(returnParam: string): void {
+      const selfUrl = `/sso-continue?return=${encodeURIComponent(returnParam)}`;
+      window.sessionStorage.setItem(LOGIN_RETURN_TO_KEY, selfUrl);
+      window.dispatchEvent(
+        new CustomEvent(OPEN_SIGN_IN_DIALOG_EVENT, {
+          detail: { returnTo: selfUrl },
+        }),
+      );
     }
 
     async function init(): Promise<void> {
@@ -83,31 +100,39 @@ export default defineComponent({
 
       const cookieJwt = AuthorizationService.loadAuthCookie();
 
-      if (cookieJwt) {
-        // User is already logged in — submit the handoff form
-        jwt.value = cookieJwt;
-        validatedReturn.value = returnParam;
-        await nextTick();
-        if (!formRef.value) {
-          // The hidden form should exist once jwt + validatedReturn are set; if it
-          // is somehow missing (future regression), surface an error instead of
-          // silently doing nothing.
-          errorMessage.value = t("views_sso_continue.error_invalid_return");
-          return;
-        }
-        formRef.value.submit();
-      } else {
-        // User is not logged in — store a PATH (not a full URL) so the post-login
-        // router.replace(returnTo) in Login.vue matches this route, then bring it
-        // back to /sso-continue to complete the handoff once the cookie is set.
-        const selfUrl = `/sso-continue?return=${encodeURIComponent(returnParam)}`;
-        window.sessionStorage.setItem(LOGIN_RETURN_TO_KEY, selfUrl);
-        window.dispatchEvent(
-          new CustomEvent(OPEN_SIGN_IN_DIALOG_EVENT, {
-            detail: { returnTo: selfUrl },
-          }),
-        );
+      if (!cookieJwt) {
+        // No session at all — send the user through the sign-in flow.
+        startColdLogin(returnParam);
+        return;
       }
+
+      // A W3ChampionsJWT cookie can still be expired or revoked. The id-service
+      // handoff validates exp + signature and returns 401, which would strand the
+      // user on a 401 error page. Validate the cookie first using the SAME check the
+      // app uses on startup (getProfile → null on invalid; the oauth store logs out
+      // on null). Only submit the handoff for a confirmed-valid cookie.
+      const profile = await AuthorizationService.getProfile(cookieJwt);
+
+      if (!profile) {
+        // Stale cookie — clear it the way the app does (store logout deletes the
+        // cookie + resets oauth state), then fall through to the cold-login flow.
+        oauthStore.logout();
+        startColdLogin(returnParam);
+        return;
+      }
+
+      // Valid session — submit the handoff form.
+      jwt.value = cookieJwt;
+      validatedReturn.value = returnParam;
+      await nextTick();
+      if (!formRef.value) {
+        // The hidden form should exist once jwt + validatedReturn are set; if it
+        // is somehow missing (future regression), surface an error instead of
+        // silently doing nothing.
+        errorMessage.value = t("views_sso_continue.error_invalid_return");
+        return;
+      }
+      formRef.value.submit();
     }
 
     onMounted((): void => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "importHelpers": true,
@@ -8,6 +9,7 @@
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "importHelpers": true,
@@ -9,7 +8,6 @@
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Adds the website side of the Quackback feedback SSO: a `/sso-continue` view that mediates the OIDC handoff to `identification-service`, an exact-origin `returnTo` allowlist, and a `Login.vue` error card (boy-scout fix for the previous infinite-spinner-on-failure). All additive and non-breaking — the cookie name/scope is unchanged and normal login still lands on the profile.

## What this adds
- **`src/views/SsoContinue.vue`** — on `/sso-continue?return=<id-service authorize URL>`: validates `return` against the IdP origin (exact-match allowlist, env-derived from `window._env_.IDENTIFICATION_URL`); if a valid `W3ChampionsJWT` session exists, auto-submits a hidden **browser POST** form to `…/connect/handoff`; otherwise opens the existing Battle.net sign-in and preserves the continuation URL.
- **`src/helpers/sso.ts`** (+ `node:test` unit tests) — pure `isAllowedReturnUrl(url, origin)` (exact-origin, no open redirects) and `isJwtExpired(jwt)` (client-side `exp` gate), plus `identificationOrigin()`/`handoffEndpoint()`.
- **`Login.vue` error UI** — replaces the infinite spinner with an error card mapping id-service codes (`MISSING_WARCRAFT_3`, `MISSING_PLAYABLE_TITLES_SCOPE`, `UNSUPPORTED_VERSION`, `PLAYABLE_TITLES_API_FAILED`) + Battle.net cancel. Success path unchanged.
- `/sso-continue` route, i18n keys, and a shared `src/constants/sso.ts`.

## Session-flow hardening (from the Codex review loop)
The login/session interaction was made substantially more robust:
- **Status-aware session bootstrap** — a transient backend 5xx during session restore no longer logs the user out app-wide (only a definitive 401 does); the user-info check is a single fetch returning `valid`/`invalid`/`error`.
- **Expired/stale cookies** handled synchronously before the handoff (an expired token is never POSTed to the handoff); cold-login clears stale store state so the sign-in dialog always mounts.
- **Cookie persisted on a successful code exchange** (profile fetch is best-effort) — a transient profile failure no longer fails the login or abandons the SSO return.
- **In-SPA redirects hydrate the profile first** (admin/profile destinations) since App's bootstrap doesn't rerun after SPA navigation; the cancelled-login path clears the saved return so it can't hijack a later login.

## Verification
- [x] `npm run lint`, `npm run dprint`, `npm run type-check-vue` (vue-tsc), `npm run build` — all clean
- [x] `src/helpers/sso.test.ts` — 13 `node:test` cases pass
- [ ] Manual dev-server scenarios (Task 6 in the design): open-redirect rejection, missing/invalid return, cold login, warm login (POST emitted to `/connect/handoff`), Battle.net cancel, normal login unaffected

## Dependency
**Inert until PR1 (identification-service OIDC IdP) is deployed** — the `/sso-continue` handoff has no live endpoint to talk to until then. Safe to merge after PR1.

> Reviewed via an automated multi-pass Codex review loop; the session/redirect edge cases above were all surfaced and fixed there. `tsconfig.json` unchanged.
