### PR TITLE
feat(sso): clear the IdP SSO session on logout (single logout)

### DIFF
--- a/src/services/AuthorizationService.ts
+++ b/src/services/AuthorizationService.ts
@@ -90,6 +90,25 @@ export default class AuthorizationService {
     Cookies.remove(w3CAuthRegion);
   }
 
+  /**
+   * Ends the identification-service OIDC SSO session by clearing its
+   * `__Host-w3c-idp-session` cookie, so logging out of the website also ends SSO. That
+   * cookie is HttpOnly on the id-service host, so it can only be cleared server-side; a
+   * hidden `<img>` GET is enough — the browser honours the response's clearing
+   * `Set-Cookie` even though it can't read the (204) body, and an image load needs no
+   * CORS. Best-effort and fire-and-forget: a failure here must never break local logout.
+   * Without it, a fresh OIDC login (e.g. Quackback) would silently reuse the up-to-30-min
+   * IdP session after a website logout instead of re-prompting for Battle.net.
+   */
+  public static clearIdpSession(): void {
+    try {
+      const image = new Image();
+      image.src = `${IDENTIFICATION_URL}connect/idp-logout?t=${Date.now()}`;
+    } catch {
+      // best-effort: never let SSO-logout cleanup throw out of logout()
+    }
+  }
+
   public static async getProfile(bearer: string): Promise<W3cToken | null> {
     const url = `${IDENTIFICATION_URL}api/oauth/user-info?jwt=${bearer}`;
     const response = await fetch(url, {

--- a/src/store/oauth/store.ts
+++ b/src/store/oauth/store.ts
@@ -92,6 +92,9 @@ export const useOauthStore = defineStore("oauth", {
     },
     logout() {
       AuthorizationService.deleteAuthCookie();
+      // Also end the OIDC SSO session at the identification-service, so a fresh OIDC
+      // login (e.g. Quackback) re-prompts instead of silently reusing the IdP session.
+      AuthorizationService.clearIdpSession();
       this.SET_PROFILE_NAME("");
       this.SET_IS_ADMIN(false);
       this.SET_BEARER("");


### PR DESCRIPTION
## Problem
Website logout (`oauthStore.logout()`) cleared only the local `W3ChampionsJWT` cookie. The identification-service keeps its own `__Host-w3c-idp-session` OIDC SSO cookie (HttpOnly, 30-min), so a fresh OIDC login (e.g. Quackback) silently reused it after a website logout instead of re-prompting for Battle.net.

## Change
`logout()` now also calls `AuthorizationService.clearIdpSession()`, which fires a hidden front-channel `GET` to the id-service `/connect/idp-logout` endpoint (via a throwaway `<img>`). That cookie is HttpOnly on the id-service host, so it can only be cleared server-side; the browser honours the response's clearing `Set-Cookie`, and an image load needs no CORS. Best-effort + fire-and-forget, wrapped so it can never throw out of `logout()`.

- `AuthorizationService.ts`: new `clearIdpSession()` (uses the existing `IDENTIFICATION_URL`).
- `store/oauth/store.ts`: `logout()` calls it.

`logout()` is the single chokepoint for clearing the session (also hit on invalid-session cleanup and the SSO cold-login path), so the IdP session is consistently cleared whenever the local session is — correct and idempotent.

## Depends on
The id-service `/connect/idp-logout` endpoint (w3champions/identification-service) — **deploy that first**. Until it's live, the `<img>` just 404s and the cleanup no-ops (no breakage).

## Verification
- [x] `npm run lint` clean
- [x] `npm run dprint` clean
- [x] `npm run type-check` (tsc -noEmit) clean
- [x] `npm run build` (vite) ✓
- [ ] Manual: log into Quackback via SSO → log out of w3champions.com → re-trigger Quackback login → expect a Battle.net re-prompt (not a silent login).
