### PR TITLE
fix(admin/lag-reports): "starts with" hint on text filters

### DIFF
--- a/src/components/admin/AdminLagReports.vue
+++ b/src/components/admin/AdminLagReports.vue
@@ -10,6 +10,7 @@
           <v-text-field
             v-model="filters.battleTag"
             label="BattleTag"
+            placeholder="Starts with…"
             variant="underlined"
             color="primary"
             clearable
@@ -20,6 +21,7 @@
           <v-text-field
             v-model="filters.gameSearch"
             label="Game ID / Name"
+            placeholder="ID, or name starts with…"
             variant="underlined"
             color="primary"
             clearable
@@ -30,6 +32,7 @@
           <v-text-field
             v-model="filters.serverName"
             label="Server Name"
+            placeholder="Starts with…"
             variant="underlined"
             color="primary"
             clearable
@@ -40,6 +43,7 @@
           <v-text-field
             v-model="filters.proxyName"
             label="Proxy Name"
+            placeholder="Starts with…"
             variant="underlined"
             color="primary"
             clearable
@@ -50,6 +54,7 @@
           <v-text-field
             v-model="filters.proxyIp"
             label="Proxy IP"
+            placeholder="Starts with…"
             variant="underlined"
             color="primary"
             clearable


### PR DESCRIPTION
## What

Adds a `placeholder="Starts with…"` hint to the lag-reports admin filter inputs (BattleTag, Game, Server Name, Proxy Name, Proxy IP) so admins know the search now matches the **start** of the value.

## Why

w3champions/website-backend#524 made `GET /api/lag-reports` fast by switching the text filters from an (unindexable) case-insensitive **substring** regex to an index-backed case-insensitive **prefix** match. That's a behavior change: typing a mid-string fragment (e.g. just the `#1234` discriminator) no longer matches. Without a hint, admins would think search is broken.

The placeholder appears when the field is focused, right as the admin starts typing. The **Game** field also matches Game IDs / Flo Game IDs exactly, so its hint reads "ID, or name starts with…".

## Screenshots / behavior

Empty field shows the label as before; on focus the placeholder reveals the "starts with…" guidance. No layout shift, no extra vertical space.

## Test plan

- [x] `npm run dprint` — clean (config has no Vue plugin; `.vue` untouched anyway — change is template-only)
- [x] `npm run lint` (ESLint, `--max-warnings=0`) — clean
- [x] `npm run type-check-vue` (vue-tsc) — clean
- [x] `npm run build` (vite) — succeeds

No logic changes — `placeholder` is the only added attribute on existing `v-text-field`s.
