### PR TITLE
feat: publicly release launcher-e on the setup guide (macOS Intel + Apple Silicon)

### DIFF
--- a/src/components/setup-guides/LauncherSetup.vue
+++ b/src/components/setup-guides/LauncherSetup.vue
@@ -35,6 +35,7 @@
                     <v-btn
                       :href="launcherEUrl"
                       target="_blank"
+                      rel="noopener"
                       class="join-button mt-0 mb-4"
                     >
                       <v-icon>{{ mdiDownload }}</v-icon>
@@ -43,6 +44,7 @@
                     <v-btn
                       :href="launcherEMacArm64Url"
                       target="_blank"
+                      rel="noopener"
                       class="join-button mt-0 mb-4 ml-8"
                     >
                       <v-icon>{{ mdiDownload }}</v-icon>
@@ -51,6 +53,7 @@
                     <v-btn
                       :href="launcherEMacIntelUrl"
                       target="_blank"
+                      rel="noopener"
                       class="join-button mt-0 mb-4 ml-8"
                     >
                       <v-icon>{{ mdiDownload }}</v-icon>

--- a/src/components/setup-guides/LauncherSetup.vue
+++ b/src/components/setup-guides/LauncherSetup.vue
@@ -20,9 +20,6 @@
               <v-tab value="windows-setup">
                 {{ $t("views_gettingstarted.manualwin") }}
               </v-tab>
-              <v-tab value="mac-setup">
-                {{ $t("views_gettingstarted.manualmac") }}
-              </v-tab>
             </v-tabs>
           </v-col>
 
@@ -44,12 +41,20 @@
                       <span class="mr-2">Windows</span>
                     </v-btn>
                     <v-btn
-                      :href="launcherUrlMac"
+                      :href="launcherEMacArm64Url"
                       target="_blank"
                       class="join-button mt-0 mb-4 ml-8"
                     >
                       <v-icon>{{ mdiDownload }}</v-icon>
-                      <span class="mr-2">Mac</span>
+                      <span class="mr-2">macOS (Apple Silicon)</span>
+                    </v-btn>
+                    <v-btn
+                      :href="launcherEMacIntelUrl"
+                      target="_blank"
+                      class="join-button mt-0 mb-4 ml-8"
+                    >
+                      <v-icon>{{ mdiDownload }}</v-icon>
+                      <span class="mr-2">macOS (Intel)</span>
                     </v-btn>
                   </v-card-text>
                   <h3>{{ $t("views_gettingstarted.launchertitle") }}</h3>
@@ -106,90 +111,6 @@
                   </div>
                 </v-card-text>
               </v-window-item>
-
-              <!-- MAC SETUP TAB -->
-              <v-window-item value="mac-setup">
-                <v-card-text class="pt-0 px-3">
-                  <v-alert variant="outlined" type="info" prominent border="start">
-                    {{ alertMessage }}
-                  </v-alert>
-                  <h3 class="mt-10">{{ $t("views_gettingstarted.manualmactitle") }}</h3>
-                  <p>{{ $t("views_gettingstarted.manualmacbody1") }}</p>
-                  <v-btn
-                    color="primary"
-                    :href="webUiLink"
-                    target="_blank"
-                    variant="outlined"
-                  >
-                    <v-icon>{{ mdiDownload }}</v-icon>
-                    <span class="mr-2 hidden-xs">
-                      {{ $t("views_gettingstarted.manualmacbody2") }}
-                    </span>
-                  </v-btn>
-                  <p class="mt-2">
-                    {{ $t("views_gettingstarted.manualmacbody3") }}
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody4") }}</code>
-                  </p>
-                  <p>
-                    {{ $t("views_gettingstarted.manualmacbody5") }}
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody6") }}</code>
-                  </p>
-                  <p>{{ $t("views_gettingstarted.manualmacbody7") }}</p>
-                  <v-btn
-                    color="primary"
-                    :href="mapsLink"
-                    target="_blank"
-                    variant="outlined"
-                  >
-                    <v-icon>{{ mdiDownload }}</v-icon>
-                    <span class="mr-2 hidden-xs">
-                      {{ $t("views_gettingstarted.manualmacbody8") }}
-                    </span>
-                  </v-btn>
-                  <p class="mt-2">
-                    {{ $t("views_gettingstarted.manualmacbody9") }}
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody10") }}</code>
-                  </p>
-                  <p>
-                    <i style="color: red">{{ $t("views_gettingstarted.manualmacbody11") }}</i>
-                    <br />
-                    {{ $t("views_gettingstarted.manualmacbody12") }}
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody13") }}</code>
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody14") }}</code>
-                    <br />
-                    {{ $t("views_gettingstarted.manualmacbody15") }}
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody16") }}</code>
-                    <br />
-                    <code>{{ $t("views_gettingstarted.manualmacbody17") }}</code>
-                    <br />
-                  </p>
-                  <p class="mt-2">{{ $t("views_gettingstarted.manualmacbody18") }}</p>
-                  <div>
-                    <ul>
-                      <li>
-                        {{ $t("views_gettingstarted.manualmacbody19") }}
-                        <code>{{ $t("views_gettingstarted.manualmacbody19_1") }}</code>
-                      </li>
-                      <li>{{ $t("views_gettingstarted.manualmacbody20") }}</li>
-                      <li>{{ $t("views_gettingstarted.manualmacbody21") }}</li>
-                      <li>{{ $t("views_gettingstarted.manualmacbody22") }}</li>
-                    </ul>
-                  </div>
-                  <div class="mt-10 video-container">
-                    <iframe
-                      src="https://www.youtube.com/embed/8s53BHfKPLs"
-                      frameborder="0"
-                      allowfullscreen
-                    ></iframe>
-                  </div>
-                </v-card-text>
-              </v-window-item>
             </v-window>
           </v-col>
         </v-row>
