### PR TITLE
feat: GA4 analytics with Silktide cookie consent + GDPR legal pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
   <title>W3Champions</title>
   <link rel="icon" href="/favicon.ico?v=5">
   <script type="text/javascript" src="/env.js?v=5"></script>
+  <!-- Cookie consent (Silktide, self-hosted) + analytics bootstrap.
+       Order matters: library CSS + JS first (synchronous, no defer), then our
+       Consent Mode default / GA4 loader / Silktide init. -->
+  <link rel="stylesheet" href="/silktide/silktide-consent-manager.css">
+  <script src="/silktide/silktide-consent-manager.js"></script>
+  <script src="/analytics-consent.js"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
        Order matters: library CSS + JS first (synchronous, no defer), then our
        Consent Mode default / GA4 loader / Silktide init. -->
   <link rel="stylesheet" href="/silktide/silktide-consent-manager.css">
+  <!-- Hide Silktide's floating cookie icon; consent is re-opened via the footer "Cookie settings" link. -->
+  <style>#stcm-icon { display: none !important; }</style>
   <script src="/silktide/silktide-consent-manager.js"></script>
   <script src="/analytics-consent.js"></script>
 </head>

--- a/public/analytics-consent.js
+++ b/public/analytics-consent.js
@@ -1,0 +1,114 @@
+/**
+ * Analytics + cookie-consent bootstrap for w3champions.com.
+ *
+ * Loaded from index.html (in <head>, AFTER the Silktide library, BEFORE the Vue
+ * app). Responsibilities:
+ *   1. Google Consent Mode v2 default (denied unless the visitor previously
+ *      granted Analytics).
+ *   2. window.__w3cLoadGa4(): idempotent GA4 loader, gated to production hosts.
+ *   3. Initialise the Silktide Consent Manager (Essential + Analytics).
+ *
+ * The GA4 Measurement ID is a public value, identical across environments, so it
+ * is hardcoded. The production-host guard prevents test/localhost traffic from
+ * polluting the production GA4 property.
+ */
+(function () {
+  "use strict";
+
+  var GA4_MEASUREMENT_ID = "G-HQ4XC36WGT";
+  var PROD_HOSTS = ["w3champions.com", "www.w3champions.com"];
+  var ANALYTICS_CONSENT_KEY = "stcm.consent.analytics"; // Silktide v2.0 key format
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    window.dataLayer.push(arguments);
+  }
+  window.gtag = window.gtag || gtag;
+
+  function analyticsPreviouslyGranted() {
+    try {
+      return window.localStorage.getItem(ANALYTICS_CONSENT_KEY) === "true";
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function isProdHost() {
+    return PROD_HOSTS.indexOf(window.location.hostname) !== -1;
+  }
+
+  // 1. Consent Mode v2 default — MUST run before any gtag.js load.
+  window.gtag("consent", "default", {
+    analytics_storage: analyticsPreviouslyGranted() ? "granted" : "denied",
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  });
+
+  // 2. Idempotent GA4 loader (production hosts only).
+  var ga4Loaded = false;
+  window.__w3cLoadGa4 = function () {
+    if (ga4Loaded || !isProdHost() || !GA4_MEASUREMENT_ID) return;
+    ga4Loaded = true;
+    window.__w3cAnalyticsActive = true;
+
+    var s = document.createElement("script");
+    s.async = true;
+    s.src = "https://www.googletagmanager.com/gtag/js?id=" + GA4_MEASUREMENT_ID;
+    document.head.appendChild(s);
+
+    window.gtag("js", new Date());
+    window.gtag("config", GA4_MEASUREMENT_ID, { send_page_view: false });
+
+    // Catch-up page_view for the current page (router.afterEach covers later
+    // navigations). Deferred so it is queued after Silktide's synchronous
+    // gtag('consent','update','granted') on a fresh Accept.
+    setTimeout(function () {
+      window.gtag("event", "page_view", {
+        page_location: window.location.href,
+        page_path: window.location.pathname + window.location.search,
+        page_title: document.title,
+      });
+    }, 0);
+  };
+
+  // 3. Initialise Silktide Consent Manager.
+  if (window.silktideConsentManager && typeof window.silktideConsentManager.init === "function") {
+    window.silktideConsentManager.init({
+      consentTypes: [
+        {
+          id: "essential",
+          name: "Essential",
+          description:
+            "<p>Required for the website to work — signing in, security (bot protection), and remembering your cookie choices and preferences (theme, language). These cannot be switched off.</p>",
+          required: true,
+        },
+        {
+          id: "analytics",
+          name: "Analytics",
+          description:
+            "<p>Help us understand how visitors use the site so we can improve it, via Google Analytics. These stay off until you allow them.</p>",
+          required: false,
+          defaultValue: false,
+          gtag: "analytics_storage",
+          onAccept: function () {
+            window.__w3cLoadGa4();
+          },
+        },
+      ],
+      text: {
+        prompt: {
+          description:
+            "<p>We use cookies to run the site and, with your consent, to measure usage. See our <a href=\"/cookies\">Cookie Policy</a> and <a href=\"/privacy\">Privacy Policy</a>.</p>",
+          acceptAllButtonText: "Accept all",
+          rejectNonEssentialButtonText: "Reject non-essential",
+          preferencesButtonText: "Preferences",
+        },
+        preferences: {
+          title: "Manage your cookie preferences",
+          saveButtonText: "Save and close",
+        },
+      },
+    });
+  }
+})();

--- a/public/analytics-consent.js
+++ b/public/analytics-consent.js
@@ -80,14 +80,14 @@
       consentTypes: [
         {
           id: "essential",
-          name: "Essential",
+          label: "Essential",
           description:
             "<p>Required for the website to work — signing in, security (bot protection), and remembering your cookie choices and preferences (theme, language). These cannot be switched off.</p>",
           required: true,
         },
         {
           id: "analytics",
-          name: "Analytics",
+          label: "Analytics",
           description:
             "<p>Help us understand how visitors use the site so we can improve it, via Google Analytics. These stay off until you allow them.</p>",
           required: false,

--- a/public/analytics-consent.js
+++ b/public/analytics-consent.js
@@ -17,7 +17,7 @@
 
   var GA4_MEASUREMENT_ID = "G-HQ4XC36WGT";
   var PROD_HOSTS = ["w3champions.com", "www.w3champions.com"];
-  var ANALYTICS_CONSENT_KEY = "stcm.consent.analytics"; // Silktide key: stcm.consent.<id> (no namespace configured) — keep in sync with init() config
+  var ANALYTICS_CONSENT_KEY = "stcm.consent.analytics"; // Silktide _buildConsentKey('analytics') with no namespace = stcm.consent.<id>; keep in sync with init() config
 
   window.dataLayer = window.dataLayer || [];
   function gtag() {

--- a/public/analytics-consent.js
+++ b/public/analytics-consent.js
@@ -17,12 +17,13 @@
 
   var GA4_MEASUREMENT_ID = "G-HQ4XC36WGT";
   var PROD_HOSTS = ["w3champions.com", "www.w3champions.com"];
-  var ANALYTICS_CONSENT_KEY = "stcm.consent.analytics"; // Silktide v2.0 key format
+  var ANALYTICS_CONSENT_KEY = "stcm.consent.analytics"; // Silktide key: stcm.consent.<id> (no namespace configured) — keep in sync with init() config
 
   window.dataLayer = window.dataLayer || [];
   function gtag() {
     window.dataLayer.push(arguments);
   }
+  // Guard: don't overwrite gtag if another script installed it first; both push to the shared window.dataLayer.
   window.gtag = window.gtag || gtag;
 
   function analyticsPreviouslyGranted() {
@@ -57,6 +58,7 @@
     s.src = "https://www.googletagmanager.com/gtag/js?id=" + GA4_MEASUREMENT_ID;
     document.head.appendChild(s);
 
+    // gtag('js'/'config') push into window.dataLayer immediately; the async gtag.js replays the queue once it loads.
     window.gtag("js", new Date());
     window.gtag("config", GA4_MEASUREMENT_ID, { send_page_view: false });
 
@@ -110,5 +112,8 @@
         },
       },
     });
+  } else {
+    // Library failed to load: keep analytics disabled (correct privacy default) but make it visible.
+    console.warn("[w3c] Silktide Consent Manager unavailable; cookie banner not shown and analytics disabled.");
   }
 })();