@@ -210,10 +131,9 @@ export default defineComponent({
   setup() {
     const alertMessage = ref<string>("These steps are only needed if you have problems with the normal W3Champions App. In that case, please reach out on Discord!");
     const ingameAddonLink = ref<string>(LAUNCHER_UPDATE_URL + "ingame-addon");
-    const webUiLink = ref<string>(LAUNCHER_UPDATE_URL + "webui");
-    const mapsLink = ref<string>(LAUNCHER_UPDATE_URL + "maps");
-    const launcherUrlMac = ref<string>(LAUNCHER_UPDATE_URL + "launcher/mac");
     const launcherEUrl = ref<string>(LAUNCHER_UPDATE_URL + "launcher-e");
+    const launcherEMacArm64Url = ref<string>(LAUNCHER_UPDATE_URL + "launcher-e/mac-arm64");
+    const launcherEMacIntelUrl = ref<string>(LAUNCHER_UPDATE_URL + "launcher-e/mac-x64");
     const route = useRoute();
     const router = useRouter();
     const tabsModel = ref({ self: (route.query.tabsModel as string) || "launcher" });
@@ -234,10 +154,9 @@ export default defineComponent({
       ingameAddonLink,
       alertMessage,
       mdiDownload,
-      webUiLink,
-      mapsLink,
-      launcherUrlMac,
-      launcherEUrl
+      launcherEUrl,
+      launcherEMacArm64Url,
+      launcherEMacIntelUrl
     };
   },
 });


### PR DESCRIPTION
## Summary
- Make the new launcher (**launcher-e**) the download for all platforms on the launcher setup guide.
- The Launcher tab now offers three downloads: **Windows**, **macOS (Apple Silicon)**, **macOS (Intel)** → `/api/launcher-e`, `/api/launcher-e/mac-arm64`, `/api/launcher-e/mac-x64`.
- Remove the obsolete **"Manual Mac OS"** tab (manual steps, Gatekeeper-bypass instructions, YouTube embed). The new macOS builds are code-signed **and notarized**, so those steps are no longer needed.
- Remove the now-unused `launcherUrlMac` / `webUiLink` / `mapsLink` refs (the Windows "Manual Windows" tab and `ingameAddonLink` are retained).
- Add `rel="noopener"` to the launcher download buttons (defense-in-depth on `target="_blank"`).

## Why no auto-detection
There is no reliable, actively-maintained browser library to distinguish macOS Intel from Apple Silicon (the macOS user-agent is frozen to "Intel"), so all three buttons are shown explicitly rather than guessing.

## Verification
No unit-test runner in this repo (by design). Verified: `npm run lint` ✅, `npm run dprint` ✅, `npm run type-check-vue` ✅, `npm run build` ✅ (1669 modules, 0 errors).

## Notes / follow-ups
- The now-unused `views_gettingstarted.manualmac*` translation keys live in the autogenerated, Google-Sheet-sourced `data.ts` and are intentionally left untouched. They can be pruned from the sheet later.
- Button labels are hardcoded platform names (matching the pre-existing pattern).

## Depends on
Requires the update-service PR (https://github.com/w3champions/update-service/pull/32) — the new `/api/launcher-e/mac-*` endpoints — to be **deployed first**.