--- a/public/silktide/silktide-consent-manager.css
+++ b/public/silktide/silktide-consent-manager.css
@@ -1,0 +1,589 @@
+/* 
+  Silktide Consent Manager - https://silktide.com/consent-manager/  
+*/
+
+/* --------------------------------
+  Global Styles
+-------------------------------- */
+/* Wrapper (Global) */
+#stcm-wrapper {
+  --boxShadow: -5px 5px 10px 0px #00000012, 0px 0px 50px 0px #0000001a;
+  --fontFamily: Helvetica Neue, Segoe UI, Arial, sans-serif;
+  --primaryColor: #F9D000;
+  --backgroundColor: #050505;
+  --textColor: #F4F0DF;
+  --backdropBackgroundColor: #00000077;
+  --backdropBackgroundBlur: 0px;
+  --iconColor: #050505;
+  --iconBackgroundColor: #F9D000;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 99999;
+  pointer-events: none;
+  border: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* --------------------------------
+Links
+-------------------------------- */
+#stcm-wrapper a {
+  all: unset;
+  display: inline-block;
+  color: var(--primaryColor);
+  text-decoration: underline;
+}
+
+#stcm-wrapper a:hover {
+  cursor: pointer;
+  color: var(--textColor);
+}
+
+/* --------------------------------
+Focus Styles
+-------------------------------- */
+#stcm-wrapper a:focus,
+#stcm-wrapper #stcm-banner button:focus,
+#stcm-wrapper #stcm-modal button:focus,
+#stcm-wrapper #stcm-icon:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px #ffffff;
+  border-radius: 5px;
+}
+
+#stcm-wrapper #stcm-icon:focus {
+  border-radius: 50%;
+}
+
+/* --------------------------------
+General Styles
+-------------------------------- */
+#stcm-wrapper .stcm-button {
+  color: var(--backgroundColor);
+  background-color: var(--primaryColor);
+  border: 2px solid var(--primaryColor);
+  padding: 10px 20px;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
+  font-size: 16px;
+  line-height: 24px;
+  cursor: pointer;
+  border-radius: 5px;
+}
+
+#stcm-wrapper .stcm-button-primary:hover {
+  background-color: var(--backgroundColor);
+  color: var(--primaryColor);
+}
+
+#stcm-wrapper .stcm-button-secondary {
+  background-color: var(--backgroundColor);
+  color: var(--primaryColor);
+}
+
+#stcm-wrapper .stcm-button-secondary:hover {
+  background-color: var(--primaryColor);
+  color: var(--backgroundColor);
+}
+
+/* --------------------------------
+Banner
+-------------------------------- */
+#stcm-banner {
+  font-family: var(--fontFamily);
+  color: var(--textColor);
+  background-color: var(--backgroundColor);
+  box-sizing: border-box;
+  padding: 32px;
+  border-radius: 12px;
+  pointer-events: auto;
+  border: 0px;
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 600px;
+  overflow: auto;
+  max-width: calc(100% - 32px);
+  max-height: calc(100vh - 32px);
+  transform: translate(0, -20px);
+  opacity: 0;
+  animation: stcm-slide-down 350ms ease-out;
+  animation-delay: 0.3s;
+  box-shadow: -5px 5px 10px 0px #00000012, 0px 0px 50px 0px #0000001a;
+}
+
+#stcm-banner.stcm-loaded {
+  opacity: 1;
+  transform: none;
+  animation: none;
+}
+
+#stcm-banner:focus {
+  border-radius: 50%;
+}
+
+#stcm-banner.stcm-pos-center {
+  top: 50%;
+  left: 50%;
+  bottom: auto;
+  right: auto;
+  position: fixed;
+  transform: translate(-50%, calc(-50% - 20px));
+  animation: stcm-slide-down-center 350ms ease-out forwards;
+}
+
+#stcm-banner.stcm-pos-bottom-left {
+  bottom: 16px;
+  left: 16px;
+  position: fixed;
+}
+
+#stcm-banner.stcm-pos-bottom-center {
+  bottom: 16px;
+  left: 50%;
+  position: fixed;
+  transform: translate(-50%, -20px);
+  animation: stcm-slide-down-bottom-center 350ms ease-out forwards;
+}
+
+#stcm-banner .stcm-preferences-button {
+  display: flex;
+  gap: 5px;
+  border: none;
+  padding: 15px 0px;
+  background-color: transparent;
+  color: var(--primaryColor);
+  cursor: pointer;
+  font-size: 16px;
+}
+
+#stcm-banner .stcm-preferences-button span {
+  display: block;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+#stcm-banner .stcm-preferences-button span:hover {
+  color: var(--textColor);
+}
+
+#stcm-banner p {
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--textColor);
+  margin: 0px 0px 15px;
+}
+
+#stcm-banner a {
+  display: inline-block;
+  color: var(--primaryColor);
+  text-decoration: underline;
+  background-color: var(--backgroundColor);
+}
+
+#stcm-banner a:hover {
+  color: var(--textColor);
+}
+
+#stcm-banner a.stcm-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  fill: var(--primaryColor); /* passed down to svg > path */
+  margin-left: auto;
+  width: 48px;
+  height: 48px;
+  text-decoration: none;
+}
+
+#stcm-banner .stcm-actions {
+  display: flex;
+  gap: 16px;
+  flex-direction: column;
+  margin-top: 24px;
+}
+
+@media (min-width: 600px) {
+  #stcm-banner .stcm-actions {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+#stcm-banner .stcm-actions-row {
+  display: flex;
+  gap: 16px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-grow: 1;
+}
+
+/* --------------------------------
+Modal
+-------------------------------- */
+#stcm-modal {
+  display: none;
+  pointer-events: auto;
+  overflow: auto;
+  width: 800px;
+  max-width: 100%;
+  max-height: 100%;
+  border: 0px;
+  transform: translate(0px, -20px);
+  opacity: 0;
+  animation: stcm-slide-up-center 350ms ease-out forwards;
+  box-shadow: -5px 5px 10px 0px #00000012, 0px 0px 50px 0px #0000001a;
+  font-family: var(--fontFamily);
+  color: var(--textColor);
+  flex-direction: column;
+  padding: 30px;
+  background-color: var(--backgroundColor);
+  border-radius: 12px;
+  box-sizing: border-box;
+}
+
+/* --------------------------------
+Modal - Header
+-------------------------------- */
+#stcm-modal header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  gap: 16px;
+}
+
+#stcm-modal h1 {
+  font-family: var(--fontFamily);
+  color: var(--textColor);
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0px;
+}
+
+#stcm-modal .stcm-modal-close {
+  display: inline-flex;
+  border: none;
+  padding: 13px;
+  cursor: pointer;
+  background: var(--backgroundColor);
+  color: var(--primaryColor);
+}
+
+#stcm-modal .stcm-modal-close svg {
+  fill: var(--primaryColor);
+}
+
+/* --------------------------------
+Modal - Content
+-------------------------------- */
+#stcm-modal section {
+  flex: 1;
+  margin-top: 32px;
+}
+
+#stcm-modal section::-webkit-scrollbar {
+  display: block; /* Force scrollbars to show */
+  width: 5px; /* Width of the scrollbar */
+}
+
+#stcm-modal section::-webkit-scrollbar-thumb {
+  background-color: var(--textColor); /* Color of the scrollbar thumb */
+  border-radius: 10px; /* Rounded corners for the thumb */
+}
+
+#stcm-modal p {
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--textColor);
+  opacity: 0.6;
+  margin: 0px 0px 15px;
+}
+
+#stcm-modal p:last-of-type {
+  margin: 0px;
+}
+
+#stcm-modal fieldset {
+  padding: 0px;
+  border: none;
+  margin: 0px 0px 32px;
+}
+
+#stcm-modal fieldset:last-of-type {
+  margin: 0px;
+}
+
+#stcm-modal legend {
+  padding: 0px;
+  margin: 0px 0px 10px;
+  font-weight: 700;
+  color: var(--textColor);
+  font-size: 16px;
+}
+
+#stcm-modal .stcm-consent-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;  
+}
+
+/* --------------------------------
+Modal - Switches
+-------------------------------- */
+#stcm-modal .stcm-toggle {
+  flex-shrink: 0;
+  position: relative;
+  display: inline-block;
+  height: 34px;
+  width: 74px;
+  cursor: pointer;
+}
+
+#stcm-modal .stcm-toggle:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px #ffffff;
+  border-radius: 25px;
+}
+
+#stcm-modal .stcm-toggle input {
+  opacity: 0;
+  position: absolute;
+}
+
+/* Unchecked Switch Styles */
+#stcm-modal .stcm-toggle-track {
+  position: relative;
+  display: block;
+  height: 34px;
+  width: 74px;
+  background: var(--textColor);
+  border-radius: 25px;
+}
+
+#stcm-modal .stcm-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  display: block;
+  height: 30px;
+  width: 30px;
+  background: var(--backgroundColor);
+  border-radius: 50%;
+  transition: left 150ms ease-out;
+}
+
+#stcm-modal .stcm-toggle-off,
+#stcm-modal .stcm-toggle-on {
+  text-transform: uppercase;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--backgroundColor);
+  position: absolute;
+  top: 5px;
+  right: 8px;
+  transition: right 150ms ease-out, opacity 150ms ease-out;
+}
+
+#stcm-modal .stcm-toggle-off {
+  opacity: 1;
+}
+
+#stcm-modal .stcm-toggle-on {
+  opacity: 0;
+}
+
+/* Checked Switch Styles */
+#stcm-modal .stcm-toggle input:checked + .stcm-toggle-track {
+  background: var(--primaryColor);
+}
+
+#stcm-modal .stcm-toggle input:checked ~ .stcm-toggle-thumb {
+  left: calc(100% - 32px);
+}
+
+#stcm-modal .stcm-toggle input:checked ~ .stcm-toggle-off {
+  right: calc(100% - 32px);
+  opacity: 0;
+}
+
+#stcm-modal .stcm-toggle input:checked ~ .stcm-toggle-on {
+  right: calc(100% - 34px);
+  opacity: 1;
+}
+
+#stcm-modal .stcm-toggle input:disabled + .stcm-toggle-track {
+  opacity: 0.65;
+  filter: grayscale(100%);
+  cursor: not-allowed;
+}
+
+/* --------------------------------
+Modal - Footer
+-------------------------------- */
+#stcm-modal footer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+@media (min-width: 600px) {
+  #stcm-modal footer {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+#stcm-modal footer a {
+  margin-left: auto;
+  padding: 0;
+}
+
+#stcm-modal footer a.stcm-credit-link {
+  text-decoration: none;
+}
+
+#stcm-modal footer a.stcm-credit-link:hover {
+  text-decoration: underline;
+}
+
+/* Cookie Icon */
+#stcm-icon {
+  display: none;
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  justify-content: center;
+  align-items: center;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  padding: 0px;
+  border: none;
+  background-color: var(--iconColor);
+  cursor: pointer;
+  box-shadow: 0px 0px 6px 0px #0000001a;
+  pointer-events: auto;
+  animation: stcm-fade-in 0.3s ease-in-out forwards;
+}
+
+#stcm-icon.stcm-pos-bottom-right {
+  left: auto;
+  right: 10px;
+}
+
+#stcm-icon svg {
+  fill: var(--iconBackgroundColor);
+}
+
+/* --------------------------------
+Backdrop
+-------------------------------- */
+#stcm-backdrop {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--backdropBackgroundColor);
+  backdrop-filter: blur(var(--backdropBackgroundBlur));
+  pointer-events: all;
+}
+
+/* --------------------------------
+Animations
+-------------------------------- */
+@keyframes stcm-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes stcm-slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes stcm-slide-down-center {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% - 20px));
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes stcm-slide-down-bottom-center {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -20px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@keyframes stcm-slide-up-center {
+  from {
+    opacity: 0;
+    transform: translate(0px, 20px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0px, 0px);
+  }
+}
+
+/* --------------------------------
+Animation - backdrop click feedback
+-------------------------------- */
+@keyframes stcm-nudge {
+  0%, 100% { right: 16px; }
+  10%, 30%, 50%, 70%, 90% { right: 20px; }
+  20%, 40%, 60%, 80% { right: 12px; }
+}
+
+/* Apply to banner */
+#stcm-banner.stcm-nudge {
+  animation: stcm-nudge 1s ease-in-out;
+}
+
+/* Apply to modal */
+#stcm-modal.stcm-nudge {
+  animation: stcm-nudge 0.5s ease-in-out;
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  #stcm-banner.stcm-nudge,
+  #stcm-modal.stcm-nudge {
+    animation: stcm-pulse 0.5s ease-in-out;
+  }
+  
+  @keyframes stcm-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.85; }
+  }
+}

--- a/public/silktide/silktide-consent-manager.js
+++ b/public/silktide/silktide-consent-manager.js
@@ -1,0 +1,1525 @@
+'use strict';
+
+/**
+ * Silktide Consent Manager v2.0
+ * https://silktide.com/consent-manager/
+ * This class is typically not instantiated directly. Use the global
+ * window.silktideConsentManager API below.
+ * 
+ * @class
+ * @param {Object} config - Configuration object for the consent manager
+ */
+class SilktideConsentManager {
+  constructor(config) {
+    this._validateConfig(config);
+    this.config = config;
+
+    // Set default eventName if not provided
+    this.config.eventName = this.config.eventName || 'stcm_consent_update';
+    
+    // Set default debug mode (false = no console logs in production)
+    // Ensure debug is a boolean, default to false
+    this.config.debug = this.config.debug === true;
+
+    this.wrapper = null;
+    this.prompt = null;
+    this.preferences = null;
+    this.icon = null;
+    this.backdrop = null;
+    this.localStorageAvailable = this._checkLocalStorageAvailable();
+    this._needsReload = false;
+
+    this.createWrapper();
+
+    if (this.shouldShowBackdrop()) {
+      this.createBackdrop();
+    }
+
+    this.createCookieIcon();
+    this.createModal();
+
+    if (this.shouldShowPrompt()) {
+      this.createBanner();
+      this.showBackdrop();
+    } else {
+      this.showCookieIcon();
+    }
+
+    this.setupEventListeners();
+
+    // Always run consent callbacks on load (handles required consents even on first visit)
+    this.runConsentCallbacksOnLoad();
+  }
+
+  /**
+   * Validate configuration object
+   * @private
+   * @param {Object} config - Configuration to validate
+   * @throws {Error} If config is invalid
+   */
+  _validateConfig(config) {
+    if (!config) {
+      throw new Error('Silktide Consent Manager: config is required');
+    }
+    if (!config.consentTypes || !Array.isArray(config.consentTypes)) {
+      throw new Error('Silktide Consent Manager: config.consentTypes must be an array');
+    }
+    if (config.consentTypes.length === 0) {
+      throw new Error('Silktide Consent Manager: config.consentTypes cannot be empty');
+    }
+  }
+
+  /**
+   * Check if localStorage is available and accessible
+   * @private
+   * @returns {boolean} True if localStorage can be used
+   */
+  _checkLocalStorageAvailable() {
+    try {
+      const testKey = '__stcm_test__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+      return true;
+    } catch (e) {
+      console.warn('Silktide Consent Manager: localStorage is not available. Consent choices will not persist.', e);
+      return false;
+    }
+  }
+
+  /**
+   * Safely get item from localStorage with error handling
+   * @private
+   * @param {string} key - localStorage key
+   * @returns {string|null} Value from localStorage or null
+   */
+  _getLocalStorageItem(key) {
+    if (!this.localStorageAvailable) {
+      return null;
+    }
+    try {
+      return localStorage.getItem(key);
+    } catch (e) {
+      console.warn('Silktide Consent Manager: Error reading from localStorage', e);
+      return null;
+    }
+  }
+
+  /**
+   * Safely set item in localStorage with error handling
+   * @private
+   * @param {string} key - localStorage key
+   * @param {string} value - Value to store
+   * @returns {boolean} True if successful
+   */
+  _setLocalStorageItem(key, value) {
+    if (!this.localStorageAvailable) {
+      return false;
+    }
+    try {
+      localStorage.setItem(key, value);
+      return true;
+    } catch (e) {
+      console.warn('Silktide Consent Manager: Error writing to localStorage', e);
+      return false;
+    }
+  }
+
+  /**
+   * Safely remove item from localStorage with error handling
+   * @private
+   * @param {string} key - localStorage key
+   * @returns {boolean} True if successful
+   */
+  _removeLocalStorageItem(key) {
+    if (!this.localStorageAvailable) {
+      return false;
+    }
+    try {
+      localStorage.removeItem(key);
+      return true;
+    } catch (e) {
+      console.warn('Silktide Consent Manager: Error removing from localStorage', e);
+      return false;
+    }
+  }
+
+  /**
+   * Clean up and remove all consent manager elements from the DOM
+   */
+  destroy() {
+    // Remove all consent manager elements from the DOM
+    if (this.wrapper && this.wrapper.parentNode) {
+      this.wrapper.parentNode.removeChild(this.wrapper);
+    }
+
+    // Restore scrolling
+    this.allowBodyScroll();
+
+    // Clear all references
+    this.wrapper = null;
+    this.prompt = null;
+    this.preferences = null;
+    this.icon = null;
+    this.backdrop = null;
+  }
+
+  /**
+   * Clear all consent choices from localStorage
+   * Clears both old and new key patterns for this namespace
+   */
+  clearAllConsents() {
+    if (!this.localStorageAvailable) {
+      return;
+    }
+
+    const keysToRemove = [];
+
+    try {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        // Match both old and new key patterns
+        if (key && (
+          key.startsWith('silktideCookieBanner_') ||
+          key.startsWith('silktideCookieChoice_') ||
+          key.startsWith('stcm.')
+        )) {
+          keysToRemove.push(key);
+        }
+      }
+
+      keysToRemove.forEach(key => this._removeLocalStorageItem(key));
+    } catch (e) {
+      // Ignore errors
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // localStorage Helper Methods (with lazy migration)
+  // ----------------------------------------------------------------
+
+  // Old key builders (for migration only)
+  _buildOldConsentKey(typeId) {
+    const suffix = this.config.namespace ? `_${this.config.namespace}` : '';
+    return `silktideCookieChoice_${typeId}${suffix}`;
+  }
+
+  _buildOldHasConsentedKey() {
+    const suffix = this.config.namespace ? `_${this.config.namespace}` : '';
+    return `silktideCookieBanner_InitialChoice${suffix}`;
+  }
+
+  // New key builders
+  _buildConsentKey(typeId) {
+    const ns = this.config.namespace ? `${this.config.namespace}.` : '';
+    return `stcm.${ns}consent.${typeId}`;
+  }
+
+  _buildHasConsentedKey() {
+    const ns = this.config.namespace ? `${this.config.namespace}.` : '';
+    return `stcm.${ns}hasConsented`;
+  }
+
+  /**
+   * Get the consent choice for a specific consent type
+   * @param {string} typeId - The consent type ID
+   * @returns {boolean|null} True if accepted, false if rejected, null if no choice made
+   */
+  getConsentChoice(typeId) {
+    const newKey = this._buildConsentKey(typeId);
+    let value = this._getLocalStorageItem(newKey);
+
+    // Migration: Check old key if new key doesn't exist
+    if (value === null) {
+      const oldKey = this._buildOldConsentKey(typeId);
+      value = this._getLocalStorageItem(oldKey);
+
+      if (value !== null) {
+        // Migrate: write to new key, delete old key
+        this._setLocalStorageItem(newKey, value);
+        this._removeLocalStorageItem(oldKey);
+      }
+    }
+
+    // Return null if no value exists, otherwise return boolean
+    return value === null ? null : value === 'true';
+  }
+
+  /**
+   * Set the consent choice for a specific consent type
+   * @param {string} typeId - The consent type ID
+   * @param {boolean} accepted - Whether the consent is accepted
+   */
+  setConsentChoice(typeId, accepted) {
+    const newKey = this._buildConsentKey(typeId);
+    this._setLocalStorageItem(newKey, accepted.toString());
+
+    // Cleanup: remove old key if it exists
+    const oldKey = this._buildOldConsentKey(typeId);
+    if (this._getLocalStorageItem(oldKey) !== null) {
+      this._removeLocalStorageItem(oldKey);
+    }
+  }
+
+  /**
+   * Check if user has made an initial consent choice
+   * @returns {boolean} True if user has consented
+   */
+  getHasConsented() {
+    const newKey = this._buildHasConsentedKey();
+    let value = this._getLocalStorageItem(newKey);
+
+    // Migration: Check old key if new key doesn't exist
+    if (value === null) {
+      const oldKey = this._buildOldHasConsentedKey();
+      value = this._getLocalStorageItem(oldKey);
+
+      if (value !== null) {
+        this._setLocalStorageItem(newKey, value);
+        this._removeLocalStorageItem(oldKey);
+      }
+    }
+
+    return value !== null;
+  }
+
+  setHasConsented() {
+    const newKey = this._buildHasConsentedKey();
+    this._setLocalStorageItem(newKey, '1');
+
+    // Cleanup old key
+    const oldKey = this._buildOldHasConsentedKey();
+    if (this._getLocalStorageItem(oldKey) !== null) {
+      this._removeLocalStorageItem(oldKey);
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Script Injection
+  // ----------------------------------------------------------------
+
+  /**
+   * Inject a script element with specified attributes
+   * @private
+   * @param {Object} scriptConfig - Script configuration
+   * @param {string} consentId - Consent type ID (for tracking)
+   */
+  _injectScript(scriptConfig, consentId) {
+    const { url, load, type, crossorigin, integrity } = scriptConfig;
+
+    if (!url) {
+      console.warn('Silktide Consent Manager: Script URL is required', scriptConfig);
+      return;
+    }
+
+    // Check if script already exists
+    const existingScript = document.querySelector(`script[src="${url}"]`);
+    if (existingScript) {
+      return; // Already injected
+    }
+
+    const script = document.createElement('script');
+    script.src = url;
+    script.dataset.consentId = consentId; // Track which consent type added this
+
+    if (load === 'async') script.async = true;
+    if (load === 'defer') script.defer = true;
+    if (type) script.type = type;
+    if (crossorigin) script.crossOrigin = crossorigin;
+    if (integrity) script.integrity = integrity;
+
+    document.head.appendChild(script);
+  }
+
+  /**
+   * Inject all scripts for a consent type
+   * @private
+   * @param {Object} consentType - Consent type configuration
+   */
+  _injectConsentScripts(consentType) {
+    if (!consentType.scripts || !Array.isArray(consentType.scripts)) {
+      return;
+    }
+
+    consentType.scripts.forEach(scriptConfig => {
+      this._injectScript(scriptConfig, consentType.id);
+    });
+  }
+
+  /**
+   * Check if consent was revoked (changed from accepted to rejected)
+   * @private
+   * @param {string} consentId - Consent type ID
+   * @param {boolean} newState - New consent state
+   * @returns {boolean} True if consent was revoked
+   */
+  _wasConsentRevoked(consentId, newState) {
+    const previousState = this.getConsentChoice(consentId);
+    // Consent was revoked if: previously true, now false
+    return previousState === true && newState === false;
+  }
+
+  // ----------------------------------------------------------------
+  // Wrapper
+  // ----------------------------------------------------------------
+  createWrapper() {
+    this.wrapper = document.createElement('div');
+    this.wrapper.id = 'stcm-wrapper';
+    document.body.insertBefore(this.wrapper, document.body.firstChild);
+  }
+
+  // ----------------------------------------------------------------
+  // Wrapper Child Generator
+  // ----------------------------------------------------------------
+  createWrapperChild(htmlContent, id) {
+    // Create child element
+    const child = document.createElement('div');
+    child.id = id;
+    child.innerHTML = htmlContent;
+
+    // Ensure wrapper exists
+    if (!this.wrapper || !document.body.contains(this.wrapper)) {
+      this.createWrapper();
+    }
+
+    // Append child to wrapper
+    this.wrapper.appendChild(child);
+    return child;
+  }
+
+  // ----------------------------------------------------------------
+  // Backdrop
+  // ----------------------------------------------------------------
+  createBackdrop() {
+    this.backdrop = this.createWrapperChild(null, 'stcm-backdrop');
+
+    // Add click handler to nudge banner/modal when backdrop is clicked
+    this.backdrop.addEventListener('click', () => {
+      this.nudgePrompt();
+    });
+  }
+
+  showBackdrop() {
+    if (this.backdrop) {
+      this.backdrop.style.display = 'block';
+    }
+    // Trigger optional onBackdropOpen callback
+    if (typeof this.config.onBackdropOpen === 'function') {
+      this.config.onBackdropOpen();
+    }
+  }
+
+  hideBackdrop() {
+    if (this.backdrop) {
+      this.backdrop.style.display = 'none';
+    }
+
+    // Trigger optional onBackdropClose callback
+    if (typeof this.config.onBackdropClose === 'function') {
+      this.config.onBackdropClose();
+    }
+  }
+
+  /**
+   * Check if backdrop should be shown
+   * @private
+   * @returns {boolean} True if backdrop should be shown
+   */
+  shouldShowBackdrop() {
+    return this.config?.backdrop?.show || false;
+  }
+
+  /**
+   * Nudge the consent prompt to draw attention when backdrop is clicked
+   * 
+   * Note: This deliberately only nudges the prompt, not the modal.
+   * The prompt is the initial banner that requires immediate action.
+   * Nudging the modal would be disruptive to users reviewing preferences.
+   * 
+   * @private
+   */
+  nudgePrompt() {
+    if (!this.prompt) {
+      return;
+    }
+
+    // Remove class if it exists
+    this.prompt.classList.remove('stcm-nudge');
+
+    // Force reflow to restart animation
+    void this.prompt.offsetWidth;
+
+    // Add class to trigger animation
+    this.prompt.classList.add('stcm-nudge');
+
+    // Remove class when animation completes (CSS defines duration)
+    this.prompt.addEventListener('animationend', () => {
+      if (this.prompt) {
+        this.prompt.classList.remove('stcm-nudge');
+      }
+    }, { once: true });
+  }
+
+  // update the checkboxes in the preferences with the values from localStorage
+  updateCheckboxState(saveToStorage = false) {
+    const preferencesSection = this.preferences.querySelector('#stcm-form');
+    const checkboxes = preferencesSection.querySelectorAll('input[type="checkbox"]');
+
+    checkboxes.forEach((checkbox) => {
+      const [, consentId] = checkbox.id.split('consent-');
+      const consentType = this.config.consentTypes.find(type => type.id === consentId);
+
+      if (!consentType) return;
+
+      if (saveToStorage) {
+        // Save the current state to localStorage and run callbacks
+        const currentState = checkbox.checked;
+
+        if (consentType.required) {
+          this.setConsentChoice(consentId, true);
+        } else {
+          // Check if the value actually changed
+          const previousValue = this.getConsentChoice(consentId);
+
+          // Check if consent was revoked (and had scripts)
+          const wasRevoked = this._wasConsentRevoked(consentId, currentState);
+          const hadScripts = consentType.scripts?.length > 0;
+
+          this.setConsentChoice(consentId, currentState);
+
+          // Only trigger integration and callbacks if value changed
+          // Note: previousValue can be:
+          //   - null: User never made a choice (using default)
+          //   - true: User previously accepted
+          //   - false: User previously rejected
+          // We fire callbacks even when changing from null to false/true
+          // because it represents an explicit choice being made
+          if (currentState !== previousValue) {
+            // Trigger automatic consent integration
+            this.triggerConsentIntegration(consentType, currentState);
+
+            // Run appropriate callback
+            if (currentState && typeof consentType.onAccept === 'function') {
+              consentType.onAccept();
+            } else if (!currentState && typeof consentType.onReject === 'function') {
+              consentType.onReject();
+            }
+          }
+
+          // Track if any consent was revoked for page reload
+          if (wasRevoked && hadScripts) {
+            this._needsReload = true;
+          }
+        }
+      } else {
+        // When reading values (opening preferences)
+        if (consentType.required) {
+          checkbox.checked = true;
+          checkbox.disabled = true;
+        } else {
+          const storedValue = this.getConsentChoice(consentId);
+
+          if (storedValue !== null) {
+            checkbox.checked = storedValue;
+          } else {
+            checkbox.checked = !!consentType.defaultValue;
+          }
+        }
+      }
+    });
+  }
+
+  /**
+   * Trigger GTM consent updates based on consentType.gtag property
+   */
+  triggerConsentIntegration(consentType, accepted) {
+    // Check if gtag parameter(s) are specified
+    if (!consentType.gtag) {
+      return;
+    }
+
+    // Normalize to array for consistent handling
+    const gtagParams = Array.isArray(consentType.gtag) ? consentType.gtag : [consentType.gtag];
+
+    // If GTM exists, call gtag
+    if (typeof gtag === 'function') {
+      const consentState = accepted ? 'granted' : 'denied';
+      const consentUpdate = {};
+
+      gtagParams.forEach(param => {
+        consentUpdate[param] = consentState;
+      });
+
+      gtag('consent', 'update', consentUpdate);
+    } else if (gtagParams.includes('analytics_storage')) {
+      // Otherwise, if Silktide Analytics exists, fire consent event
+      if (typeof window.silktide === 'function') {
+        window.silktide(accepted ? 'consent' : 'unconsent');
+      }
+    }
+
+    // Push generic consent update event to dataLayer for GTM tag triggers
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ 'event': this.config.eventName });
+  }
+
+  /**
+   * Batch update all consents at once
+   * Compares current states against localStorage and only triggers updates if changes detected
+   * @param {Object} consentStates - Object mapping consent type IDs to boolean values
+   * @returns {boolean} - True if any changes were made
+   */
+  batchUpdateConsents(consentStates) {
+    const changes = [];
+    const gtagConsentUpdate = {};
+    let hasChanges = false;
+    let needsReload = false;
+
+    // First pass: identify changes and build gtag consent object
+    this.config.consentTypes.forEach((type) => {
+      const newState = consentStates[type.id];
+      const previousState = this.getConsentChoice(type.id);
+      
+      // Check if this consent actually changed
+      if (newState !== previousState) {
+        hasChanges = true;
+        
+        changes.push({
+          type: type,
+          newState: newState,
+          previousState: previousState
+        });
+
+        // Check if consent was revoked and had scripts
+        const wasRevoked = previousState === true && newState === false;
+        const hadScripts = type.scripts?.length > 0;
+        if (wasRevoked && hadScripts) {
+          needsReload = true;
+        }
+
+        // Build gtag consent parameters
+        if (type.gtag) {
+          const gtagParams = Array.isArray(type.gtag) ? type.gtag : [type.gtag];
+          const consentState = newState ? 'granted' : 'denied';
+          gtagParams.forEach(param => {
+            gtagConsentUpdate[param] = consentState;
+          });
+        }
+      }
+    });
+
+    // If no changes, return early
+    if (!hasChanges) {
+      return false;
+    }
+
+    // Second pass: save to localStorage
+    changes.forEach(({ type, newState }) => {
+      this.setConsentChoice(type.id, newState);
+    });
+
+    // Call gtag once with all consent updates
+    if (Object.keys(gtagConsentUpdate).length > 0 && typeof gtag === 'function') {
+      gtag('consent', 'update', gtagConsentUpdate);
+      if (this.config.debug) {
+        console.log('✓ gtag consent updated (from user action):', gtagConsentUpdate);
+      }
+    } else if (gtagConsentUpdate.analytics_storage) {
+      // Silktide Analytics fallback
+      if (typeof window.silktide === 'function') {
+        const analyticsGranted = gtagConsentUpdate.analytics_storage === 'granted';
+        window.silktide(analyticsGranted ? 'consent' : 'unconsent');
+      }
+    }
+
+    // Fire single GTM event
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ 'event': this.config.eventName });
+    if (this.config.debug) {
+      console.log('▶ GTM Event Sent: ' + this.config.eventName + ' (from user action)');
+    }
+
+    // Third pass: run callbacks and inject scripts
+    changes.forEach(({ type, newState }) => {
+      if (newState) {
+        this._injectConsentScripts(type);
+        if (typeof type.onAccept === 'function') {
+          type.onAccept();
+        }
+      } else {
+        if (typeof type.onReject === 'function') {
+          type.onReject();
+        }
+      }
+    });
+
+    // Reload page if consent was revoked and scripts were injected
+    if (needsReload) {
+      setTimeout(() => {
+        window.location.reload();
+      }, 100);
+    }
+
+    return true;
+  }
+
+  // ----------------------------------------------------------------
+  // Consent Handling
+  // ----------------------------------------------------------------
+  handleConsentChoice(accepted) {
+    // We set that an initial choice was made regardless of what it was so we don't show the prompt again
+    this.setHasConsented();
+
+    this.removeBanner();
+    this.hideBackdrop();
+    this.toggleModal(false);
+    this.showCookieIcon();
+
+    // Build consent states object for all consent types
+    const consentStates = {};
+    this.config.consentTypes.forEach((type) => {
+      if (type.required) {
+        consentStates[type.id] = true;
+      } else {
+        consentStates[type.id] = accepted;
+      }
+    });
+
+    // Use batch update to set all consents at once
+    this.batchUpdateConsents(consentStates);
+
+    // Trigger optional onAcceptAll/onRejectAll callbacks
+    if (accepted && typeof this.config.onAcceptAll === 'function') {
+      this.config.onAcceptAll();
+    } else if (!accepted && typeof this.config.onRejectAll === 'function') {
+      this.config.onRejectAll();
+    }
+
+    // finally update the checkboxes in the modal with the values from localStorage
+    this.updateCheckboxState();
+  }
+
+  /**
+   * Get all accepted consents as an object
+   * @returns {Object} Object mapping consent type IDs to their accepted state
+   */
+  getAcceptedConsents() {
+    return (this.config.consentTypes || []).reduce((acc, consentType) => {
+      acc[consentType.id] = this.getConsentChoice(consentType.id);
+      return acc;
+    }, {});
+  }
+
+  /**
+   * Get all rejected consents as an object
+   * @returns {Object} Object mapping consent type IDs to their rejected state
+   */
+  getRejectedConsents() {
+    return (this.config.consentTypes || []).reduce((acc, consentType) => {
+      const choice = this.getConsentChoice(consentType.id);
+      // Only return true if explicitly rejected (false), not if no choice made (null)
+      acc[consentType.id] = choice === false;
+      return acc;
+    }, {});
+  }
+
+  /**
+   * Run all consent callbacks on page load
+   * Builds a single gtag consent object with both accepted and rejected consents
+   * Fires one GTM event only if this is the first consent load
+   */
+  runConsentCallbacksOnLoad() {
+    if (!this.config.consentTypes) return;
+
+    // Build a single gtag consent object with both accepted and rejected consents
+    const gtagConsentUpdate = {};
+    let hasGtagUpdates = false;
+    let isFirstConsentLoad = false;
+
+    const acceptedConsents = this.getAcceptedConsents();
+    const rejectedConsents = this.getRejectedConsents();
+
+    // Process all consent types and build one comprehensive gtag object
+    this.config.consentTypes.forEach((type) => {
+      // Handle required consents (always inject scripts and run onAccept)
+      if (type.required) {
+        // Set to localStorage immediately if not already set (prevents duplicate firing)
+        const currentValue = this.getConsentChoice(type.id);
+        if (currentValue === null) {
+          this.setConsentChoice(type.id, true);
+          isFirstConsentLoad = true; // Required consent was just set for first time
+        }
+        
+        this._injectConsentScripts(type);
+        
+        // Add required consents to gtag update (always granted)
+        if (type.gtag) {
+          hasGtagUpdates = true;
+          const gtagParams = Array.isArray(type.gtag) ? type.gtag : [type.gtag];
+          gtagParams.forEach(param => {
+            gtagConsentUpdate[param] = 'granted';
+          });
+        }
+        
+        if (typeof type.onAccept === 'function') {
+          type.onAccept();
+        }
+        return;
+      }
+
+      // Check if accepted
+      if (acceptedConsents[type.id]) {
+        this._injectConsentScripts(type);
+        
+        if (type.gtag) {
+          hasGtagUpdates = true;
+          const gtagParams = Array.isArray(type.gtag) ? type.gtag : [type.gtag];
+          gtagParams.forEach(param => {
+            gtagConsentUpdate[param] = 'granted';
+          });
+        }
+
+        if (typeof type.onAccept === 'function') {
+          type.onAccept();
+        }
+      }
+      // Check if rejected
+      else if (rejectedConsents[type.id]) {
+        if (type.gtag) {
+          hasGtagUpdates = true;
+          const gtagParams = Array.isArray(type.gtag) ? type.gtag : [type.gtag];
+          gtagParams.forEach(param => {
+            gtagConsentUpdate[param] = 'denied';
+          });
+        }
+
+        if (typeof type.onReject === 'function') {
+          type.onReject();
+        }
+      }
+    });
+
+    // Call gtag ONCE with all consent states (both granted and denied)
+    if (hasGtagUpdates && typeof gtag === 'function') {
+      gtag('consent', 'update', gtagConsentUpdate);
+      if (this.config.debug) {
+        console.log('✓ gtag consent updated (on page load):', gtagConsentUpdate);
+      }
+    } else if (gtagConsentUpdate.analytics_storage && typeof window.silktide === 'function') {
+      // Silktide Analytics fallback
+      const analyticsGranted = gtagConsentUpdate.analytics_storage === 'granted';
+      window.silktide(analyticsGranted ? 'consent' : 'unconsent');
+    }
+
+    // Fire GTM event if we have any granted consents (so GTM tags can trigger)
+    // Check if any consent is granted (not just denied)
+    const hasGrantedConsents = Object.values(gtagConsentUpdate).some(value => value === 'granted');
+    if (hasGtagUpdates && hasGrantedConsents) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ 'event': this.config.eventName });
+      if (this.config.debug) {
+        const eventContext = isFirstConsentLoad ? 'from first page load' : 'from return visit';
+        console.log('▶ GTM Event Sent: ' + this.config.eventName + ' (' + eventContext + ')');
+      }
+    }
+  }
+
+  /**
+   * Run through all of the consent callbacks based on the current localStorage values
+   */
+  runStoredConsentCallbacks() {
+    this.config.consentTypes.forEach((type) => {
+      const accepted = this.getConsentChoice(type.id);
+
+      if (accepted) {
+        this._injectConsentScripts(type);
+      }
+
+      // Trigger automatic consent integration
+      this.triggerConsentIntegration(type, accepted);
+
+      // Set localStorage and run accept/reject callbacks
+      if (accepted) {
+        if (typeof type.onAccept === 'function') {
+          type.onAccept();
+        }
+      } else {
+        if (typeof type.onReject === 'function') {
+          type.onReject();
+        }
+      }
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Banner
+  // ----------------------------------------------------------------
+  
+  /**
+   * Get banner HTML content
+   * @private
+   * @returns {string} HTML string for banner
+   */
+  getBannerContent() {
+    const bannerDescription =
+      this.config.text?.prompt?.description ||
+      "<p>We use cookies on our site to enhance your user experience, provide personalized content, and analyze our traffic.</p>";
+
+    // Accept button
+    const acceptAllButtonText = this.config.text?.prompt?.acceptAllButtonText || 'Accept all';
+    const acceptAllButtonLabel = this.config.text?.prompt?.acceptAllButtonAccessibleLabel;
+    const acceptAllButton = `<button class="stcm-accept-all stcm-button stcm-button-primary"${
+      acceptAllButtonLabel && acceptAllButtonLabel !== acceptAllButtonText
+        ? ` aria-label="${acceptAllButtonLabel}"`
+        : ''
+    }>${acceptAllButtonText}</button>`;
+
+    // Reject button
+    const rejectNonEssentialButtonText = this.config.text?.prompt?.rejectNonEssentialButtonText || 'Reject non-essential';
+    const rejectNonEssentialButtonLabel = this.config.text?.prompt?.rejectNonEssentialButtonAccessibleLabel;
+    const rejectNonEssentialButton = `<button class="stcm-reject-all stcm-button stcm-button-primary"${
+      rejectNonEssentialButtonLabel && rejectNonEssentialButtonLabel !== rejectNonEssentialButtonText
+        ? ` aria-label="${rejectNonEssentialButtonLabel}"`
+        : ''
+    }>${rejectNonEssentialButtonText}</button>`;
+
+    // Preferences button
+    const preferencesButtonText = this.config.text?.prompt?.preferencesButtonText || 'Preferences';
+    const preferencesButtonLabel = this.config.text?.prompt?.preferencesButtonAccessibleLabel;
+    const preferencesButton = `<button class="stcm-preferences-button"${
+      preferencesButtonLabel && preferencesButtonLabel !== preferencesButtonText
+        ? ` aria-label="${preferencesButtonLabel}"`
+        : ''
+    }><span>${preferencesButtonText}</span></button>`;
+
+
+    // Silktide logo link
+    const silktideLogo = `
+      <a class="stcm-logo" href="https://silktide.com/consent-manager" target="_blank" rel="noreferrer" aria-label="Visit the Silktide Consent Manager page">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="inherit">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M14.1096 16.7745C13.8895 17.2055 13.3537 17.3805 12.9129 17.1653L8.28443 14.9055L2.73192 17.7651L11.1025 21.9814C11.909 22.3876 12.8725 22.3591 13.6524 21.9058L20.4345 17.9645C21.2845 17.4704 21.7797 16.5522 21.7164 15.5872L21.7088 15.4704C21.6487 14.5561 21.0962 13.7419 20.2579 13.3326L15.6793 11.0972L10.2283 13.9045L13.71 15.6043C14.1507 15.8195 14.3297 16.3434 14.1096 16.7745ZM8.2627 12.9448L13.7136 10.1375L10.2889 8.46543C9.84803 8.25021 9.66911 7.72629 9.88916 7.29524C10.1093 6.86417 10.6451 6.68921 11.0859 6.90442L15.6575 9.13647L21.2171 6.27325L12.8808 2.03496C12.0675 1.62147 11.0928 1.65154 10.3078 2.11432L3.54908 6.09869C2.70732 6.59492 2.21846 7.50845 2.28139 8.46761L2.29003 8.59923C2.35002 9.51362 2.9026 10.3278 3.7409 10.7371L8.2627 12.9448ZM6.31884 13.9458L2.94386 12.2981C1.53727 11.6113 0.610092 10.2451 0.509431 8.71094L0.500795 8.57933C0.3952 6.96993 1.21547 5.4371 2.62787 4.60447L9.38662 0.620092C10.7038 -0.156419 12.3392 -0.206861 13.7039 0.486938L23.3799 5.40639C23.4551 5.44459 23.5224 5.4918 23.5811 5.54596C23.7105 5.62499 23.8209 5.73754 23.897 5.87906C24.1266 6.30534 23.9594 6.83293 23.5234 7.05744L17.6231 10.0961L21.0549 11.7716C22.4615 12.4583 23.3887 13.8245 23.4893 15.3587L23.497 15.4755C23.6033 17.0947 22.7724 18.6354 21.346 19.4644L14.5639 23.4057C13.2554 24.1661 11.6386 24.214 10.2854 23.5324L0.621855 18.6649C0.477299 18.592 0.361696 18.4859 0.279794 18.361C0.210188 18.2968 0.150054 18.2204 0.10296 18.133C-0.126635 17.7067 0.0406445 17.1792 0.47659 16.9546L6.31884 13.9458Z" fill="inherit"/>
+        </svg>
+      </a>
+    `;
+
+    const bannerContent = `
+      ${bannerDescription}
+      <div class="stcm-actions">
+        ${acceptAllButton}
+        ${rejectNonEssentialButton}
+        <div class="stcm-actions-row">
+          ${preferencesButton}
+          ${silktideLogo}
+        </div>
+      </div>
+    `;
+
+    return bannerContent;
+  }
+
+  /**
+   * Check if user has made an initial consent choice
+   * @returns {boolean} True if user has consented
+   */
+  hasConsented() {
+    return this.getHasConsented();
+  }
+
+  createBanner() {
+    // Create prompt element
+    this.prompt = this.createWrapperChild(this.getBannerContent(), 'stcm-banner');
+
+    // Add positioning class from config
+    if (this.prompt && this.config.prompt?.position) {
+      // Map old position names to new stcm- prefixed names
+      const positionMap = {
+        'center': 'stcm-pos-center',
+        'bottomLeft': 'stcm-pos-bottom-left',
+        'bottomCenter': 'stcm-pos-bottom-center',
+        'bottomRight': 'stcm-pos-bottom-right'
+      };
+      const mappedPosition = positionMap[this.config.prompt.position] || this.config.prompt.position;
+      this.prompt.classList.add(mappedPosition);
+    }
+
+    // Lock in final state after slide-in animation completes
+    // This allows nudge animation to work without conflicts
+    this.prompt.addEventListener('animationend', () => {
+      if (this.prompt) {
+        this.prompt.classList.add('stcm-loaded');
+      }
+    }, { once: true });
+
+    // Trigger optional onPromptOpen callback
+    if (this.prompt && typeof this.config.onPromptOpen === 'function') {
+      this.config.onPromptOpen();
+    }
+  }
+
+  removeBanner() {
+    if (this.prompt && this.prompt.parentNode) {
+      this.prompt.parentNode.removeChild(this.prompt);
+      this.prompt = null;
+
+      // Trigger optional onPromptClose callback
+      if (typeof this.config.onPromptClose === 'function') {
+        this.config.onPromptClose();
+      }
+    }
+  }
+
+  /**
+   * Check if consent prompt should be shown
+   * Returns true if user hasn't made a consent choice yet
+   * @private
+   * @returns {boolean} True if prompt should be displayed
+   */
+  shouldShowPrompt() {
+    if (this.config.autoShow === false) {
+      return false;
+    }
+    return !this.getHasConsented();
+  }
+
+  // ----------------------------------------------------------------
+  // Modal
+  // ----------------------------------------------------------------
+  
+  /**
+   * Get modal HTML content
+   * @private
+   * @returns {string} HTML string for modal
+   */
+  getModalContent() {
+    const preferencesTitle =
+      this.config.text?.preferences?.title || 'Customize your cookie preferences';
+
+    const preferencesDescription =
+      this.config.text?.preferences?.description ||
+      "<p>We respect your right to privacy. You can choose not to allow some types of cookies. Your cookie preferences will apply across our website.</p>";
+
+    // Preferences button
+    const preferencesButtonLabel = this.config.text?.prompt?.preferencesButtonAccessibleLabel;
+
+    const closeModalButton = `<button class="stcm-modal-close"${preferencesButtonLabel ? ` aria-label="${preferencesButtonLabel}"` : ''}>
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M19.4081 3.41559C20.189 2.6347 20.189 1.36655 19.4081 0.585663C18.6272 -0.195221 17.3591 -0.195221 16.5782 0.585663L10 7.17008L3.41559 0.59191C2.6347 -0.188974 1.36655 -0.188974 0.585663 0.59191C-0.195221 1.37279 -0.195221 2.64095 0.585663 3.42183L7.17008 10L0.59191 16.5844C-0.188974 17.3653 -0.188974 18.6335 0.59191 19.4143C1.37279 20.1952 2.64095 20.1952 3.42183 19.4143L10 12.8299L16.5844 19.4081C17.3653 20.189 18.6335 20.189 19.4143 19.4081C20.1952 18.6272 20.1952 17.3591 19.4143 16.5782L12.8299 10L19.4081 3.41559Z"/>
+      </svg>
+    </button>`;
+
+
+    const consentTypes = this.config.consentTypes || [];
+    const acceptedConsentMap = this.getAcceptedConsents();
+
+    // Save button
+    const saveButtonText = this.config.text?.preferences?.saveButtonText || 'Save and close';
+    const saveButtonLabel = this.config.text?.preferences?.saveButtonAccessibleLabel;
+    const saveButton = `<button class="stcm-modal-save stcm-button stcm-button-primary"${
+      saveButtonLabel && saveButtonLabel !== saveButtonText
+        ? ` aria-label="${saveButtonLabel}"`
+        : ''
+    }>${saveButtonText}</button>`;
+
+    // Reject button
+    const rejectNonEssentialButtonText = this.config.text?.prompt?.rejectNonEssentialButtonText || 'Reject non-essential';
+    const rejectNonEssentialButtonLabel = this.config.text?.prompt?.rejectNonEssentialButtonAccessibleLabel;
+    const rejectNonEssentialButton = `<button class="stcm-modal-reject-all stcm-button stcm-button-primary"${
+      rejectNonEssentialButtonLabel && rejectNonEssentialButtonLabel !== rejectNonEssentialButtonText
+        ? ` aria-label="${rejectNonEssentialButtonLabel}"`
+        : ''
+    }>${rejectNonEssentialButtonText}</button>`;
+
+    // Credit link
+    const creditLinkText = this.config.text?.preferences?.creditLinkText || 'Get this consent manager for free';
+    const creditLinkAccessibleLabel = this.config.text?.preferences?.creditLinkAccessibleLabel;
+    const creditLink = `<a class="stcm-credit-link" href="https://silktide.com/consent-manager" target="_blank" rel="noreferrer"${
+      creditLinkAccessibleLabel && creditLinkAccessibleLabel !== creditLinkText
+        ? ` aria-label="${creditLinkAccessibleLabel}"`
+        : ''
+    }>${creditLinkText}</a>`;
+
+
+
+    const modalContent = `
+      <header>
+        <h1>${preferencesTitle}</h1>
+        ${closeModalButton}
+      </header>
+      ${preferencesDescription}
+      <section id="stcm-form">
+        ${consentTypes
+          .map((type) => {
+            const accepted = acceptedConsentMap[type.id];
+            let isChecked = false;
+
+            // if it's accepted then show as checked
+            if (accepted) {
+              isChecked = true;
+            }
+
+            // if nothing has been accepted / rejected yet, then show as checked if the default value is true
+            if (!accepted && !this.hasConsented()) {
+              isChecked = type.defaultValue;
+            }
+
+            return `
+            <fieldset>
+              <legend>${type.label}</legend>
+              <div class="stcm-consent-row">
+                <div class="stcm-consent-description">${type.description}</div>
+                <label class="stcm-toggle" for="consent-${type.id}">
+                  <input type="checkbox" id="consent-${type.id}" ${
+              type.required ? 'checked disabled' : isChecked ? 'checked' : ''
+            } />
+                  <span class="stcm-toggle-track" aria-hidden="true"></span>
+                  <span class="stcm-toggle-thumb" aria-hidden="true"></span>
+                  <span class="stcm-toggle-off" aria-hidden="true">Off</span>
+                  <span class="stcm-toggle-on" aria-hidden="true">On</span>
+                </label>
+              </div>
+            </fieldset>
+          `;
+          })
+          .join('')}
+      </section>
+      <footer>
+        ${saveButton}
+        ${rejectNonEssentialButton}
+        ${creditLink}
+      </footer>
+    `;
+
+    return modalContent;
+  }
+
+  createModal() {
+    // Create preferences element
+    this.preferences = this.createWrapperChild(this.getModalContent(), 'stcm-modal');
+  }
+
+  toggleModal(show) {
+    if (!this.preferences) return;
+
+    this.preferences.style.display = show ? 'flex' : 'none';
+
+    if (show) {
+      this.showBackdrop();
+      this.hideCookieIcon();
+      this.removeBanner();
+      this.preventBodyScroll();
+
+      // Focus the close button
+      const modalCloseButton = this.preferences.querySelector('.stcm-modal-close');
+      modalCloseButton.focus();
+
+      // Trigger optional onPreferencesOpen callback
+      if (typeof this.config.onPreferencesOpen === 'function') {
+        this.config.onPreferencesOpen();
+      }
+
+      this.updateCheckboxState(false); // read from storage when opening
+    } else {
+      // Close the modal without saving anything - saving is handled by the "Save and Close" and "Reject All" buttons only
+      this.hideBackdrop();
+      this.showCookieIcon();
+      this.allowBodyScroll();
+
+      // Trigger optional onPreferencesClose callback
+      if (typeof this.config.onPreferencesClose === 'function') {
+        this.config.onPreferencesClose();
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Consent Icon
+  // ----------------------------------------------------------------
+  
+  /**
+   * Get cookie icon SVG content
+   * @private
+   * @returns {string} SVG string for icon
+   */
+  getCookieIconContent() {
+    return `
+      <svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M19.1172 1.15625C19.0547 0.734374 18.7344 0.390624 18.3125 0.328124C16.5859 0.0859365 14.8281 0.398437 13.2813 1.21875L7.5 4.30469C5.96094 5.125 4.71875 6.41406 3.95313 7.98437L1.08594 13.8906C0.320314 15.4609 0.0703136 17.2422 0.375001 18.9609L1.50781 25.4297C1.8125 27.1562 2.64844 28.7344 3.90625 29.9531L8.61719 34.5156C9.875 35.7344 11.4766 36.5156 13.2031 36.7578L19.6875 37.6719C21.4141 37.9141 23.1719 37.6016 24.7188 36.7812L30.5 33.6953C32.0391 32.875 33.2813 31.5859 34.0469 30.0078L36.9141 24.1094C37.6797 22.5391 37.9297 20.7578 37.625 19.0391C37.5547 18.625 37.2109 18.3125 36.7969 18.25C32.7734 17.6094 29.5469 14.5703 28.6328 10.6406C28.4922 10.0469 28.0078 9.59375 27.4063 9.5C23.1406 8.82031 19.7734 5.4375 19.1094 1.15625H19.1172ZM15.25 10.25C15.913 10.25 16.5489 10.5134 17.0178 10.9822C17.4866 11.4511 17.75 12.087 17.75 12.75C17.75 13.413 17.4866 14.0489 17.0178 14.5178C16.5489 14.9866 15.913 15.25 15.25 15.25C14.587 15.25 13.9511 14.9866 13.4822 14.5178C13.0134 14.0489 12.75 13.413 12.75 12.75C12.75 12.087 13.0134 11.4511 13.4822 10.9822C13.9511 10.5134 14.587 10.25 15.25 10.25ZM10.25 25.25C10.25 24.587 10.5134 23.9511 10.9822 23.4822C11.4511 23.0134 12.087 22.75 12.75 22.75C13.413 22.75 14.0489 23.0134 14.5178 23.4822C14.9866 23.9511 15.25 24.587 15.25 25.25C15.25 25.913 14.9866 26.5489 14.5178 27.0178C14.0489 27.4866 13.413 27.75 12.75 27.75C12.087 27.75 11.4511 27.4866 10.9822 27.0178C10.5134 26.5489 10.25 25.913 10.25 25.25ZM27.75 20.25C28.413 20.25 29.0489 20.5134 29.5178 20.9822C29.9866 21.4511 30.25 22.087 30.25 22.75C30.25 23.413 29.9866 24.0489 29.5178 24.5178C29.0489 24.9866 28.413 25.25 27.75 25.25C27.087 25.25 26.4511 24.9866 25.9822 24.5178C25.5134 24.0489 25.25 23.413 25.25 22.75C25.25 22.087 25.5134 21.4511 25.9822 20.9822C26.4511 20.5134 27.087 20.25 27.75 20.25Z" />
+      </svg>
+    `;
+  }
+
+  createCookieIcon() {
+    this.icon = document.createElement('button');
+    this.icon.id = 'stcm-icon';
+    this.icon.title = 'Manage your consent preferences for this site';
+    this.icon.innerHTML = this.getCookieIconContent();
+
+    if (this.config.text?.prompt?.preferencesButtonAccessibleLabel) {
+      this.icon.ariaLabel = this.config.text?.prompt?.preferencesButtonAccessibleLabel;
+    }
+
+    // Ensure wrapper exists
+    if (!this.wrapper || !document.body.contains(this.wrapper)) {
+      this.createWrapper();
+    }
+
+    // Append child to wrapper
+    this.wrapper.appendChild(this.icon);
+
+    // Add positioning class from config
+    if (this.icon && this.config.icon?.position) {
+      // Map old position names to new stcm- prefixed names
+      const positionMap = {
+        'bottomRight': 'stcm-pos-bottom-right',
+        'bottomLeft': 'stcm-pos-bottom-left'
+      };
+      const mappedPosition = positionMap[this.config.icon.position] || this.config.icon.position;
+      this.icon.classList.add(mappedPosition);
+    }
+
+    // Add color scheme class from config
+    if (this.icon && this.config.icon?.colorScheme) {
+      this.icon.classList.add(this.config.icon.colorScheme);
+    }
+  }
+
+  showCookieIcon() {
+    if (this.icon) {
+      this.icon.style.display = 'flex';
+    }
+  }
+
+  hideCookieIcon() {
+    if (this.icon) {
+      this.icon.style.display = 'none';
+    }
+  }
+
+  /**
+   * This runs if the user closes the preferences without making a choice for the first time
+   * We apply the default values and the necessary values as default
+   */
+  handleDefaultConsent() {
+    this.config.consentTypes.forEach((type) => {
+      let accepted = true;
+      // Set localStorage and run accept/reject callbacks
+      if (type.required || type.defaultValue) {
+        this.setConsentChoice(type.id, true);
+      } else {
+        accepted = false;
+        this.setConsentChoice(type.id, false);
+      }
+
+      if (accepted) {
+        if (typeof type.onAccept === 'function') {
+          type.onAccept();
+        }
+      } else {
+        if (typeof type.onReject === 'function') {
+          type.onReject();
+        }
+      }
+      // set the flag to say that the consent choice has been made
+      this.setHasConsented();
+      this.updateCheckboxState();
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Focusable Elements
+  // ----------------------------------------------------------------
+  
+  /**
+   * Get all focusable elements within a container
+   * @private
+   * @param {HTMLElement} element - Container element
+   * @returns {NodeList} List of focusable elements
+   */
+  getFocusableElements(element) {
+    return element.querySelectorAll(
+      'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+  }
+
+  // ----------------------------------------------------------------
+  // Event Listeners
+  // ----------------------------------------------------------------
+  setupEventListeners() {
+    // Check Prompt exists before trying to add event listeners
+    if (this.prompt) {
+      // Get the buttons
+      const acceptButton = this.prompt.querySelector('.stcm-accept-all');
+      const rejectButton = this.prompt.querySelector('.stcm-reject-all');
+      const preferencesButton = this.prompt.querySelector('.stcm-preferences-button');
+
+      // Add event listeners to the buttons
+      acceptButton?.addEventListener('click', () => this.handleConsentChoice(true));
+      rejectButton?.addEventListener('click', () => this.handleConsentChoice(false));
+      preferencesButton?.addEventListener('click', () => {
+        this.showBackdrop();
+        this.toggleModal(true);
+      });
+
+      // Focus Trap
+      const focusableElements = this.getFocusableElements(this.prompt);
+      const firstFocusableEl = focusableElements[0];
+      const lastFocusableEl = focusableElements[focusableElements.length - 1];
+
+      // Add keydown event listener to handle tab navigation
+      this.prompt.addEventListener('keydown', (e) => {
+        if (e.key === 'Tab') {
+          if (e.shiftKey) {
+            if (document.activeElement === firstFocusableEl) {
+              lastFocusableEl.focus();
+              e.preventDefault();
+            }
+          } else {
+            if (document.activeElement === lastFocusableEl) {
+              firstFocusableEl.focus();
+              e.preventDefault();
+            }
+          }
+        }
+      });
+
+      // Set initial focus
+      if (this.config.mode !== 'wizard') {
+        acceptButton?.focus();
+      }
+    }
+
+    // Check Preferences exists before trying to add event listeners
+    if (this.preferences) {
+      const closeButton = this.preferences.querySelector('.stcm-modal-close');
+      const saveButton = this.preferences.querySelector('.stcm-modal-save');
+      const rejectAllButton = this.preferences.querySelector('.stcm-modal-reject-all');
+
+      // Close button - only closes modal, doesn't save or fire events
+      closeButton?.addEventListener('click', () => {
+        this.toggleModal(false);
+        this.hideBackdrop();
+        
+        // If user hasn't made initial choice, show prompt again next time
+        // Otherwise, just close without doing anything
+      });
+
+      // Save button - reads checkbox states and batch updates
+      saveButton?.addEventListener('click', () => {
+        // We set that an initial choice was made
+        this.setHasConsented();
+
+        // Read current checkbox states from the modal
+        const preferencesSection = this.preferences.querySelector('#stcm-form');
+        const checkboxes = preferencesSection.querySelectorAll('input[type="checkbox"]');
+        const consentStates = {};
+
+        checkboxes.forEach(checkbox => {
+          const [, consentId] = checkbox.id.split('consent-');
+          consentStates[consentId] = checkbox.checked;
+        });
+
+        // Use batch update to set all consents at once (only fires if changes detected)
+        this.batchUpdateConsents(consentStates);
+
+        // Close modal and show icon
+        this.toggleModal(false);
+        this.hideBackdrop();
+        this.removeBanner();
+        this.showCookieIcon();
+      });
+
+      // Reject All button - sets required to true, all others to false, then batch updates
+      rejectAllButton?.addEventListener('click', () => {
+        // We set that an initial choice was made
+        this.setHasConsented();
+
+        // First, update the checkbox UI to reflect rejection
+        const preferencesSection = this.preferences.querySelector('#stcm-form');
+        const checkboxes = preferencesSection.querySelectorAll('input[type="checkbox"]');
+        
+        checkboxes.forEach(checkbox => {
+          const [, consentId] = checkbox.id.split('consent-');
+          const consentType = this.config.consentTypes.find(type => type.id === consentId);
+          
+          if (consentType && !consentType.required) {
+            checkbox.checked = false;
+          }
+        });
+
+        // Build consent states: required = true, optional = false
+        const consentStates = {};
+        this.config.consentTypes.forEach((type) => {
+          consentStates[type.id] = type.required ? true : false;
+        });
+
+        // Use batch update to set all consents at once
+        this.batchUpdateConsents(consentStates);
+
+        // Close modal and show icon
+        this.toggleModal(false);
+        this.hideBackdrop();
+        this.removeBanner();
+        this.showCookieIcon();
+      });
+
+      // Preferences Focus Trap
+      const focusableElements = this.getFocusableElements(this.preferences);
+      const firstFocusableEl = focusableElements[0];
+      const lastFocusableEl = focusableElements[focusableElements.length - 1];
+
+      this.preferences.addEventListener('keydown', (e) => {
+        if (e.key === 'Tab') {
+          if (e.shiftKey) {
+            if (document.activeElement === firstFocusableEl) {
+              lastFocusableEl.focus();
+              e.preventDefault();
+            }
+          } else {
+            if (document.activeElement === lastFocusableEl) {
+              firstFocusableEl.focus();
+              e.preventDefault();
+            }
+          }
+        }
+        if (e.key === 'Escape') {
+          this.toggleModal(false);
+        }
+      });
+
+      closeButton?.focus();
+
+      // Note: Checkboxes no longer trigger immediate consent updates
+      // Users can toggle them freely, and consent is only updated when clicking "Save and Close"
+    }
+
+    // Check Icon exists before trying to add event listeners
+    if (this.icon) {
+      this.icon.addEventListener('click', () => {
+        // If preferences is not found, create it
+        if (!this.preferences) {
+          this.createModal();
+          this.toggleModal(true);
+          this.hideCookieIcon();
+        }
+        // If preferences is hidden, show it
+        else if (this.preferences.style.display === 'none' || this.preferences.style.display === '') {
+          this.toggleModal(true);
+          this.hideCookieIcon();
+        }
+        // If preferences is visible, hide it
+        else {
+          this.toggleModal(false);
+        }
+      });
+    }
+  }
+
+  preventBodyScroll() {
+    document.body.style.overflow = 'hidden';
+    // Prevent iOS Safari scrolling
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+  }
+
+  allowBodyScroll() {
+    document.body.style.overflow = '';
+    document.body.style.position = '';
+    document.body.style.width = '';
+  }
+}
+
+/**
+ * ============================================================================
+ * Public API (IIFE Wrapper)
+ * ============================================================================
+ */
+(function () {
+  window.silktideConsentManager = {};
+
+  let consentManager;
+
+  /**
+   * Initialize the consent manager with the given configuration
+   * Destroys any existing instance and creates a new one.
+   * 
+   * @param {Object} config - Configuration object
+   */
+  function init(config = {}) {
+    // Function to create instance
+    const create = () => {
+      // Destroy existing instance if present
+      if (consentManager) {
+        consentManager.destroy();
+        consentManager = null;
+      }
+
+      // Create new instance (class constructor validates config)
+      consentManager = new SilktideConsentManager(config);
+    };
+
+    // Initialize immediately if DOM ready, otherwise wait
+    if (document.body) {
+      create();
+    } else {
+      document.addEventListener('DOMContentLoaded', create, {once: true});
+    }
+  }
+
+  /**
+   * Update the configuration by deep merging with existing config
+   * Requires an existing instance to be initialized first.
+   * 
+   * @param {Object} newConfig - Partial configuration object to merge with existing config
+   */
+  function update(newConfig = {}) {
+    if (!consentManager) {
+      console.error('Silktide Consent Manager: Cannot update - no instance initialized. Call init() first.');
+      return;
+    }
+
+    function deepMerge(target, source) {
+      const output = { ...target };
+      for (const key in source) {
+        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+          output[key] = deepMerge(target[key] || {}, source[key]);
+        } else {
+          output[key] = source[key];
+        }
+      }
+      return output;
+    }
+
+    // Deep merge new config into existing and re-initialize
+    const mergedConfig = deepMerge(consentManager.config, newConfig);
+    init(mergedConfig);
+  }
+  
+  /**
+   * Reset all consent choices and show the prompt again
+   * Clears all localStorage entries and reinitializes as if fresh page load
+   */
+  function resetConsent() {
+    if (!consentManager) {
+      console.error('Silktide Consent Manager: Cannot reset - no instance initialized.');
+      return;
+    }
+
+    // Clear all consent-related localStorage
+    consentManager.clearAllConsents();
+
+    // Re-initialize with current config from instance
+    init(consentManager.config);
+  }
+
+  /**
+   * Get the current consent manager instance (for advanced usage)
+   * @returns {SilktideConsentManager|null} Current instance or null if not initialized
+   */
+  function getInstance() {
+    return consentManager;
+  }
+
+  window.silktideConsentManager.init = init;
+  window.silktideConsentManager.update = update;
+  window.silktideConsentManager.getInstance = getInstance;
+  window.silktideConsentManager.resetConsent = resetConsent;
+})();

--- a/src/App.vue
+++ b/src/App.vue
@@ -146,7 +146,7 @@
     </v-main>
     <v-footer class="pa-0 flex-0-0 w3-glass">
       <v-row justify="center" no-gutters>
-        <v-btn variant="text" tile class="my-2" to="/imprint">Imprint</v-btn>
+        <v-btn variant="text" tile class="my-2" :to="{ name: EMainRouteName.IMPRINT }">Imprint</v-btn>
         <v-btn variant="text" tile class="my-2" :to="{ name: EMainRouteName.PRIVACY }">Privacy Policy</v-btn>
         <v-btn variant="text" tile class="my-2" :to="{ name: EMainRouteName.COOKIES }">Cookie Policy</v-btn>
         <v-btn variant="text" tile class="my-2" @click="openCookieSettings">Cookie settings</v-btn>

--- a/src/App.vue
+++ b/src/App.vue
@@ -147,6 +147,9 @@
     <v-footer class="pa-0 flex-0-0 w3-glass">
       <v-row justify="center" no-gutters>
         <v-btn variant="text" tile class="my-2" to="/imprint">Imprint</v-btn>
+        <v-btn variant="text" tile class="my-2" :to="{ name: EMainRouteName.PRIVACY }">Privacy Policy</v-btn>
+        <v-btn variant="text" tile class="my-2" :to="{ name: EMainRouteName.COOKIES }">Cookie Policy</v-btn>
+        <v-btn variant="text" tile class="my-2" @click="openCookieSettings">Cookie settings</v-btn>
       </v-row>
     </v-footer>
   </v-app>
@@ -169,6 +172,7 @@ import { battleTagToName } from "./helpers/profile";
 import { EMainRouteName } from "@/router/types";
 import { LOGIN_RETURN_TO_KEY, OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import LocaleIcon from "@/components/common/LocaleIcon.vue";
+import { openCookieSettings } from "@/analytics/analytics";
 
 import {
   mdiAccountCircle,
@@ -419,6 +423,7 @@ export default defineComponent({
       activeLanguages,
       getTheme,
       setTheme,
+      openCookieSettings,
       EMainRouteName,
       toggleSignInDialog,
     };

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -1,0 +1,42 @@
+/**
+ * Vue-side analytics + consent helpers.
+ *
+ * The GA4 script, Google Consent Mode wiring, and Silktide initialisation live
+ * in `public/analytics-consent.js`, which loads before the Vue app. This module
+ * only:
+ *   - forwards SPA page-view events to GA4 when analytics is active, and
+ *   - re-opens the Silktide consent banner ("Cookie settings").
+ *
+ * `window.__w3cAnalyticsActive` is set to true by `public/analytics-consent.js`
+ * once GA4 has actually loaded (i.e. consent granted AND on a production host),
+ * so `trackPageView` is a no-op before consent and on non-production hosts.
+ */
+
+type GtagFn = (...args: unknown[]) => void;
+
+interface SilktideConsentManager {
+  resetConsent?: () => void;
+}
+
+interface AnalyticsWindow extends Window {
+  gtag?: GtagFn;
+  __w3cAnalyticsActive?: boolean;
+  silktideConsentManager?: SilktideConsentManager;
+}
+
+/** Send a GA4 page_view. No-op until the user has consented and GA4 is loaded. */
+export function trackPageView(pagePath: string, pageTitle: string): void {
+  const w = window as AnalyticsWindow;
+  if (!w.__w3cAnalyticsActive || typeof w.gtag !== "function") return;
+  w.gtag("event", "page_view", {
+    page_location: window.location.href,
+    page_path: pagePath,
+    page_title: pageTitle,
+  });
+}
+
+/** Re-open the Silktide banner so the user can change or withdraw consent. */
+export function openCookieSettings(): void {
+  const w = window as AnalyticsWindow;
+  w.silktideConsentManager?.resetConsent?.();
+}

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -5,7 +5,7 @@
  * in `public/analytics-consent.js`, which loads before the Vue app. This module
  * only:
  *   - forwards SPA page-view events to GA4 when analytics is active, and
- *   - re-opens the Silktide consent banner ("Cookie settings").
+ *   - opens the Silktide preferences modal ("Cookie settings").
  *
  * `window.__w3cAnalyticsActive` is set to true by `public/analytics-consent.js`
  * once GA4 has actually loaded (i.e. consent granted AND on a production host),
@@ -14,7 +14,12 @@
 
 type GtagFn = (...args: unknown[]) => void;
 
+interface SilktideInstance {
+  toggleModal?: (show: boolean) => void;
+}
+
 interface SilktideConsentManager {
+  getInstance?: () => SilktideInstance | null;
   resetConsent?: () => void;
 }
 
@@ -35,8 +40,8 @@ export function trackPageView(pagePath: string, pageTitle: string): void {
   });
 }
 
-/** Re-open the Silktide banner so the user can change or withdraw consent. */
+/** Open the Silktide preferences modal so the user can change or withdraw consent (non-destructive). */
 export function openCookieSettings(): void {
   const w = window as AnalyticsWindow;
-  w.silktideConsentManager?.resetConsent?.();
+  w.silktideConsentManager?.getInstance?.()?.toggleModal?.(true);
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -341,7 +341,8 @@ const titleForRoute = (to: RouteLocationNormalized): string => {
 let initialNavigationTracked = false;
 
 router.afterEach((to: RouteLocationNormalized) => {
-  document.title = titleForRoute(to);
+  const title = titleForRoute(to);
+  document.title = title;
 
   if (!initialNavigationTracked) {
     initialNavigationTracked = true;
@@ -349,7 +350,7 @@ router.afterEach((to: RouteLocationNormalized) => {
   }
 
   nextTick(() => {
-    trackPageView(to.fullPath, document.title);
+    trackPageView(to.fullPath, title);
   });
 });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,8 @@ import CountryRankings from "@/views/CountryRankings.vue";
 import TournamentsList from "@/views/TournamentsList.vue";
 import Player from "@/views/Player.vue";
 import Imprint from "@/views/Imprint.vue";
+import PrivacyPolicy from "@/views/PrivacyPolicy.vue";
+import CookiePolicy from "@/views/CookiePolicy.vue";
 import MatchDetail from "@/views/MatchDetail.vue";
 import Matches from "@/views/Matches.vue";
 import Faq from "@/views/Faq.vue";
@@ -124,6 +126,16 @@ const routes: RouteRecordRaw[] = [
     path: "/imprint",
     name: EMainRouteName.IMPRINT,
     component: Imprint,
+  },
+  {
+    path: "/privacy",
+    name: EMainRouteName.PRIVACY,
+    component: PrivacyPolicy,
+  },
+  {
+    path: "/cookies",
+    name: EMainRouteName.COOKIES,
+    component: CookiePolicy,
   },
   {
     path: "/rankings",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,6 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized, type RouteRecordRaw } from "vue-router";
+import { nextTick } from "vue";
+import { trackPageView } from "@/analytics/analytics";
 import Rankings from "@/views/Rankings.vue";
 import CountryRankings from "@/views/CountryRankings.vue";
 import TournamentsList from "@/views/TournamentsList.vue";
@@ -333,8 +335,22 @@ const titleForRoute = (to: RouteLocationNormalized): string => {
   return documentTitle(to.name as string);
 };
 
+// GA4 sends the initial page's view via the catch-up in public/analytics-consent.js,
+// so skip the router's very first afterEach to avoid double-counting; track every
+// subsequent navigation. trackPageView is a no-op until consent + GA4 are active.
+let initialNavigationTracked = false;
+
 router.afterEach((to: RouteLocationNormalized) => {
   document.title = titleForRoute(to);
+
+  if (!initialNavigationTracked) {
+    initialNavigationTracked = true;
+    return;
+  }
+
+  nextTick(() => {
+    trackPageView(to.fullPath, document.title);
+  });
 });
 
 export default router;

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -44,6 +44,8 @@ export enum EMainRouteName {
   LOGIN = "Login",
   FAQ = "FAQ",
   IMPRINT = "Imprint",
+  PRIVACY = "Privacy Policy",
+  COOKIES = "Cookie Policy",
   RANKINGS = "Rankings",
   COUNTRY_RANKINGS = "Country Rankings",
   MATCH = "Match",

--- a/src/views/CookiePolicy.vue
+++ b/src/views/CookiePolicy.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-container class="pa-3 w3-container-width">
+    <v-row>
+      <v-col cols="12">
+        <v-card>
+          <v-card-title class="pt-3">Cookie Policy</v-card-title>
+          <v-card-text>Last updated: 7 June 2026</v-card-text>
+
+          <v-card-text>
+            <p>
+              This page explains the cookies and similar browser storage we use. We use two categories:
+              <strong>Necessary</strong> (always on, required for the site to work) and <strong>Analytics</strong>
+              (off until you allow them). You can change or withdraw your choices at any time:
+            </p>
+            <v-btn color="primary" variant="flat" class="mt-2" @click="openCookieSettings">Manage cookie settings</v-btn>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>Necessary</h3>
+            <p>
+              Required to provide the service, including signing in, security, and remembering your choices. These are
+              first-party, and no separate consent is needed. "Functional preference" items below store a choice you
+              actively make (such as theme or language) and are not used for tracking.
+            </p>
+            <h3>Analytics (consent required)</h3>
+            <p>
+              Google Analytics 4 helps us understand how the site is used. These cookies are only set after you allow
+              analytics (and only when JavaScript is enabled), and stop being used when you withdraw consent.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <v-table density="compact">
+              <thead>
+                <tr>
+                  <th class="text-left">Name</th>
+                  <th class="text-left">Storage</th>
+                  <th class="text-left">Category</th>
+                  <th class="text-left">Purpose</th>
+                  <th class="text-left">Retention</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>w3CAuth</td><td>Cookie</td><td>Necessary</td><td>Authentication (sign-in token)</td><td>365 days</td></tr>
+                <tr><td>w3CAuthRegion</td><td>Cookie</td><td>Necessary</td><td>Selected sign-in region</td><td>365 days</td></tr>
+                <tr><td>Cloudflare Turnstile (cf_*)</td><td>Cookie</td><td>Necessary</td><td>Bot/abuse protection on sign-in</td><td>Session / short</td></tr>
+                <tr><td>_ga, _ga_*</td><td>Cookie</td><td>Analytics (consent)</td><td>Google Analytics usage measurement</td><td>Up to 2 years</td></tr>
+                <tr><td>theme</td><td>localStorage</td><td>Necessary</td><td>Functional preference: interface theme</td><td>Persistent</td></tr>
+                <tr><td>w3c-locale</td><td>localStorage</td><td>Necessary</td><td>Functional preference: language</td><td>Persistent</td></tr>
+                <tr><td>w3c-gateway</td><td>localStorage</td><td>Necessary</td><td>Functional preference: gateway</td><td>Persistent</td></tr>
+                <tr><td>spoilerFree settings</td><td>localStorage</td><td>Necessary</td><td>Functional preference: spoiler-free mode</td><td>Persistent</td></tr>
+                <tr><td>patreon_oauth_state</td><td>localStorage</td><td>Necessary</td><td>OAuth security (CSRF protection)</td><td>Transient</td></tr>
+                <tr><td>stcm.consent.*</td><td>localStorage</td><td>Necessary</td><td>Stores your cookie choices</td><td>Persistent</td></tr>
+                <tr><td>Login return path</td><td>sessionStorage</td><td>Necessary</td><td>Redirect back after sign-in</td><td>Session</td></tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+
+          <v-card-text>
+            <p>
+              For more on how we handle personal data, see our
+              <router-link :to="{ name: EMainRouteName.PRIVACY }" class="text-primary">Privacy Policy</router-link>.
+            </p>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { EMainRouteName } from "@/router/types";
+import { openCookieSettings } from "@/analytics/analytics";
+
+export default defineComponent({
+  name: "CookiePolicyView",
+  setup() {
+    return { EMainRouteName, openCookieSettings };
+  },
+});
+</script>

--- a/src/views/CookiePolicy.vue
+++ b/src/views/CookiePolicy.vue
@@ -43,7 +43,7 @@
               <tbody>
                 <tr><td>w3CAuth</td><td>Cookie</td><td>Necessary</td><td>Authentication (sign-in token)</td><td>365 days</td></tr>
                 <tr><td>w3CAuthRegion</td><td>Cookie</td><td>Necessary</td><td>Selected sign-in region</td><td>365 days</td></tr>
-                <tr><td>Cloudflare Turnstile (cf_*)</td><td>Cookie</td><td>Necessary</td><td>Bot/abuse protection on sign-in</td><td>Session / short</td></tr>
+                <tr><td>Cloudflare (__cf_bm, cf_*)</td><td>Cookie</td><td>Necessary</td><td>CDN delivery + bot/abuse protection</td><td>Session / short</td></tr>
                 <tr><td>_ga, _ga_*</td><td>Cookie</td><td>Analytics (consent)</td><td>Google Analytics usage measurement</td><td>Up to 2 years</td></tr>
                 <tr><td>theme</td><td>localStorage</td><td>Necessary</td><td>Functional preference: interface theme</td><td>Persistent</td></tr>
                 <tr><td>w3c-locale</td><td>localStorage</td><td>Necessary</td><td>Functional preference: language</td><td>Persistent</td></tr>

--- a/src/views/CookiePolicy.vue
+++ b/src/views/CookiePolicy.vue
@@ -33,11 +33,11 @@
             <v-table density="compact">
               <thead>
                 <tr>
-                  <th class="text-left">Name</th>
-                  <th class="text-left">Storage</th>
-                  <th class="text-left">Category</th>
-                  <th class="text-left">Purpose</th>
-                  <th class="text-left">Retention</th>
+                  <th class="text-left" scope="col">Name</th>
+                  <th class="text-left" scope="col">Storage</th>
+                  <th class="text-left" scope="col">Category</th>
+                  <th class="text-left" scope="col">Purpose</th>
+                  <th class="text-left" scope="col">Retention</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/views/Imprint.vue
+++ b/src/views/Imprint.vue
@@ -24,7 +24,7 @@
               <a href="mailto:w3champions.team@gmail.com" class="text-primary">w3champions.team@gmail.com</a>
               <br />
               Internet address:
-              <a href="https://w3champions.com" target="_blank" class="text-primary">https://w3champions.com</a>
+              <a href="https://w3champions.com" target="_blank" rel="noopener noreferrer" class="text-primary">https://w3champions.com</a>
             </p>
           </v-card-text>
           <v-card-text>
@@ -44,7 +44,7 @@
           <v-card-text class="py-0">
             <h3>Graphics and Image Sources</h3>
             <p>
-              <a href="https://blizzard.gamespress.com/de/Warcraft-III-Reforged-Launch-Press-Kit" target="_blank" class="text-primary">
+              <a href="https://blizzard.gamespress.com/de/Warcraft-III-Reforged-Launch-Press-Kit" target="_blank" rel="noopener noreferrer" class="text-primary">
                 https://blizzard.gamespress.com/de/Warcraft-III-Reforged-Launch-Press-Kit
               </a>
             </p>

--- a/src/views/Imprint.vue
+++ b/src/views/Imprint.vue
@@ -3,7 +3,7 @@
     <v-row>
       <v-col cols="12">
         <v-card>
-          <v-card-title class="pt-3">Impressum</v-card-title>
+          <v-card-title class="pt-3">Legal Notice / Imprint</v-card-title>
           <v-card-text>
             W3Champions is owned and operated by:
             <br />
@@ -27,6 +27,20 @@
               <a href="https://w3champions.com" target="_blank" class="text-primary">https://w3champions.com</a>
             </p>
           </v-card-text>
+          <v-card-text>
+            <h3>EU Representative (GDPR Article 27)</h3>
+            <p>
+              For individuals in the European Union, our representative under Article 27 GDPR is:
+              <br />
+              Alexander Beninski
+              <br />
+              Cherni Vrah 51
+              <br />
+              1404 Sofia, Bulgaria
+              <br />
+              Phone: +359 89 759 9552
+            </p>
+          </v-card-text>
           <v-card-text class="py-0">
             <h3>Graphics and Image Sources</h3>
             <p>
@@ -48,34 +62,21 @@
             </p>
           </v-card-text>
           <v-card-text>
-            <h3>Disclaimer</h3>
-            Accountability for content
+            <h3>Privacy</h3>
             <p>
-              <br />
-              The contents of our pages have been created with the utmost care. However, we cannot guarantee the
-              contents' accuracy, completeness or topicality. According to statutory provisions, we are furthermore
-              responsible for our own content on these web pages. In this matter, please note that we are not obliged to
-              monitor the transmitted or saved information of third parties, or investigate circumstances pointing to
-              illegal activity. Our obligations to remove or block the use of information under generally applicable
-              laws remain unaffected by this as per §§ 8 to 10 of the Telemedia Act (TMG).
-              <br />
-              <br />
-              Accountability for links
-              <br />
-              Responsibility for the content of external links (to web pages of third parties) lies solely with the
-              operators of the linked pages. No violations were evident to us at the time of linking. Should any legal
-              infringement become known to us, we will remove the respective link immediately.
-              <br />
-              <br />
-              Copyright
-              <br />
-              Our web pages and their contents are subject to German copyright law. Unless expressly permitted by law,
-              every form of utilizing, reproducing or processing works subject to copyright protection on our web pages
-              requires the prior consent of the respective owner of the rights. Individual reproductions of a work are
-              only allowed for private use. The materials from these pages are copyrighted and any unauthorized use may
-              violate copyright laws.
-              <br />
-              <br />
+              For information about how we handle personal data and cookies, please see our
+              <router-link :to="{ name: EMainRouteName.PRIVACY }" class="text-primary">Privacy Policy</router-link>
+              and
+              <router-link :to="{ name: EMainRouteName.COOKIES }" class="text-primary">Cookie Policy</router-link>.
+            </p>
+          </v-card-text>
+          <v-card-text>
+            <h3>Disclaimer</h3>
+            <p>
+              The contents of these pages were created with care, but we do not guarantee their accuracy, completeness,
+              or timeliness. We are not responsible for the content of external websites we link to; responsibility for
+              those lies with their respective operators. If we become aware of any legal infringement, we will remove
+              the relevant link or content promptly.
             </p>
           </v-card-text>
         </v-card>
@@ -86,12 +87,12 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { EMainRouteName } from "@/router/types";
 
 export default defineComponent({
   name: "ImprintView",
-  components: {},
   setup() {
-    return {};
+    return { EMainRouteName };
   },
 });
 </script>

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -1,0 +1,153 @@
+<template>
+  <v-container class="pa-3 w3-container-width">
+    <v-row>
+      <v-col cols="12">
+        <v-card>
+          <v-card-title class="pt-3">Privacy Policy</v-card-title>
+          <v-card-text>Last updated: 7 June 2026</v-card-text>
+
+          <v-card-text>
+            <p>
+              This Privacy Policy explains how W3Champions ("we", "us") collects and uses personal data when you use
+              <a href="https://w3champions.com" target="_blank" rel="noopener noreferrer" class="text-primary">w3champions.com</a>
+              and related services. We are committed to protecting your privacy and complying with the EU General Data
+              Protection Regulation (GDPR) and applicable data-protection law.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>1. Who we are (Data Controller)</h3>
+            <p>
+              Deespul LLC<br />
+              Registered in North Carolina, USA<br />
+              D-U-N-S Number: 101376347 &middot; Company Number: 2115577<br />
+              E-Mail:
+              <a href="mailto:w3champions.team@gmail.com" class="text-primary">w3champions.team@gmail.com</a>
+            </p>
+            <h3>EU Representative (GDPR Article 27)</h3>
+            <p>
+              For individuals in the European Union, our representative under Article 27 GDPR is:<br />
+              Alexander Beninski<br />
+              Cherni Vrah 51<br />
+              1404 Sofia, Bulgaria<br />
+              Phone: +359 89 759 9552
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>2. What we collect, why, and our legal basis</h3>
+            <p>
+              <strong>Account &amp; gameplay data</strong> (BattleTag and account identifiers, profile, match history,
+              rankings, clan and arranged-team data, chat messages) &mdash; to provide the service you sign up for.
+              <em>Legal basis: performance of a contract (Art. 6(1)(b) GDPR).</em>
+            </p>
+            <p>
+              <strong>Security &amp; anti-abuse data</strong> (IP address, bot-protection checks via Cloudflare
+              Turnstile, VPN/proxy detection) &mdash; to keep the platform secure and fair.
+              <em>Legal basis: our legitimate interests (Art. 6(1)(f) GDPR).</em>
+            </p>
+            <p>
+              <strong>Analytics data</strong> (usage and device data via Google Analytics 4) &mdash; only if you allow
+              analytics cookies. <em>Legal basis: your consent (Art. 6(1)(a) GDPR), which you can withdraw at any time.</em>
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>3. Who we share data with (recipients)</h3>
+            <p>We use the following processors and third parties. Each accesses only the data needed for its purpose:</p>
+            <ul>
+              <li><strong>Google</strong> (Google Ireland Ltd. / Google LLC) &mdash; Google Analytics 4.</li>
+              <li><strong>Blizzard Entertainment / Battle.net</strong> &mdash; account login (BattleTag).</li>
+              <li><strong>Patreon</strong> and <strong>Ko-Fi</strong> &mdash; optional reward/subscription linking.</li>
+              <li><strong>Cloudflare</strong> &mdash; bot protection (Turnstile).</li>
+              <li><strong>getIPintel</strong> &mdash; VPN/proxy detection for anti-abuse.</li>
+              <li>Hosting and infrastructure providers that operate our servers.</li>
+            </ul>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>4. International data transfers</h3>
+            <p>
+              When you allow analytics, data is transferred to Google LLC in the United States. This transfer relies on
+              Google's certification under the <strong>EU-US Data Privacy Framework</strong> (an EU adequacy decision),
+              with the EU Standard Contractual Clauses as an additional safeguard. See
+              <a href="https://policies.google.com/privacy/frameworks" target="_blank" rel="noopener noreferrer" class="text-primary">Google's data-transfer frameworks</a>.
+              You can withdraw analytics consent at any time (see "Managing cookies" below).
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>5. How long we keep data</h3>
+            <p>
+              We keep account and gameplay data for as long as your account is active, and afterwards only as needed for
+              legitimate purposes (e.g. abuse prevention, legal obligations) or until you ask us to delete it. Analytics
+              data is retained according to our Google Analytics retention settings.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>6. Your rights</h3>
+            <p>
+              Subject to applicable law, you have the right to access, correct, erase, restrict, or object to the
+              processing of your personal data, to data portability, and to <strong>withdraw consent</strong> at any
+              time. To exercise these rights, contact us at
+              <a href="mailto:w3champions.team@gmail.com" class="text-primary">w3champions.team@gmail.com</a>
+              or our EU representative above. You also have the right to lodge a complaint with your data-protection
+              supervisory authority.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>7. Automated decision-making</h3>
+            <p>
+              We use automated systems for matchmaking, rankings, and some moderation. These do not produce legal or
+              similarly significant effects on you within the meaning of Article 22 GDPR.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>8. Children</h3>
+            <p>
+              This service is not directed to children. You must be at least 16 years old to create an account. We do
+              not knowingly collect personal data from children under 16; if we learn that we have, we will delete it.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>9. US / California privacy rights</h3>
+            <p>
+              We do not sell your personal information. If you are a US resident, you may have rights to access or delete
+              your personal information; contact us at the address above to exercise them.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>10. Cookies</h3>
+            <p>
+              We use cookies and similar technologies as described in our
+              <router-link :to="{ name: EMainRouteName.COOKIES }" class="text-primary">Cookie Policy</router-link>.
+              You can change or withdraw your choices at any time using the "Cookie settings" link in the page footer.
+            </p>
+          </v-card-text>
+
+          <v-card-text>
+            <h3>11. Changes to this policy</h3>
+            <p>We may update this policy from time to time. The "Last updated" date above reflects the latest version.</p>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { EMainRouteName } from "@/router/types";
+
+export default defineComponent({
+  name: "PrivacyPolicyView",
+  setup() {
+    return { EMainRouteName };
+  },
+});
+</script>

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -79,13 +79,38 @@
           <v-card-text>
             <h3>5. How long we keep data</h3>
             <p>
-              Your account is linked to your Battle.net BattleTag and we do not offer account deletion. Player
-              profiles, match history, rankings and similar gameplay data therefore form a permanent competitive
-              record and are retained <strong>indefinitely</strong>, as they are necessary to operate the service and
-              to provide a complete player history. Other personal data is kept for as long as necessary to meet our
-              legal, accounting, or billing obligations, or to protect the security and integrity of the platform
-              (preventing fraud and abuse). For these reasons, personal data generally cannot be erased on request.
-              Analytics data is retained according to our Google Analytics retention settings.
+              We deliberately collect as little personal data as possible. Most of the data we hold is
+              <strong>pseudonymous</strong> &mdash; it is linked to your Battle.net account (your BattleTag) rather than
+              to your name or contact details, and we do not collect names, postal addresses or similar details.
+              Pseudonymous data is still personal data under the GDPR; pseudonymisation is one of the safeguards we use
+              to keep it proportionate.
+            </p>
+            <p>We keep different data for different lengths of time, depending on why we hold it:</p>
+            <ul>
+              <li>
+                <strong>Gameplay and competitive records</strong> (match history, rankings, leaderboards, clan and
+                team data, public profile) &mdash; kept for as long as we operate W3Champions. A complete, continuous
+                competitive history is a core part of the service, so these records are not removed when an account
+                becomes inactive.
+              </li>
+              <li>
+                <strong>Security and anti-abuse data</strong> (such as IP addresses) &mdash; kept only as long as
+                necessary for security, fraud and abuse prevention and to enforce our Terms, and where relevant to
+                establish or defend legal claims, after which it is deleted or anonymised.
+              </li>
+              <li>
+                <strong>Patreon / Ko-Fi connection identifiers</strong> &mdash; kept while your supporter link is
+                active and for a short period afterwards for accounting and dispute-handling.
+              </li>
+              <li>
+                <strong>Analytics (Google Analytics 4)</strong> &mdash; collected only if you consent; you can withdraw
+                consent at any time, and we do not keep analytics data if you opt out.
+              </li>
+            </ul>
+            <p>
+              Where data has no fixed end date, we keep it no longer than necessary for these purposes and review
+              periodically whether continued retention is still justified. Where we no longer need data in an
+              identifiable form, we delete or anonymise it.
             </p>
           </v-card-text>
 
@@ -97,8 +122,15 @@
               time. To exercise these rights, contact us at
               <a href="mailto:w3champions.team@gmail.com" class="text-primary">w3champions.team@gmail.com</a>
               or our EU representative above. You also have the right to lodge a complaint with your data-protection
-              supervisory authority. Note that erasure does not apply to the gameplay and account data we are required
-              or have legitimate grounds to retain (see "How long we keep data" above).
+              supervisory authority.
+            </p>
+            <p>
+              We assess every erasure or objection request individually and will delete or <strong>anonymise</strong>
+              what we can. We may, however, keep certain data where data-protection law allows &mdash; in particular
+              your <strong>public competitive records</strong> (which form part of the service and the competitive
+              history, as an exercise of the right to freedom of expression and information) and
+              <strong>security data</strong> we need to protect the platform or to establish or defend legal claims.
+              Where we cannot fully erase data, we will explain what we are keeping and why.
             </p>
           </v-card-text>
 

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -122,7 +122,7 @@
           </v-card-text>
 
           <v-card-text>
-            <h3>10. Cookies</h3>
+            <h3>10. Managing cookies</h3>
             <p>
               We use cookies and similar technologies as described in our
               <router-link :to="{ name: EMainRouteName.COOKIES }" class="text-primary">Cookie Policy</router-link>.

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -42,8 +42,8 @@
               <em>Legal basis: performance of a contract (Art. 6(1)(b) GDPR).</em>
             </p>
             <p>
-              <strong>Security &amp; anti-abuse data</strong> (IP address, bot-protection checks via Cloudflare
-              Turnstile, VPN/proxy detection) &mdash; to keep the platform secure and fair.
+              <strong>Security &amp; anti-abuse data</strong> (IP address, diagnostic data, bot-protection checks via
+              Cloudflare Turnstile, VPN/proxy detection) &mdash; to keep the platform secure and fair.
               <em>Legal basis: our legitimate interests (Art. 6(1)(f) GDPR).</em>
             </p>
             <p>
@@ -59,7 +59,7 @@
               <li><strong>Google</strong> (Google Ireland Ltd. / Google LLC) &mdash; Google Analytics 4.</li>
               <li><strong>Blizzard Entertainment / Battle.net</strong> &mdash; account login (BattleTag).</li>
               <li><strong>Patreon</strong> and <strong>Ko-Fi</strong> &mdash; optional reward/subscription linking.</li>
-              <li><strong>Cloudflare</strong> &mdash; bot protection (Turnstile).</li>
+              <li><strong>Cloudflare</strong> &mdash; content delivery network (CDN) and bot protection (Turnstile).</li>
               <li><strong>getIPintel</strong> &mdash; VPN/proxy detection for anti-abuse.</li>
               <li>Hosting and infrastructure providers that operate our servers.</li>
             </ul>
@@ -79,9 +79,13 @@
           <v-card-text>
             <h3>5. How long we keep data</h3>
             <p>
-              We keep account and gameplay data for as long as your account is active, and afterwards only as needed for
-              legitimate purposes (e.g. abuse prevention, legal obligations) or until you ask us to delete it. Analytics
-              data is retained according to our Google Analytics retention settings.
+              Your account is linked to your Battle.net BattleTag and we do not offer account deletion. Player
+              profiles, match history, rankings and similar gameplay data therefore form a permanent competitive
+              record and are retained <strong>indefinitely</strong>, as they are necessary to operate the service and
+              to provide a complete player history. Other personal data is kept for as long as necessary to meet our
+              legal, accounting, or billing obligations, or to protect the security and integrity of the platform
+              (preventing fraud and abuse). For these reasons, personal data generally cannot be erased on request.
+              Analytics data is retained according to our Google Analytics retention settings.
             </p>
           </v-card-text>
 
@@ -93,7 +97,8 @@
               time. To exercise these rights, contact us at
               <a href="mailto:w3champions.team@gmail.com" class="text-primary">w3champions.team@gmail.com</a>
               or our EU representative above. You also have the right to lodge a complaint with your data-protection
-              supervisory authority.
+              supervisory authority. Note that erasure does not apply to the gameplay and account data we are required
+              or have legitimate grounds to retain (see "How long we keep data" above).
             </p>
           </v-card-text>
 


### PR DESCRIPTION
## Summary

Adds **consent-gated Google Analytics 4** via the **Silktide Consent Manager**, and brings the site's legal pages into GDPR shape for a US company (Deespul LLC) serving EU users.

- **GA4** (`G-HQ4XC36WGT`, hardcoded — a public, non-secret value): **hard-blocked** until the visitor grants Analytics consent, and **only active on the production hostnames** (`w3champions.com` / `www.w3champions.com`) so test/localhost never pollute the property. SPA page-views fire from the existing `router.afterEach`.
- **Silktide Consent Manager v2.0**: self-hosted (no third-party CDN), with built-in **Google Consent Mode v2** wiring (default-denied). Two categories: Essential (always on) + Analytics (opt-in). Footer "Cookie settings" reopens the preferences modal non-destructively.
- **Legal**: new `/privacy` (Art 13/14 Privacy Policy incl. EU Art 27 representative, legal bases, recipients, EU-US DPF transfer disclosure, rights, min-age 16) and `/cookies` (Cookie Policy + real cookie inventory). **Imprint rewritten**: inapplicable German-law text (§ TMG — repealed; German copyright/liability) removed → accurate US controller identity + EU Art 27 representative.

## What changed

| Area | Files |
|---|---|
| GA4 + consent | `public/analytics-consent.js` (Consent Mode default + prod-host-gated loader + Silktide init), `src/analytics/analytics.ts` (`trackPageView`, `openCookieSettings`), `index.html`, `src/router/index.ts` |
| Silktide (vendored) | `public/silktide/silktide-consent-manager.{js,css}` (v2.0, MIT, self-hosted) |
| Legal | `src/views/PrivacyPolicy.vue`, `src/views/CookiePolicy.vue`, `src/views/Imprint.vue`, `src/router/{index,types}.ts`, `src/App.vue` |

## ⚠️ Action items before/after go-live (operational — not code)

- [ ] In **GA4 admin**: accept Google's **Data Processing Terms**; set **data retention**; disable **Google Signals** + Advertising Features.
- [ ] **GA4 only activates on the production hostname by design** — it will NOT fire on `test.w3champions.com`. Validate GA4 in **Realtime/DebugView right after the prod deploy** (on test, only the banner/consent UX is verifiable, not data flow).
- [ ] Ensure the **EU representative mandate** (Alexander Beninski, Sofia) is **in writing** and reachable.
- [ ] **Legal review** of the drafted Privacy/Cookie/Imprint text by a qualified privacy lawyer (it is an informational starting draft, not legal advice). Privacy contact currently reuses `w3champions.team@gmail.com`.
- [ ] Recommended: maintain an internal **Art 30 RoPA** (a DPO is not required at this size).
- _Intentionally skipped per request:_ a separate **UK GDPR Art 27 representative** (needed only if serving UK users).

## Compliance assessment (summary)

Research-backed findings that drove this PR (informational, not legal advice): GDPR **applies** under Art 3(2) (offering services to + monitoring EU users via GA4); the largest prior gap was the **total absence of a privacy policy** and **analytics without prior consent** — both fixed here. The EU-US **Data Privacy Framework** remains valid as of 2025/2026 (Latombe challenge dismissed Sep 2025; appeal pending), with Google's **SCCs** as fallback — disclosed in the Privacy Policy. The old Imprint's German **TMG** citation was doubly defective (TMG repealed → DDG in 2024; and German imprint law doesn't bind a US LLC) — removed.

## Test plan

Automated gates (all green): `npm run type-check-vue`, `npm run lint`, `npm run dprint`, `npm run build`.

Manual (browser — consent UI + prod-gated GA4 can't be automated):
- [ ] First visit shows the banner (Accept all / Reject non-essential / Preferences); Analytics defaults OFF.
- [ ] **Reject** → no `gtag/js` request, no `_ga` cookie.
- [ ] **Accept** on a prod host → GA4 loads, `_ga` set, one `page_view` per route (no double-count on landing); on `localhost`/test GA4 stays suppressed (prod-host guard — expected).
- [ ] Footer **Cookie settings** reopens the preferences modal; lowering Analytics stops further collection.
- [ ] `/privacy` and `/cookies` render; Imprint shows the EU representative and contains no German-law text.
- [ ] No console errors.