### PR TITLE
Add player warning admin pages

### DIFF
--- a/src/components/admin/AdminNavigation.vue
+++ b/src/components/admin/AdminNavigation.vue
@@ -195,6 +195,13 @@ export default defineComponent({
             component: "admin-warnings",
             routeName: EAdminRouteName.PLAYER_WARNINGS,
           },
+          {
+            title: "Warning Templates",
+            icon: mdiTooltipTextOutline,
+            permission: EPermission.Warnings,
+            component: "admin-warning-templates",
+            routeName: EAdminRouteName.WARNING_TEMPLATES,
+          },
         ],
       },
       {

--- a/src/components/admin/AdminNavigation.vue
+++ b/src/components/admin/AdminNavigation.vue
@@ -60,6 +60,7 @@ import {
   mdiMonitorDashboard, mdiRocket, mdiRss, mdiSwordCross, mdiTable, mdiTooltipTextOutline,
   mdiAccountKey, mdiFileDocumentOutline, mdiFileDocument, mdiTrophy, mdiLink,
   mdiAccountMultiple, mdiRadar, mdiAccountHeart, mdiApi, mdiTranslate, mdiWaveform,
+  mdiAlertCircleOutline,
 } from "@mdi/js";
 
 export default defineComponent({
@@ -179,6 +180,20 @@ export default defineComponent({
             permission: EPermission.Moderation,
             component: "admin-launcher-chat",
             routeName: EAdminRouteName.LAUNCHER_CHAT,
+          },
+        ],
+      },
+      {
+        title: "Warnings",
+        icon: mdiAlertCircleOutline,
+        permission: EPermission.Warnings,
+        items: [
+          {
+            title: "Player Warnings",
+            icon: mdiAlertCircleOutline,
+            permission: EPermission.Warnings,
+            component: "admin-warnings",
+            routeName: EAdminRouteName.PLAYER_WARNINGS,
           },
         ],
       },

--- a/src/components/admin/AdminPermissions.vue
+++ b/src/components/admin/AdminPermissions.vue
@@ -155,6 +155,7 @@ export default defineComponent({
       { name: EPermission[EPermission.Tournaments], value: EPermission.Tournaments },
       { name: EPermission[EPermission.Content], value: EPermission.Content },
       { name: EPermission[EPermission.Proxies], value: EPermission.Proxies },
+      { name: EPermission[EPermission.Warnings], value: EPermission.Warnings },
       { name: EPermission[EPermission.SmurfCheckerQuery], value: EPermission.SmurfCheckerQuery },
       { name: EPermission[EPermission.SmurfCheckerQueryExplanation], value: EPermission.SmurfCheckerQueryExplanation },
       { name: EPermission[EPermission.SmurfCheckerAdministration], value: EPermission.SmurfCheckerAdministration },

--- a/src/components/admin/AdminWarningTemplates.vue
+++ b/src/components/admin/AdminWarningTemplates.vue
@@ -206,9 +206,9 @@ import AdminService from "@/services/admin/AdminService";
 import { useOauthStore } from "@/store/oauth/store";
 import { EPlayerWarningSeverity, type PlayerWarningDefinition, type PlayerWarningDefinitionRequest, type PlayerWarningTranslations } from "@/store/admin/types";
 import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiDelete, mdiInformationOutline, mdiPencil } from "@mdi/js";
-import { warningLocaleItems } from "./warnings/warningLocaleItems";
+import { clientLocaleItems } from "@/locales/clientLocaleItems";
 
-const localeItems = warningLocaleItems;
+const localeItems = clientLocaleItems;
 
 function emptyTranslations(): PlayerWarningTranslations {
   return Object.fromEntries(localeItems.map((locale) => [locale.value, ""])) as PlayerWarningTranslations;

--- a/src/components/admin/AdminWarningTemplates.vue
+++ b/src/components/admin/AdminWarningTemplates.vue
@@ -1,0 +1,452 @@
+<template>
+  <div>
+    <v-card-title class="pt-3">
+      Warning Templates
+    </v-card-title>
+
+    <div class="d-flex align-center px-4 mb-3">
+      <v-switch
+        v-model="showDisabled"
+        label="Show disabled"
+        color="primary"
+        hide-details
+        density="compact"
+        @update:model-value="loadDefinitions()"
+      />
+      <v-spacer />
+      <v-btn class="bg-primary text-w3-race-bg" @click="openCreateDialog">
+        Add template
+      </v-btn>
+    </div>
+
+    <v-alert
+      v-if="errorMessage"
+      class="mx-4 mb-3"
+      type="error"
+      variant="tonal"
+      density="compact"
+      closable
+      @click:close="errorMessage = ''"
+    >
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-data-table
+      class="px-4"
+      :headers="headers"
+      :items="definitions"
+      :loading="loading"
+      :items-per-page="25"
+      item-value="_id"
+    >
+      <template v-slot:item.title="{ item }">
+        <div class="font-weight-medium">{{ getTranslation(item.title, 'en') }}</div>
+        <div class="text-medium-emphasis text-caption">{{ getTranslation(item.body, 'en') }}</div>
+      </template>
+
+      <template v-slot:item.severity="{ item }">
+        <v-chip :color="severityColor(item.severity)" size="small" variant="tonal">
+          <v-icon start size="small">{{ severityIcon(item.severity) }}</v-icon>
+          {{ item.severity }}
+        </v-chip>
+      </template>
+
+      <template v-slot:item.translations="{ item }">
+        <v-chip
+          :color="translationCount(item) === localeItems.length ? 'success' : 'warning'"
+          size="small"
+          variant="tonal"
+        >
+          {{ translationCount(item) }}/{{ localeItems.length }}
+        </v-chip>
+      </template>
+
+      <template v-slot:item.enabled="{ item }">
+        <v-chip :color="item.enabled ? 'success' : 'medium-emphasis'" size="small" variant="tonal">
+          {{ item.enabled ? "Enabled" : "Disabled" }}
+        </v-chip>
+      </template>
+
+      <template v-slot:item.actions="{ item }">
+        <v-icon size="small" class="mr-2" @click="openEditDialog(item)">{{ mdiPencil }}</v-icon>
+        <v-icon
+          v-if="item.enabled"
+          size="small"
+          color="error"
+          @click="disableDefinition(item)"
+        >
+          {{ mdiDelete }}
+        </v-icon>
+      </template>
+    </v-data-table>
+
+    <v-dialog v-model="dialogOpen" max-width="980px">
+      <v-card>
+        <v-card-title class="pt-3">
+          {{ editedDefinitionId ? "Edit warning template" : "Add warning template" }}
+        </v-card-title>
+
+        <v-card-text>
+          <v-row>
+            <v-col cols="12" md="4">
+              <v-select
+                v-model="editedSeverity"
+                :items="severityItems"
+                item-title="title"
+                item-value="value"
+                label="Severity"
+                variant="underlined"
+                color="primary"
+              >
+                <template v-slot:item="{ props, item }">
+                  <v-list-item v-bind="props">
+                    <template v-slot:prepend>
+                      <v-icon :color="item.raw.color">{{ item.raw.icon }}</v-icon>
+                    </template>
+                  </v-list-item>
+                </template>
+              </v-select>
+            </v-col>
+
+            <v-col cols="6" md="4">
+              <v-text-field
+                v-model.number="editedSortOrder"
+                label="Sort order"
+                type="number"
+                variant="underlined"
+                color="primary"
+              />
+            </v-col>
+
+            <v-col cols="6" md="4">
+              <v-switch
+                v-model="editedEnabled"
+                label="Enabled"
+                color="success"
+                hide-details
+              />
+            </v-col>
+
+            <v-col cols="12">
+              <v-tabs v-model="editedLocale" color="primary" density="compact" show-arrows>
+                <v-tab
+                  v-for="locale in localeItems"
+                  :key="locale.value"
+                  :value="locale.value"
+                >
+                  {{ locale.value.toUpperCase() }}
+                  <v-icon
+                    v-if="!hasLocaleTranslation(locale.value)"
+                    size="x-small"
+                    color="warning"
+                    class="ml-1"
+                  >
+                    {{ mdiAlertCircleOutline }}
+                  </v-icon>
+                </v-tab>
+              </v-tabs>
+
+              <v-window v-model="editedLocale">
+                <v-window-item
+                  v-for="locale in localeItems"
+                  :key="locale.value"
+                  :value="locale.value"
+                  :transition="false"
+                >
+                  <div class="text-caption text-medium-emphasis mt-3">
+                    {{ locale.title }} {{ locale.value === 'en' ? '(required fallback)' : '(optional, falls back to English)' }}
+                  </div>
+                  <v-text-field
+                    v-model="editedTitle[locale.value]"
+                    class="mt-2"
+                    label="Title"
+                    variant="underlined"
+                    color="primary"
+                    :required="locale.value === 'en'"
+                  />
+                  <v-textarea
+                    v-model="editedBody[locale.value]"
+                    label="Message"
+                    rows="5"
+                    variant="underlined"
+                    color="primary"
+                    :required="locale.value === 'en'"
+                  />
+                </v-window-item>
+              </v-window>
+
+              <div class="template-locale-summary text-caption text-medium-emphasis mt-2">
+                Filled locales: {{ filledLocaleCount }}/{{ localeItems.length }}.
+                Missing locales will use English in the launcher.
+              </div>
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">Cancel</v-btn>
+          <v-btn
+            class="bg-primary text-w3-race-bg"
+            :loading="saving"
+            :disabled="!canSave"
+            @click="saveDefinition"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted, ref } from "vue";
+import AdminService from "@/services/admin/AdminService";
+import { useOauthStore } from "@/store/oauth/store";
+import { EPlayerWarningSeverity, type PlayerWarningDefinition, type PlayerWarningDefinitionRequest, type PlayerWarningTranslations } from "@/store/admin/types";
+import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiDelete, mdiInformationOutline, mdiPencil } from "@mdi/js";
+import { warningLocaleItems } from "./warnings/warningLocaleItems";
+
+const localeItems = warningLocaleItems;
+
+function emptyTranslations(): PlayerWarningTranslations {
+  return Object.fromEntries(localeItems.map((locale) => [locale.value, ""])) as PlayerWarningTranslations;
+}
+
+export default defineComponent({
+  name: "AdminWarningTemplates",
+  setup() {
+    const oauthStore = useOauthStore();
+    const definitions = ref<PlayerWarningDefinition[]>([]);
+    const loading = ref<boolean>(false);
+    const saving = ref<boolean>(false);
+    const showDisabled = ref<boolean>(true);
+    const errorMessage = ref<string>("");
+    const dialogOpen = ref<boolean>(false);
+    const editedDefinitionId = ref<string>("");
+    const editedSeverity = ref<EPlayerWarningSeverity>(EPlayerWarningSeverity.Warning);
+    const editedEnabled = ref<boolean>(true);
+    const editedSortOrder = ref<number>(100);
+    const editedLocale = ref<string>("en");
+    const editedTitle = ref<PlayerWarningTranslations>(emptyTranslations());
+    const editedBody = ref<PlayerWarningTranslations>(emptyTranslations());
+
+    const headers = [
+      { title: "Template", key: "title", sortable: false },
+      { title: "Severity", key: "severity", sortable: false },
+      { title: "Translations", key: "translations", sortable: false },
+      { title: "Enabled", key: "enabled", sortable: false },
+      { title: "Sort", key: "sortOrder", sortable: true },
+      { title: "", key: "actions", sortable: false, align: "end" as const },
+    ];
+
+    const severityItems = [
+      { title: "Info", value: EPlayerWarningSeverity.Info, color: "success", icon: mdiInformationOutline },
+      { title: "Warning", value: EPlayerWarningSeverity.Warning, color: "warning", icon: mdiAlertCircleOutline },
+      { title: "Critical", value: EPlayerWarningSeverity.Critical, color: "error", icon: mdiAlertOctagonOutline },
+    ];
+
+    const filledLocaleCount = computed<number>(() =>
+      localeItems.filter((locale) => hasLocaleTranslation(locale.value)).length
+    );
+
+    const canSave = computed<boolean>(() =>
+      !!editedTitle.value.en?.trim()
+      && !!editedBody.value.en?.trim()
+      && Number.isFinite(Number(editedSortOrder.value))
+    );
+
+    async function loadDefinitions(): Promise<void> {
+      loading.value = true;
+      errorMessage.value = "";
+      try {
+        definitions.value = await AdminService.getWarningDefinitions(oauthStore.token, showDisabled.value);
+      } catch (error) {
+        definitions.value = [];
+        errorMessage.value = getErrorMessage(error);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function openCreateDialog(): void {
+      editedDefinitionId.value = "";
+      editedSeverity.value = EPlayerWarningSeverity.Warning;
+      editedEnabled.value = true;
+      editedSortOrder.value = nextSortOrder();
+      editedLocale.value = "en";
+      editedTitle.value = emptyTranslations();
+      editedBody.value = emptyTranslations();
+      dialogOpen.value = true;
+    }
+
+    function openEditDialog(definition: PlayerWarningDefinition): void {
+      editedDefinitionId.value = definition._id;
+      editedSeverity.value = definition.severity;
+      editedEnabled.value = definition.enabled;
+      editedSortOrder.value = definition.sortOrder ?? 0;
+      editedLocale.value = "en";
+      editedTitle.value = withLocaleDefaults(definition.title);
+      editedBody.value = withLocaleDefaults(definition.body);
+      dialogOpen.value = true;
+    }
+
+    function closeDialog(): void {
+      dialogOpen.value = false;
+    }
+
+    async function saveDefinition(): Promise<void> {
+      if (!canSave.value) return;
+
+      saving.value = true;
+      errorMessage.value = "";
+      try {
+        const request = buildRequest();
+        if (editedDefinitionId.value) {
+          await AdminService.updateWarningDefinition(oauthStore.token, editedDefinitionId.value, request);
+        } else {
+          await AdminService.createWarningDefinition(oauthStore.token, request);
+        }
+        closeDialog();
+        await loadDefinitions();
+      } catch (error) {
+        errorMessage.value = getErrorMessage(error);
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    async function disableDefinition(definition: PlayerWarningDefinition): Promise<void> {
+      if (!confirm(`Disable "${getTranslation(definition.title, "en")}"?`)) return;
+
+      errorMessage.value = "";
+      try {
+        await AdminService.deleteWarningDefinition(oauthStore.token, definition._id);
+        await loadDefinitions();
+      } catch (error) {
+        errorMessage.value = getErrorMessage(error);
+      }
+    }
+
+    function buildRequest(): PlayerWarningDefinitionRequest {
+      return {
+        severity: editedSeverity.value,
+        title: trimTranslations(editedTitle.value),
+        body: trimTranslations(editedBody.value),
+        enabled: editedEnabled.value,
+        sortOrder: Number(editedSortOrder.value),
+      };
+    }
+
+    function trimTranslations(translations: PlayerWarningTranslations): PlayerWarningTranslations {
+      const result: PlayerWarningTranslations = { en: translations.en.trim() };
+      for (const locale of localeItems) {
+        const value = translations[locale.value]?.trim();
+        if (locale.value !== "en" && value) {
+          result[locale.value] = value;
+        }
+      }
+      return result;
+    }
+
+    function withLocaleDefaults(translations: PlayerWarningTranslations): PlayerWarningTranslations {
+      return {
+        ...emptyTranslations(),
+        ...translations,
+      };
+    }
+
+    function nextSortOrder(): number {
+      const maxSortOrder = definitions.value.reduce((max, definition) => Math.max(max, definition.sortOrder || 0), 0);
+      return maxSortOrder + 10;
+    }
+
+    function hasLocaleTranslation(locale: string): boolean {
+      return !!editedTitle.value[locale]?.trim() && !!editedBody.value[locale]?.trim();
+    }
+
+    function translationCount(definition: PlayerWarningDefinition): number {
+      return localeItems.filter((locale) =>
+        !!definition.title[locale.value]?.trim() && !!definition.body[locale.value]?.trim()
+      ).length;
+    }
+
+    function getTranslation(translations: PlayerWarningTranslations, locale: string): string {
+      return translations[locale]?.trim()
+        || translations.en?.trim()
+        || Object.values(translations).find((value) => !!value?.trim())
+        || "";
+    }
+
+    function severityColor(severity: EPlayerWarningSeverity): string {
+      switch (severity) {
+        case EPlayerWarningSeverity.Info:
+          return "success";
+        case EPlayerWarningSeverity.Critical:
+          return "error";
+        default:
+          return "warning";
+      }
+    }
+
+    function severityIcon(severity: EPlayerWarningSeverity): string {
+      switch (severity) {
+        case EPlayerWarningSeverity.Info:
+          return mdiInformationOutline;
+        case EPlayerWarningSeverity.Critical:
+          return mdiAlertOctagonOutline;
+        default:
+          return mdiAlertCircleOutline;
+      }
+    }
+
+    function getErrorMessage(error: unknown): string {
+      return error instanceof Error ? error.message : "Something went wrong.";
+    }
+
+    onMounted(loadDefinitions);
+
+    return {
+      definitions,
+      loading,
+      saving,
+      showDisabled,
+      errorMessage,
+      dialogOpen,
+      editedDefinitionId,
+      editedSeverity,
+      editedEnabled,
+      editedSortOrder,
+      editedLocale,
+      editedTitle,
+      editedBody,
+      headers,
+      severityItems,
+      localeItems,
+      filledLocaleCount,
+      canSave,
+      mdiAlertCircleOutline,
+      mdiDelete,
+      mdiPencil,
+      loadDefinitions,
+      openCreateDialog,
+      openEditDialog,
+      closeDialog,
+      saveDefinition,
+      disableDefinition,
+      hasLocaleTranslation,
+      translationCount,
+      getTranslation,
+      severityColor,
+      severityIcon,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.template-locale-summary {
+  line-height: 1.5;
+}
+</style>

--- a/src/components/admin/AdminWarnings.vue
+++ b/src/components/admin/AdminWarnings.vue
@@ -1,0 +1,397 @@
+<template>
+  <div>
+    <v-card-title class="pt-3">
+      Player Warnings
+    </v-card-title>
+
+    <div class="d-flex align-center px-4 ga-4">
+      <div class="w-33">
+        <player-search
+          search-label="Search player"
+          @playerFound="onPlayerFound"
+          @searchCleared="onPlayerSearchCleared"
+        />
+      </div>
+      <v-select
+        v-model="statusFilter"
+        class="w-25"
+        :items="statusItems"
+        item-title="title"
+        item-value="value"
+        label="Status"
+        variant="underlined"
+        color="primary"
+        clearable
+        hide-details
+      />
+      <v-spacer />
+      <v-btn class="bg-primary text-w3-race-bg" @click="openCreateDialog">
+        New warning
+      </v-btn>
+    </div>
+
+    <v-alert
+      v-if="errorMessage"
+      class="ma-4"
+      type="error"
+      variant="tonal"
+      density="compact"
+      closable
+      @click:close="errorMessage = ''"
+    >
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-data-table-server
+      class="px-4"
+      :headers="headers"
+      :items="warnings"
+      :items-length="total"
+      :items-per-page="tableOptions.itemsPerPage"
+      :items-per-page-options="[10, 25, 50, 100]"
+      :loading="loading"
+      :page="tableOptions.page"
+      :sort-by="[]"
+      item-value="_id"
+      @update:options="onTableOptionsUpdate"
+    >
+      <template v-slot:item.title="{ item }">
+        <div class="font-weight-medium">{{ item.title.en }}</div>
+        <div class="text-medium-emphasis text-caption">{{ item.body.en }}</div>
+      </template>
+
+      <template v-slot:item.status="{ item }">
+        <v-chip :color="statusColor(item.status)" size="small" variant="tonal">
+          {{ item.status }}
+        </v-chip>
+      </template>
+
+      <template v-slot:item.severity="{ item }">
+        <v-chip :color="severityColor(item.severity)" size="small" variant="tonal">
+          <v-icon start size="small">{{ severityIcon(item.severity) }}</v-icon>
+          {{ item.severity }}
+        </v-chip>
+      </template>
+
+      <template v-slot:item.createdAt="{ item }">
+        {{ formatDate(item.createdAt) }}
+      </template>
+
+      <template v-slot:item.actions="{ item }">
+        <v-btn
+          v-if="canCancel(item)"
+          size="small"
+          variant="text"
+          color="error"
+          @click="cancelWarning(item)"
+        >
+          Cancel
+        </v-btn>
+      </template>
+    </v-data-table-server>
+
+    <v-dialog v-model="createDialogOpen" max-width="720px">
+      <v-card>
+        <v-card-title class="pt-3">
+          New Player Warning
+        </v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col cols="12">
+              <player-search
+                :set-autofocus="false"
+                search-label="Player"
+                @playerFound="onCreatePlayerFound"
+                @searchCleared="createForm.targetBattleTag = ''"
+              />
+              <div v-if="createForm.targetBattleTag" class="text-caption text-medium-emphasis mt-1">
+                Selected: {{ createForm.targetBattleTag }}
+              </div>
+            </v-col>
+            <v-col cols="12">
+              <v-text-field v-model="createForm.title.en" label="Title" variant="underlined" color="primary" />
+            </v-col>
+            <v-col cols="12">
+              <v-textarea v-model="createForm.body.en" label="Message" rows="5" variant="underlined" color="primary" />
+            </v-col>
+            <v-col cols="12">
+              <div class="text-subtitle-2 mb-2">Severity</div>
+              <v-btn-toggle
+                v-model="createForm.severity"
+                mandatory
+                divided
+                class="warning-severity-toggle"
+              >
+                <v-btn
+                  v-for="item in severityItems"
+                  :key="item.value"
+                  :value="item.value"
+                  :color="item.color"
+                  class="warning-severity-button"
+                >
+                  <v-icon start>{{ item.icon }}</v-icon>
+                  {{ item.title }}
+                </v-btn>
+              </v-btn-toggle>
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="createDialogOpen = false">Cancel</v-btn>
+          <v-btn
+            class="bg-primary text-w3-race-bg"
+            :loading="saving"
+            :disabled="!canCreate"
+            @click="createWarning"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted, reactive, ref, watch } from "vue";
+import PlayerSearch from "@/components/common/PlayerSearch.vue";
+import AdminService from "@/services/admin/AdminService";
+import { useOauthStore } from "@/store/oauth/store";
+import { EPlayerWarningSeverity, EPlayerWarningStatus, type CreatePlayerWarningRequest, type PlayerWarning } from "@/store/admin/types";
+import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiInformationOutline } from "@mdi/js";
+
+type StatusFilter = EPlayerWarningStatus | "";
+type VuetifyTableUpdateOptions = {
+  page: number;
+  itemsPerPage: number;
+};
+
+export default defineComponent({
+  name: "AdminWarnings",
+  components: {
+    PlayerSearch,
+  },
+  setup() {
+    const oauthStore = useOauthStore();
+    const warnings = ref<PlayerWarning[]>([]);
+    const total = ref<number>(0);
+    const loading = ref<boolean>(false);
+    const saving = ref<boolean>(false);
+    const errorMessage = ref<string>("");
+    const selectedBattleTag = ref<string>("");
+    const statusFilter = ref<StatusFilter>("");
+    const createDialogOpen = ref<boolean>(false);
+    const tableOptions = ref<VuetifyTableUpdateOptions>({ page: 1, itemsPerPage: 25 });
+
+    const createForm = reactive<CreatePlayerWarningRequest>({
+      targetBattleTag: "",
+      severity: EPlayerWarningSeverity.Warning,
+      title: { en: "" },
+      body: { en: "" },
+    });
+
+    const headers = [
+      { title: "Player", key: "targetBattleTag", sortable: false },
+      { title: "Warning", key: "title", sortable: false },
+      { title: "Severity", key: "severity", sortable: false },
+      { title: "Status", key: "status", sortable: false },
+      { title: "Issued By", key: "issuedByBattleTag", sortable: false },
+      { title: "Created", key: "createdAt", sortable: false },
+      { title: "", key: "actions", sortable: false },
+    ];
+
+    const statusItems = [
+      { title: "All", value: "" },
+      ...Object.values(EPlayerWarningStatus).map((status) => ({ title: status, value: status })),
+    ];
+
+    const severityItems = [
+      { title: "Info", value: EPlayerWarningSeverity.Info, color: "success", icon: mdiInformationOutline },
+      { title: "Warning", value: EPlayerWarningSeverity.Warning, color: "warning", icon: mdiAlertCircleOutline },
+      { title: "Critical", value: EPlayerWarningSeverity.Critical, color: "error", icon: mdiAlertOctagonOutline },
+    ];
+
+    const canCreate = computed<boolean>(() =>
+      !!createForm.targetBattleTag
+      && !!createForm.title.en.trim()
+      && !!createForm.body.en.trim()
+    );
+
+    async function loadWarnings(): Promise<void> {
+      loading.value = true;
+      errorMessage.value = "";
+      try {
+        const result = await AdminService.getWarnings(oauthStore.token, {
+          page: tableOptions.value.page,
+          itemsPerPage: tableOptions.value.itemsPerPage,
+          battleTag: selectedBattleTag.value,
+          status: statusFilter.value,
+        });
+        warnings.value = result.warnings;
+        total.value = result.total;
+      } catch (error) {
+        warnings.value = [];
+        total.value = 0;
+        errorMessage.value = getErrorMessage(error);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function onTableOptionsUpdate(options: VuetifyTableUpdateOptions): void {
+      tableOptions.value = {
+        page: options.page > 0 ? options.page : 1,
+        itemsPerPage: options.itemsPerPage > 0 ? options.itemsPerPage : 25,
+      };
+      loadWarnings();
+    }
+
+    function onPlayerFound(battleTag: string): void {
+      selectedBattleTag.value = battleTag;
+    }
+
+    function onPlayerSearchCleared(): void {
+      selectedBattleTag.value = "";
+    }
+
+    function onCreatePlayerFound(battleTag: string): void {
+      createForm.targetBattleTag = battleTag;
+    }
+
+    function openCreateDialog(): void {
+      createForm.targetBattleTag = selectedBattleTag.value;
+      createForm.severity = EPlayerWarningSeverity.Warning;
+      createForm.title = { en: "" };
+      createForm.body = { en: "" };
+      createDialogOpen.value = true;
+    }
+
+    async function createWarning(): Promise<void> {
+      if (!canCreate.value) return;
+
+      saving.value = true;
+      errorMessage.value = "";
+      try {
+        await AdminService.createWarning(oauthStore.token, {
+          targetBattleTag: createForm.targetBattleTag,
+          severity: createForm.severity,
+          title: { en: createForm.title.en.trim() },
+          body: { en: createForm.body.en.trim() },
+        });
+        createDialogOpen.value = false;
+        await loadWarnings();
+      } catch (error) {
+        errorMessage.value = getErrorMessage(error);
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    async function cancelWarning(warning: PlayerWarning): Promise<void> {
+      errorMessage.value = "";
+      try {
+        await AdminService.cancelWarning(oauthStore.token, warning._id);
+        await loadWarnings();
+      } catch (error) {
+        errorMessage.value = getErrorMessage(error);
+      }
+    }
+
+    function canCancel(warning: PlayerWarning): boolean {
+      return warning.status === EPlayerWarningStatus.Pending || warning.status === EPlayerWarningStatus.Sent;
+    }
+
+    function statusColor(status: EPlayerWarningStatus): string {
+      switch (status) {
+        case EPlayerWarningStatus.Acknowledged:
+          return "success";
+        case EPlayerWarningStatus.Cancelled:
+          return "medium-emphasis";
+        case EPlayerWarningStatus.Sent:
+          return "info";
+        default:
+          return "warning";
+      }
+    }
+
+    function severityColor(severity: EPlayerWarningSeverity): string {
+      switch (severity) {
+        case EPlayerWarningSeverity.Info:
+          return "success";
+        case EPlayerWarningSeverity.Critical:
+          return "error";
+        default:
+          return "warning";
+      }
+    }
+
+    function severityIcon(severity: EPlayerWarningSeverity): string {
+      switch (severity) {
+        case EPlayerWarningSeverity.Info:
+          return mdiInformationOutline;
+        case EPlayerWarningSeverity.Critical:
+          return mdiAlertOctagonOutline;
+        default:
+          return mdiAlertCircleOutline;
+      }
+    }
+
+    function formatDate(value?: string): string {
+      return value ? new Date(value).toLocaleString() : "";
+    }
+
+    function getErrorMessage(error: unknown): string {
+      return error instanceof Error ? error.message : "Something went wrong.";
+    }
+
+    watch([selectedBattleTag, statusFilter], () => {
+      tableOptions.value.page = 1;
+      loadWarnings();
+    });
+
+    onMounted(loadWarnings);
+
+    return {
+      warnings,
+      total,
+      loading,
+      saving,
+      errorMessage,
+      selectedBattleTag,
+      statusFilter,
+      createDialogOpen,
+      tableOptions,
+      createForm,
+      headers,
+      statusItems,
+      severityItems,
+      canCreate,
+      onTableOptionsUpdate,
+      onPlayerFound,
+      onPlayerSearchCleared,
+      onCreatePlayerFound,
+      openCreateDialog,
+      createWarning,
+      cancelWarning,
+      canCancel,
+      statusColor,
+      severityColor,
+      severityIcon,
+      formatDate,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.warning-severity-toggle {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: 100%;
+}
+
+.warning-severity-button {
+  min-height: 56px;
+}
+</style>

--- a/src/components/admin/AdminWarnings.vue
+++ b/src/components/admin/AdminWarnings.vue
@@ -56,8 +56,8 @@
       @update:options="onTableOptionsUpdate"
     >
       <template v-slot:item.title="{ item }">
-        <div class="font-weight-medium">{{ item.title.en }}</div>
-        <div class="text-medium-emphasis text-caption">{{ item.body.en }}</div>
+        <div class="font-weight-medium">{{ getDefinitionText(item.title, "en") }}</div>
+        <div class="text-medium-emphasis text-caption">{{ getDefinitionText(item.body, "en") }}</div>
       </template>
 
       <template v-slot:item.status="{ item }">
@@ -90,7 +90,7 @@
       </template>
     </v-data-table-server>
 
-    <v-dialog v-model="createDialogOpen" max-width="720px">
+    <v-dialog v-model="createDialogOpen" max-width="760px">
       <v-card>
         <v-card-title class="pt-3">
           New Player Warning
@@ -108,31 +108,92 @@
                 Selected: {{ createForm.targetBattleTag }}
               </div>
             </v-col>
-            <v-col cols="12">
-              <v-text-field v-model="createForm.title.en" label="Title" variant="underlined" color="primary" />
+
+            <v-col cols="12" md="7">
+              <v-select
+                v-model="selectedWarningOption"
+                :items="definitionItems"
+                item-title="title"
+                item-value="value"
+                label="Warning"
+                variant="underlined"
+                color="primary"
+                :loading="definitionsLoading"
+              />
             </v-col>
-            <v-col cols="12">
-              <v-textarea v-model="createForm.body.en" label="Message" rows="5" variant="underlined" color="primary" />
+
+            <v-col cols="12" md="5">
+              <v-select
+                v-model="previewLocale"
+                :items="previewLocaleItems"
+                item-title="title"
+                item-value="value"
+                label="Preview language"
+                variant="underlined"
+                color="primary"
+                :disabled="isCustomWarning"
+              />
             </v-col>
-            <v-col cols="12">
-              <div class="text-subtitle-2 mb-2">Severity</div>
-              <v-btn-toggle
-                v-model="createForm.severity"
-                mandatory
-                divided
-                class="warning-severity-toggle"
+
+            <v-col cols="12" md="4">
+              <v-select
+                v-model="customSeverity"
+                :items="severityItems"
+                item-title="title"
+                item-value="value"
+                label="Severity"
+                variant="underlined"
+                color="primary"
+                :disabled="!isCustomWarning"
               >
-                <v-btn
-                  v-for="item in severityItems"
-                  :key="item.value"
-                  :value="item.value"
-                  :color="item.color"
-                  class="warning-severity-button"
-                >
-                  <v-icon start>{{ item.icon }}</v-icon>
-                  {{ item.title }}
-                </v-btn>
-              </v-btn-toggle>
+                <template v-slot:item="{ props, item }">
+                  <v-list-item v-bind="props">
+                    <template v-slot:prepend>
+                      <v-icon :color="item.raw.color">{{ item.raw.icon }}</v-icon>
+                    </template>
+                  </v-list-item>
+                </template>
+              </v-select>
+            </v-col>
+
+            <v-col cols="12" md="8">
+              <v-text-field
+                :model-value="titleFieldValue"
+                label="Title"
+                variant="underlined"
+                color="primary"
+                :disabled="!isCustomWarning"
+                @update:model-value="customTitle = String($event)"
+              />
+            </v-col>
+
+            <v-col cols="12">
+              <v-textarea
+                :model-value="bodyFieldValue"
+                label="Message"
+                rows="4"
+                variant="underlined"
+                color="primary"
+                :disabled="!isCustomWarning"
+                @update:model-value="customBody = String($event)"
+              />
+            </v-col>
+
+            <v-col cols="12">
+              <v-sheet class="warning-preview pa-4" rounded>
+                <div>
+                  <v-chip :color="severityColor(previewSeverity)" variant="tonal" size="small">
+                    <v-icon start size="small">{{ severityIcon(previewSeverity) }}</v-icon>
+                    {{ previewSeverity }}
+                  </v-chip>
+                  <div class="text-h6 mt-3 mb-2 warning-preview-title">
+                    {{ previewTitle || "Title preview" }}
+                  </div>
+                  <div class="warning-preview-body">
+                    {{ previewBody || "Message preview" }}
+                  </div>
+                </div>
+              </v-sheet>
             </v-col>
           </v-row>
         </v-card-text>
@@ -145,7 +206,7 @@
             :disabled="!canCreate"
             @click="createWarning"
           >
-            Save
+            Send
           </v-btn>
         </v-card-actions>
       </v-card>
@@ -158,7 +219,7 @@ import { computed, defineComponent, onMounted, reactive, ref, watch } from "vue"
 import PlayerSearch from "@/components/common/PlayerSearch.vue";
 import AdminService from "@/services/admin/AdminService";
 import { useOauthStore } from "@/store/oauth/store";
-import { EPlayerWarningSeverity, EPlayerWarningStatus, type CreatePlayerWarningRequest, type PlayerWarning } from "@/store/admin/types";
+import { EPlayerWarningSeverity, EPlayerWarningStatus, type CreatePlayerWarningRequest, type PlayerWarning, type PlayerWarningDefinition, type PlayerWarningTranslations } from "@/store/admin/types";
 import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiInformationOutline } from "@mdi/js";
 
 type StatusFilter = EPlayerWarningStatus | "";
@@ -166,6 +227,9 @@ type VuetifyTableUpdateOptions = {
   page: number;
   itemsPerPage: number;
 };
+
+const DEFAULT_PREVIEW_LOCALE = "en";
+const CUSTOM_WARNING_OPTION = "__custom";
 
 export default defineComponent({
   name: "AdminWarnings",
@@ -175,20 +239,25 @@ export default defineComponent({
   setup() {
     const oauthStore = useOauthStore();
     const warnings = ref<PlayerWarning[]>([]);
+    const warningDefinitions = ref<PlayerWarningDefinition[]>([]);
     const total = ref<number>(0);
     const loading = ref<boolean>(false);
+    const definitionsLoading = ref<boolean>(false);
     const saving = ref<boolean>(false);
     const errorMessage = ref<string>("");
     const selectedBattleTag = ref<string>("");
     const statusFilter = ref<StatusFilter>("");
+    const selectedWarningOption = ref<string>(CUSTOM_WARNING_OPTION);
+    const previewLocale = ref<string>(DEFAULT_PREVIEW_LOCALE);
+    const customSeverity = ref<EPlayerWarningSeverity>(EPlayerWarningSeverity.Warning);
+    const customTitle = ref<string>("");
+    const customBody = ref<string>("");
     const createDialogOpen = ref<boolean>(false);
     const tableOptions = ref<VuetifyTableUpdateOptions>({ page: 1, itemsPerPage: 25 });
 
     const createForm = reactive<CreatePlayerWarningRequest>({
       targetBattleTag: "",
-      severity: EPlayerWarningSeverity.Warning,
-      title: { en: "" },
-      body: { en: "" },
+      warningDefinitionId: undefined,
     });
 
     const headers = [
@@ -206,16 +275,65 @@ export default defineComponent({
       ...Object.values(EPlayerWarningStatus).map((status) => ({ title: status, value: status })),
     ];
 
+    const previewLocaleItems = [
+      { title: "English", value: "en" },
+      { title: "Deutsch", value: "de" },
+      { title: "Français", value: "fr" },
+      { title: "한국어", value: "kr" },
+      { title: "Polski", value: "pl" },
+      { title: "Português", value: "pt" },
+      { title: "Русский", value: "ru" },
+      { title: "Srpski", value: "sr" },
+      { title: "Українська", value: "ua" },
+      { title: "中文", value: "zh" },
+    ];
+
     const severityItems = [
       { title: "Info", value: EPlayerWarningSeverity.Info, color: "success", icon: mdiInformationOutline },
       { title: "Warning", value: EPlayerWarningSeverity.Warning, color: "warning", icon: mdiAlertCircleOutline },
       { title: "Critical", value: EPlayerWarningSeverity.Critical, color: "error", icon: mdiAlertOctagonOutline },
     ];
 
+    const definitionItems = computed(() => [
+      { title: "Custom", value: CUSTOM_WARNING_OPTION },
+      ...warningDefinitions.value.map((definition) => ({
+        title: `${getDefinitionText(definition.title, DEFAULT_PREVIEW_LOCALE)} (${definition.severity})`,
+        value: definition._id,
+      })),
+    ]);
+
+    const isCustomWarning = computed<boolean>(() => selectedWarningOption.value === CUSTOM_WARNING_OPTION);
+
+    const selectedDefinition = computed<PlayerWarningDefinition | undefined>(() =>
+      warningDefinitions.value.find((definition) => definition._id === selectedWarningOption.value)
+    );
+
+    const previewSeverity = computed<EPlayerWarningSeverity>(() =>
+      selectedDefinition.value?.severity ?? customSeverity.value
+    );
+
+    const previewTitle = computed<string>(() =>
+      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.title, previewLocale.value) : customTitle.value.trim()
+    );
+
+    const previewBody = computed<string>(() =>
+      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.body, previewLocale.value) : customBody.value.trim()
+    );
+
+    const titleFieldValue = computed<string>(() =>
+      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.title, DEFAULT_PREVIEW_LOCALE) : customTitle.value
+    );
+
+    const bodyFieldValue = computed<string>(() =>
+      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.body, DEFAULT_PREVIEW_LOCALE) : customBody.value
+    );
+
     const canCreate = computed<boolean>(() =>
       !!createForm.targetBattleTag
-      && !!createForm.title.en.trim()
-      && !!createForm.body.en.trim()
+      && (
+        !!selectedDefinition.value
+        || (isCustomWarning.value && !!customTitle.value.trim() && !!customBody.value.trim())
+      )
     );
 
     async function loadWarnings(): Promise<void> {
@@ -239,6 +357,18 @@ export default defineComponent({
       }
     }
 
+    async function loadWarningDefinitions(): Promise<void> {
+      definitionsLoading.value = true;
+      try {
+        warningDefinitions.value = await AdminService.getWarningDefinitions(oauthStore.token);
+      } catch (error) {
+        warningDefinitions.value = [];
+        errorMessage.value = getErrorMessage(error);
+      } finally {
+        definitionsLoading.value = false;
+      }
+    }
+
     function onTableOptionsUpdate(options: VuetifyTableUpdateOptions): void {
       tableOptions.value = {
         page: options.page > 0 ? options.page : 1,
@@ -259,11 +389,18 @@ export default defineComponent({
       createForm.targetBattleTag = battleTag;
     }
 
-    function openCreateDialog(): void {
+    async function openCreateDialog(): Promise<void> {
+      if (warningDefinitions.value.length === 0) {
+        await loadWarningDefinitions();
+      }
+
       createForm.targetBattleTag = selectedBattleTag.value;
-      createForm.severity = EPlayerWarningSeverity.Warning;
-      createForm.title = { en: "" };
-      createForm.body = { en: "" };
+      selectedWarningOption.value = CUSTOM_WARNING_OPTION;
+      createForm.warningDefinitionId = undefined;
+      customSeverity.value = EPlayerWarningSeverity.Warning;
+      customTitle.value = "";
+      customBody.value = "";
+      previewLocale.value = DEFAULT_PREVIEW_LOCALE;
       createDialogOpen.value = true;
     }
 
@@ -273,12 +410,19 @@ export default defineComponent({
       saving.value = true;
       errorMessage.value = "";
       try {
-        await AdminService.createWarning(oauthStore.token, {
+        const request: CreatePlayerWarningRequest = {
           targetBattleTag: createForm.targetBattleTag,
-          severity: createForm.severity,
-          title: { en: createForm.title.en.trim() },
-          body: { en: createForm.body.en.trim() },
-        });
+        };
+
+        if (selectedDefinition.value) {
+          request.warningDefinitionId = selectedDefinition.value._id;
+        } else {
+          request.severity = customSeverity.value;
+          request.title = { en: customTitle.value.trim() };
+          request.body = { en: customBody.value.trim() };
+        }
+
+        await AdminService.createWarning(oauthStore.token, request);
         createDialogOpen.value = false;
         await loadWarnings();
       } catch (error) {
@@ -341,6 +485,10 @@ export default defineComponent({
       return value ? new Date(value).toLocaleString() : "";
     }
 
+    function getDefinitionText(translations: PlayerWarningTranslations, locale: string): string {
+      return translations[locale] || translations.en || Object.values(translations).find(Boolean) || "";
+    }
+
     function getErrorMessage(error: unknown): string {
       return error instanceof Error ? error.message : "Something went wrong.";
     }
@@ -350,22 +498,40 @@ export default defineComponent({
       loadWarnings();
     });
 
-    onMounted(loadWarnings);
+    onMounted(async () => {
+      await Promise.all([loadWarnings(), loadWarningDefinitions()]);
+    });
 
     return {
       warnings,
+      warningDefinitions,
       total,
       loading,
+      definitionsLoading,
       saving,
       errorMessage,
       selectedBattleTag,
       statusFilter,
+      selectedWarningOption,
+      previewLocale,
+      customSeverity,
+      customTitle,
+      customBody,
       createDialogOpen,
       tableOptions,
       createForm,
       headers,
       statusItems,
       severityItems,
+      previewLocaleItems,
+      definitionItems,
+      isCustomWarning,
+      selectedDefinition,
+      previewSeverity,
+      previewTitle,
+      previewBody,
+      titleFieldValue,
+      bodyFieldValue,
       canCreate,
       onTableOptionsUpdate,
       onPlayerFound,
@@ -379,19 +545,24 @@ export default defineComponent({
       severityColor,
       severityIcon,
       formatDate,
+      getDefinitionText,
     };
   },
 });
 </script>
 
 <style scoped>
-.warning-severity-toggle {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  width: 100%;
+.warning-preview {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.65);
 }
 
-.warning-severity-button {
-  min-height: 56px;
+.warning-preview-title {
+  line-height: 1.35;
+}
+
+.warning-preview-body {
+  line-height: 1.55;
+  white-space: pre-line;
 }
 </style>

--- a/src/components/admin/AdminWarnings.vue
+++ b/src/components/admin/AdminWarnings.vue
@@ -427,6 +427,8 @@ export default defineComponent({
           return "success";
         case EPlayerWarningStatus.Cancelled:
           return "medium-emphasis";
+        case EPlayerWarningStatus.Undeliverable:
+          return "error";
         case EPlayerWarningStatus.Sent:
           return "info";
         default:
@@ -467,6 +469,10 @@ export default defineComponent({
 
       if (warning.cancelledAt) {
         return `Cancelled ${formatDate(warning.cancelledAt)}`;
+      }
+
+      if (warning.undeliverableAt) {
+        return `Undeliverable ${formatDate(warning.undeliverableAt)}`;
       }
 
       return "Waiting";

--- a/src/components/admin/AdminWarnings.vue
+++ b/src/components/admin/AdminWarnings.vue
@@ -9,6 +9,7 @@
         <player-search
           search-label="Search player"
           @playerFound="onPlayerFound"
+          @searchRequested="onPlayerFound"
           @searchCleared="onPlayerSearchCleared"
         />
       </div>
@@ -25,6 +26,10 @@
         hide-details
       />
       <v-spacer />
+      <v-btn variant="text" :loading="loading" @click="loadWarnings">
+        <v-icon start>{{ mdiRefresh }}</v-icon>
+        Refresh
+      </v-btn>
       <v-btn class="bg-primary text-w3-race-bg" @click="openCreateDialog">
         New warning
       </v-btn>
@@ -56,8 +61,10 @@
       @update:options="onTableOptionsUpdate"
     >
       <template v-slot:item.title="{ item }">
-        <div class="font-weight-medium">{{ getDefinitionText(item.title, "en") }}</div>
-        <div class="text-medium-emphasis text-caption">{{ getDefinitionText(item.body, "en") }}</div>
+        <div class="warning-summary">
+          <div class="font-weight-medium warning-summary-title">{{ getDefinitionText(item.title, "en") }}</div>
+          <div class="text-medium-emphasis text-caption warning-summary-body">{{ getDefinitionText(item.body, "en") }}</div>
+        </div>
       </template>
 
       <template v-slot:item.status="{ item }">
@@ -74,7 +81,20 @@
       </template>
 
       <template v-slot:item.createdAt="{ item }">
-        {{ formatDate(item.createdAt) }}
+        <div class="warning-timeline">
+          <div>
+            <span class="text-medium-emphasis">Created:</span>
+            {{ formatDate(item.createdAt) }}
+          </div>
+          <div>
+            <span class="text-medium-emphasis">Sent:</span>
+            {{ item.sentAt ? formatDate(item.sentAt) : "Not yet" }}
+          </div>
+          <div>
+            <span class="text-medium-emphasis">Ack:</span>
+            {{ acknowledgementText(item) }}
+          </div>
+        </div>
       </template>
 
       <template v-slot:item.actions="{ item }">
@@ -109,7 +129,7 @@
               </div>
             </v-col>
 
-            <v-col cols="12" md="7">
+            <v-col cols="12">
               <v-select
                 v-model="selectedWarningOption"
                 :items="definitionItems"
@@ -122,22 +142,9 @@
               />
             </v-col>
 
-            <v-col cols="12" md="5">
-              <v-select
-                v-model="previewLocale"
-                :items="previewLocaleItems"
-                item-title="title"
-                item-value="value"
-                label="Preview language"
-                variant="underlined"
-                color="primary"
-                :disabled="isCustomWarning"
-              />
-            </v-col>
-
             <v-col cols="12" md="4">
               <v-select
-                v-model="customSeverity"
+                :model-value="previewSeverity"
                 :items="severityItems"
                 item-title="title"
                 item-value="value"
@@ -145,6 +152,7 @@
                 variant="underlined"
                 color="primary"
                 :disabled="!isCustomWarning"
+                @update:model-value="customSeverity = $event as EPlayerWarningSeverity"
               >
                 <template v-slot:item="{ props, item }">
                   <v-list-item v-bind="props">
@@ -178,23 +186,6 @@
                 @update:model-value="customBody = String($event)"
               />
             </v-col>
-
-            <v-col cols="12">
-              <v-sheet class="warning-preview pa-4" rounded>
-                <div>
-                  <v-chip :color="severityColor(previewSeverity)" variant="tonal" size="small">
-                    <v-icon start size="small">{{ severityIcon(previewSeverity) }}</v-icon>
-                    {{ previewSeverity }}
-                  </v-chip>
-                  <div class="text-h6 mt-3 mb-2 warning-preview-title">
-                    {{ previewTitle || "Title preview" }}
-                  </div>
-                  <div class="warning-preview-body">
-                    {{ previewBody || "Message preview" }}
-                  </div>
-                </div>
-              </v-sheet>
-            </v-col>
           </v-row>
         </v-card-text>
         <v-card-actions>
@@ -220,7 +211,7 @@ import PlayerSearch from "@/components/common/PlayerSearch.vue";
 import AdminService from "@/services/admin/AdminService";
 import { useOauthStore } from "@/store/oauth/store";
 import { EPlayerWarningSeverity, EPlayerWarningStatus, type CreatePlayerWarningRequest, type PlayerWarning, type PlayerWarningDefinition, type PlayerWarningTranslations } from "@/store/admin/types";
-import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiInformationOutline } from "@mdi/js";
+import { mdiAlertCircleOutline, mdiAlertOctagonOutline, mdiInformationOutline, mdiRefresh } from "@mdi/js";
 
 type StatusFilter = EPlayerWarningStatus | "";
 type VuetifyTableUpdateOptions = {
@@ -248,7 +239,6 @@ export default defineComponent({
     const selectedBattleTag = ref<string>("");
     const statusFilter = ref<StatusFilter>("");
     const selectedWarningOption = ref<string>(CUSTOM_WARNING_OPTION);
-    const previewLocale = ref<string>(DEFAULT_PREVIEW_LOCALE);
     const customSeverity = ref<EPlayerWarningSeverity>(EPlayerWarningSeverity.Warning);
     const customTitle = ref<string>("");
     const customBody = ref<string>("");
@@ -261,31 +251,18 @@ export default defineComponent({
     });
 
     const headers = [
-      { title: "Player", key: "targetBattleTag", sortable: false },
-      { title: "Warning", key: "title", sortable: false },
+      { title: "Player", key: "targetBattleTag", sortable: false, width: "18%" },
+      { title: "Warning", key: "title", sortable: false, width: "34%" },
       { title: "Severity", key: "severity", sortable: false },
       { title: "Status", key: "status", sortable: false },
       { title: "Issued By", key: "issuedByBattleTag", sortable: false },
-      { title: "Created", key: "createdAt", sortable: false },
+      { title: "Timeline", key: "createdAt", sortable: false, width: "22%" },
       { title: "", key: "actions", sortable: false },
     ];
 
     const statusItems = [
       { title: "All", value: "" },
       ...Object.values(EPlayerWarningStatus).map((status) => ({ title: status, value: status })),
-    ];
-
-    const previewLocaleItems = [
-      { title: "English", value: "en" },
-      { title: "Deutsch", value: "de" },
-      { title: "Français", value: "fr" },
-      { title: "한국어", value: "kr" },
-      { title: "Polski", value: "pl" },
-      { title: "Português", value: "pt" },
-      { title: "Русский", value: "ru" },
-      { title: "Srpski", value: "sr" },
-      { title: "Українська", value: "ua" },
-      { title: "中文", value: "zh" },
     ];
 
     const severityItems = [
@@ -312,14 +289,6 @@ export default defineComponent({
       selectedDefinition.value?.severity ?? customSeverity.value
     );
 
-    const previewTitle = computed<string>(() =>
-      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.title, previewLocale.value) : customTitle.value.trim()
-    );
-
-    const previewBody = computed<string>(() =>
-      selectedDefinition.value ? getDefinitionText(selectedDefinition.value.body, previewLocale.value) : customBody.value.trim()
-    );
-
     const titleFieldValue = computed<string>(() =>
       selectedDefinition.value ? getDefinitionText(selectedDefinition.value.title, DEFAULT_PREVIEW_LOCALE) : customTitle.value
     );
@@ -336,24 +305,31 @@ export default defineComponent({
       )
     );
 
+    let loadWarningsRequestId = 0;
+
     async function loadWarnings(): Promise<void> {
+      const requestId = ++loadWarningsRequestId;
       loading.value = true;
       errorMessage.value = "";
       try {
         const result = await AdminService.getWarnings(oauthStore.token, {
           page: tableOptions.value.page,
           itemsPerPage: tableOptions.value.itemsPerPage,
-          battleTag: selectedBattleTag.value,
+          battleTag: selectedBattleTag.value.trim(),
           status: statusFilter.value,
         });
+        if (requestId !== loadWarningsRequestId) return;
         warnings.value = result.warnings;
         total.value = result.total;
       } catch (error) {
+        if (requestId !== loadWarningsRequestId) return;
         warnings.value = [];
         total.value = 0;
         errorMessage.value = getErrorMessage(error);
       } finally {
-        loading.value = false;
+        if (requestId === loadWarningsRequestId) {
+          loading.value = false;
+        }
       }
     }
 
@@ -378,7 +354,7 @@ export default defineComponent({
     }
 
     function onPlayerFound(battleTag: string): void {
-      selectedBattleTag.value = battleTag;
+      selectedBattleTag.value = battleTag.trim();
     }
 
     function onPlayerSearchCleared(): void {
@@ -400,7 +376,6 @@ export default defineComponent({
       customSeverity.value = EPlayerWarningSeverity.Warning;
       customTitle.value = "";
       customBody.value = "";
-      previewLocale.value = DEFAULT_PREVIEW_LOCALE;
       createDialogOpen.value = true;
     }
 
@@ -485,8 +460,23 @@ export default defineComponent({
       return value ? new Date(value).toLocaleString() : "";
     }
 
+    function acknowledgementText(warning: PlayerWarning): string {
+      if (warning.acknowledgedAt) {
+        return formatDate(warning.acknowledgedAt);
+      }
+
+      if (warning.cancelledAt) {
+        return `Cancelled ${formatDate(warning.cancelledAt)}`;
+      }
+
+      return "Waiting";
+    }
+
     function getDefinitionText(translations: PlayerWarningTranslations, locale: string): string {
-      return translations[locale] || translations.en || Object.values(translations).find(Boolean) || "";
+      return translations[locale]?.trim()
+        || translations.en?.trim()
+        || Object.values(translations).find((value) => !!value?.trim())
+        || "";
     }
 
     function getErrorMessage(error: unknown): string {
@@ -513,7 +503,6 @@ export default defineComponent({
       selectedBattleTag,
       statusFilter,
       selectedWarningOption,
-      previewLocale,
       customSeverity,
       customTitle,
       customBody,
@@ -523,16 +512,15 @@ export default defineComponent({
       headers,
       statusItems,
       severityItems,
-      previewLocaleItems,
       definitionItems,
       isCustomWarning,
       selectedDefinition,
       previewSeverity,
-      previewTitle,
-      previewBody,
       titleFieldValue,
       bodyFieldValue,
       canCreate,
+      mdiRefresh,
+      loadWarnings,
       onTableOptionsUpdate,
       onPlayerFound,
       onPlayerSearchCleared,
@@ -545,6 +533,7 @@ export default defineComponent({
       severityColor,
       severityIcon,
       formatDate,
+      acknowledgementText,
       getDefinitionText,
     };
   },
@@ -552,17 +541,27 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.warning-preview {
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  background: rgba(255, 255, 255, 0.65);
+.warning-summary {
+  max-width: min(380px, 34vw);
 }
 
-.warning-preview-title {
+.warning-summary-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.warning-summary-body {
+  display: -webkit-box;
   line-height: 1.35;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
-.warning-preview-body {
-  line-height: 1.55;
-  white-space: pre-line;
+.warning-timeline {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  min-width: 190px;
 }
 </style>

--- a/src/components/admin/warnings/warningLocaleItems.ts
+++ b/src/components/admin/warnings/warningLocaleItems.ts
@@ -1,0 +1,15 @@
+export const warningLocaleItems = [
+  { title: "English", value: "en" },
+  { title: "Deutsch", value: "de" },
+  { title: "Español (EU)", value: "es-ES" },
+  { title: "Español (AL)", value: "es-419" },
+  { title: "Français", value: "fr" },
+  { title: "Italiano", value: "it" },
+  { title: "Polski", value: "pl" },
+  { title: "Português (BR)", value: "pt-BR" },
+  { title: "Português (PT)", value: "pt-PT" },
+  { title: "한국어", value: "ko" },
+  { title: "Русский", value: "ru" },
+  { title: "简体中文", value: "zh-CN" },
+  { title: "繁體中文", value: "zh-TW" },
+] as const;

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -26,6 +26,8 @@
       autocomplete="off"
       clearable
       @click:clear="clearSearch"
+      @click:append-inner="submitSearch"
+      @keydown.enter.prevent="submitSearch"
     />
   </div>
 </template>
@@ -95,6 +97,16 @@ export default defineComponent({
       context.emit("playerFound", btag);
     }
 
+    function submitSearch(): void {
+      const searchValue = (input.value || selected.value || "").trim();
+      if (!searchValue) {
+        clearSearch();
+        return;
+      }
+
+      context.emit("searchRequested", searchValue);
+    }
+
     watch(input, onInput);
 
     function onInput(val: string): void {
@@ -130,6 +142,7 @@ export default defineComponent({
       isLoading,
       searchedPlayers,
       clearSearch,
+      submitSearch,
     };
   },
 });

--- a/src/locales/clientLocaleItems.ts
+++ b/src/locales/clientLocaleItems.ts
@@ -1,4 +1,4 @@
-export const warningLocaleItems = [
+export const clientLocaleItems = [
   { title: "English", value: "en" },
   { title: "Deutsch", value: "de" },
   { title: "Español (EU)", value: "es-ES" },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,6 +38,7 @@ import AdminSmurfs from "@/components/admin/AdminSmurfs.vue";
 import AdminSmurfManageIdentifiers from "@/components/admin/AdminSmurfManageIdentifiers.vue";
 import AdminGlobalMute from "@/components/admin/AdminGlobalMute.vue";
 import AdminLoungeMute from "@/components/admin/AdminLoungeMute.vue";
+import AdminWarnings from "@/components/admin/AdminWarnings.vue";
 import AdminViewGameChat from "@/components/admin/AdminViewGameChat.vue";
 import AdminProxies from "@/components/admin/AdminProxies.vue";
 import AdminNewsForLauncher from "@/components/admin/AdminNewsForLauncher.vue";
@@ -271,6 +272,7 @@ const routes: RouteRecordRaw[] = [
       { path: "admin-smurfs-manage-identifiers", name: EAdminRouteName.SMURF_CHECKER_MANAGE_IDENTIFIERS, component: AdminSmurfManageIdentifiers },
       { path: "admin-global-mute", name: EAdminRouteName.GLOBAL_MUTE, component: AdminGlobalMute },
       { path: "admin-lounge-mute", name: EAdminRouteName.LOUNGE_MUTE, component: AdminLoungeMute },
+      { path: "admin-warnings", name: EAdminRouteName.PLAYER_WARNINGS, component: AdminWarnings },
       { path: "admin-view-game-chat", name: EAdminRouteName.VIEW_GAME_CHAT, component: AdminViewGameChat },
       { path: "admin-launcher-chat", name: EAdminRouteName.LAUNCHER_CHAT, component: AdminLauncherChat },
       { path: "admin-proxies", name: EAdminRouteName.PROXY_SETTINGS, component: AdminProxies },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,6 +39,7 @@ import AdminSmurfManageIdentifiers from "@/components/admin/AdminSmurfManageIden
 import AdminGlobalMute from "@/components/admin/AdminGlobalMute.vue";
 import AdminLoungeMute from "@/components/admin/AdminLoungeMute.vue";
 import AdminWarnings from "@/components/admin/AdminWarnings.vue";
+import AdminWarningTemplates from "@/components/admin/AdminWarningTemplates.vue";
 import AdminViewGameChat from "@/components/admin/AdminViewGameChat.vue";
 import AdminProxies from "@/components/admin/AdminProxies.vue";
 import AdminNewsForLauncher from "@/components/admin/AdminNewsForLauncher.vue";
@@ -273,6 +274,7 @@ const routes: RouteRecordRaw[] = [
       { path: "admin-global-mute", name: EAdminRouteName.GLOBAL_MUTE, component: AdminGlobalMute },
       { path: "admin-lounge-mute", name: EAdminRouteName.LOUNGE_MUTE, component: AdminLoungeMute },
       { path: "admin-warnings", name: EAdminRouteName.PLAYER_WARNINGS, component: AdminWarnings },
+      { path: "admin-warning-templates", name: EAdminRouteName.WARNING_TEMPLATES, component: AdminWarningTemplates },
       { path: "admin-view-game-chat", name: EAdminRouteName.VIEW_GAME_CHAT, component: AdminViewGameChat },
       { path: "admin-launcher-chat", name: EAdminRouteName.LAUNCHER_CHAT, component: AdminLauncherChat },
       { path: "admin-proxies", name: EAdminRouteName.PROXY_SETTINGS, component: AdminProxies },

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -8,6 +8,7 @@ export enum EAdminRouteName {
   GLOBAL_MUTE = "Admin - Global Mute",
   LOUNGE_MUTE = "Admin - Lounge Mute",
   PLAYER_WARNINGS = "Admin - Player Warnings",
+  WARNING_TEMPLATES = "Admin - Warning Templates",
   VIEW_GAME_CHAT = "Admin - View Game Chat",
   LAUNCHER_CHAT = "Admin - Launcher Game Chat",
   PROXY_SETTINGS = "Admin - Proxy Settings",

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -7,6 +7,7 @@ export enum EAdminRouteName {
   SMURF_CHECKER_MANAGE_IDENTIFIERS = "Admin - Manage Identifiers",
   GLOBAL_MUTE = "Admin - Global Mute",
   LOUNGE_MUTE = "Admin - Lounge Mute",
+  PLAYER_WARNINGS = "Admin - Player Warnings",
   VIEW_GAME_CHAT = "Admin - View Game Chat",
   LAUNCHER_CHAT = "Admin - Launcher Game Chat",
   PROXY_SETTINGS = "Admin - Proxy Settings",

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -1,5 +1,5 @@
 import { API_URL } from "@/main";
-import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreatePlayerWarningRequest, CreatePlayerWarningResponse, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PlayerWarning, PlayerWarningDefinition, PlayerWarningsGetRequest, PlayerWarningsResponse, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
+import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreatePlayerWarningRequest, CreatePlayerWarningResponse, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PlayerWarning, PlayerWarningDefinition, PlayerWarningDefinitionRequest, PlayerWarningsGetRequest, PlayerWarningsResponse, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
 import { authorizedFetch } from "@/helpers/general";
 import { SmurfDetectionResult } from "./smurf-detection/SmurfDetectionResponse";
 
@@ -52,11 +52,38 @@ export default class AdminService {
     return await response.json();
   }
 
-  public static async getWarningDefinitions(token: string): Promise<PlayerWarningDefinition[]> {
-    const url = `${API_URL}api/admin/warning-definitions`;
+  public static async getWarningDefinitions(token: string, includeDisabled = false): Promise<PlayerWarningDefinition[]> {
+    const url = `${API_URL}api/admin/warning-definitions${includeDisabled ? "?includeDisabled=true" : ""}`;
     const response = await authorizedFetch("GET", url, token);
     if (!response.ok) {
       throw new Error(await getAdminErrorMessage(response, "Failed to load warning templates."));
+    }
+    return await response.json();
+  }
+
+  public static async createWarningDefinition(token: string, warningDefinition: PlayerWarningDefinitionRequest): Promise<PlayerWarningDefinition> {
+    const url = `${API_URL}api/admin/warning-definitions`;
+    const response = await authorizedFetch("POST", url, token, JSON.stringify(warningDefinition));
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to create warning template."));
+    }
+    return await response.json();
+  }
+
+  public static async updateWarningDefinition(token: string, id: string, warningDefinition: PlayerWarningDefinitionRequest): Promise<PlayerWarningDefinition> {
+    const url = `${API_URL}api/admin/warning-definitions/${encodeURIComponent(id)}`;
+    const response = await authorizedFetch("PUT", url, token, JSON.stringify(warningDefinition));
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to update warning template."));
+    }
+    return await response.json();
+  }
+
+  public static async deleteWarningDefinition(token: string, id: string): Promise<PlayerWarningDefinition> {
+    const url = `${API_URL}api/admin/warning-definitions/${encodeURIComponent(id)}`;
+    const response = await authorizedFetch("DELETE", url, token);
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to disable warning template."));
     }
     return await response.json();
   }

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -1,5 +1,5 @@
 import { API_URL } from "@/main";
-import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreatePlayerWarningRequest, CreatePlayerWarningResponse, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PlayerWarning, PlayerWarningsGetRequest, PlayerWarningsResponse, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
+import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreatePlayerWarningRequest, CreatePlayerWarningResponse, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PlayerWarning, PlayerWarningDefinition, PlayerWarningsGetRequest, PlayerWarningsResponse, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
 import { authorizedFetch } from "@/helpers/general";
 import { SmurfDetectionResult } from "./smurf-detection/SmurfDetectionResponse";
 
@@ -48,6 +48,15 @@ export default class AdminService {
     const response = await authorizedFetch("POST", url, token, JSON.stringify(warning));
     if (!response.ok) {
       throw new Error(await getAdminErrorMessage(response, "Failed to create warning."));
+    }
+    return await response.json();
+  }
+
+  public static async getWarningDefinitions(token: string): Promise<PlayerWarningDefinition[]> {
+    const url = `${API_URL}api/admin/warning-definitions`;
+    const response = await authorizedFetch("GET", url, token);
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to load warning templates."));
     }
     return await response.json();
   }

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -1,5 +1,5 @@
 import { API_URL } from "@/main";
-import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
+import { BannedPlayer, BannedPlayersGetRequest, BannedPlayersResponse, BanReasonTranslation, ChangePortraitsCommand, ChangePortraitsDto, CreateBanReasonTranslationRequest, CreatePlayerWarningRequest, CreatePlayerWarningResponse, CreateRewardRequest, DriftDetectionResult, DriftSyncResult, GlobalChatBanResponse, GloballyMutedPlayer, GlobalMute, ModuleDefinition, PaginatedAssignments, PatreonAccountLink, PatreonMemberDetails, PlayerWarning, PlayerWarningsGetRequest, PlayerWarningsResponse, PortraitDefinition, PortraitDefinitionDTO, PortraitDefinitionGroup, ProductMapping, ProductMappingUsersResponse, ProviderConfiguration, Proxy, ProxySettings, QueueData, ReconciliationResult, ReplayChatLog, Reward, RewardAssignment, SearchedPlayer, UpdateBanReasonTranslationRequest, UpdateRewardRequest } from "@/store/admin/types";
 import { authorizedFetch } from "@/helpers/general";
 import { SmurfDetectionResult } from "./smurf-detection/SmurfDetectionResponse";
 
@@ -23,6 +23,42 @@ export default class AdminService {
     const url = `${API_URL}api/admin/bannedPlayers`;
     const response = await authorizedFetch("POST", url, token, JSON.stringify(bannedPlayer));
     return response.ok ? "" : await response.json();
+  }
+
+  public static async getWarnings(token: string, req: PlayerWarningsGetRequest): Promise<PlayerWarningsResponse> {
+    let url = `${API_URL}api/admin/warnings?page=${req.page}&itemsPerPage=${req.itemsPerPage}`;
+
+    if (req.battleTag) {
+      url += `&battleTag=${encodeURIComponent(req.battleTag)}`;
+    }
+
+    if (req.status) {
+      url += `&status=${encodeURIComponent(req.status)}`;
+    }
+
+    const response = await authorizedFetch("GET", url, token);
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to load warnings."));
+    }
+    return await response.json();
+  }
+
+  public static async createWarning(token: string, warning: CreatePlayerWarningRequest): Promise<CreatePlayerWarningResponse> {
+    const url = `${API_URL}api/admin/warnings`;
+    const response = await authorizedFetch("POST", url, token, JSON.stringify(warning));
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to create warning."));
+    }
+    return await response.json();
+  }
+
+  public static async cancelWarning(token: string, warningId: string): Promise<PlayerWarning> {
+    const url = `${API_URL}api/admin/warnings/${encodeURIComponent(warningId)}/cancel`;
+    const response = await authorizedFetch("POST", url, token);
+    if (!response.ok) {
+      throw new Error(await getAdminErrorMessage(response, "Failed to cancel warning."));
+    }
+    return await response.json();
   }
 
   public static async getBanReasonTranslations(token: string): Promise<BanReasonTranslation[]> {
@@ -421,4 +457,9 @@ export default class AdminService {
     const data = await response.json();
     return data.globalChatBans || [];
   }
+}
+
+async function getAdminErrorMessage(response: Response, fallback: string): Promise<string> {
+  const body = await response.text();
+  return body || `${fallback} (${response.status})`;
 }

--- a/src/store/admin/permission/types.ts
+++ b/src/store/admin/permission/types.ts
@@ -20,6 +20,7 @@ export enum EPermission {
   Tournaments,
   Content,
   Proxies,
+  Warnings,
   SmurfCheckerQuery,
   SmurfCheckerQueryExplanation,
   SmurfCheckerAdministration,

--- a/src/store/admin/permission/types.ts
+++ b/src/store/admin/permission/types.ts
@@ -12,16 +12,16 @@ export interface IPermission {
 }
 
 export enum EPermission {
-  Permissions,
-  Moderation,
-  Queue,
-  Logs,
-  Maps,
-  Tournaments,
-  Content,
-  Proxies,
-  Warnings,
-  SmurfCheckerQuery,
-  SmurfCheckerQueryExplanation,
-  SmurfCheckerAdministration,
+  Permissions = 0,
+  Moderation = 1,
+  Queue = 2,
+  Logs = 3,
+  Maps = 4,
+  Tournaments = 5,
+  Content = 6,
+  Proxies = 7,
+  SmurfCheckerQuery = 8,
+  SmurfCheckerQueryExplanation = 9,
+  SmurfCheckerAdministration = 10,
+  Warnings = 11,
 }

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -127,8 +127,6 @@ export type PlayerWarning = {
   targetBattleTag: string;
   issuedByBattleTag: string;
   warningDefinitionId?: string;
-  rule?: string;
-  category?: string;
   severity: EPlayerWarningSeverity;
   title: PlayerWarningTranslations;
   body: PlayerWarningTranslations;
@@ -167,6 +165,16 @@ export type PlayerWarningDefinition = {
   body: PlayerWarningTranslations;
   enabled: boolean;
   sortOrder: number;
+  createdByBattleTag?: string;
+  updatedByBattleTag?: string;
+};
+
+export type PlayerWarningDefinitionRequest = {
+  severity: EPlayerWarningSeverity;
+  title: PlayerWarningTranslations;
+  body: PlayerWarningTranslations;
+  enabled: boolean;
+  sortOrder?: number;
 };
 
 export type CreatePlayerWarningResponse = {

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -104,6 +104,67 @@ export interface BannedPlayersResponse {
   players: BannedPlayer[];
 }
 
+export enum EPlayerWarningStatus {
+  Pending = "Pending",
+  Sent = "Sent",
+  Acknowledged = "Acknowledged",
+  Cancelled = "Cancelled",
+}
+
+export enum EPlayerWarningSeverity {
+  Info = "Info",
+  Warning = "Warning",
+  Critical = "Critical",
+}
+
+export type PlayerWarningTranslations = {
+  en: string;
+  [locale: string]: string;
+};
+
+export type PlayerWarning = {
+  _id: string;
+  targetBattleTag: string;
+  issuedByBattleTag: string;
+  rule?: string;
+  category?: string;
+  severity: EPlayerWarningSeverity;
+  title: PlayerWarningTranslations;
+  body: PlayerWarningTranslations;
+  status: EPlayerWarningStatus;
+  createdAt: string;
+  sentAt?: string;
+  acknowledgedAt?: string;
+  cancelledAt?: string;
+  cancelledByBattleTag?: string;
+};
+
+export type PlayerWarningsGetRequest = {
+  page: number;
+  itemsPerPage: number;
+  battleTag?: string;
+  status?: EPlayerWarningStatus | "";
+};
+
+export type PlayerWarningsResponse = {
+  total: number;
+  warnings: PlayerWarning[];
+};
+
+export type CreatePlayerWarningRequest = {
+  targetBattleTag: string;
+  rule?: string;
+  category?: string;
+  severity?: EPlayerWarningSeverity;
+  title: PlayerWarningTranslations;
+  body: PlayerWarningTranslations;
+};
+
+export type CreatePlayerWarningResponse = {
+  warning: PlayerWarning;
+  delivered: boolean;
+};
+
 export interface AdminNavigationItem {
   title: string;
   icon?: string;

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -126,6 +126,7 @@ export type PlayerWarning = {
   _id: string;
   targetBattleTag: string;
   issuedByBattleTag: string;
+  warningDefinitionId?: string;
   rule?: string;
   category?: string;
   severity: EPlayerWarningSeverity;
@@ -153,11 +154,19 @@ export type PlayerWarningsResponse = {
 
 export type CreatePlayerWarningRequest = {
   targetBattleTag: string;
-  rule?: string;
-  category?: string;
+  warningDefinitionId?: string;
   severity?: EPlayerWarningSeverity;
+  title?: PlayerWarningTranslations;
+  body?: PlayerWarningTranslations;
+};
+
+export type PlayerWarningDefinition = {
+  _id: string;
+  severity: EPlayerWarningSeverity;
   title: PlayerWarningTranslations;
   body: PlayerWarningTranslations;
+  enabled: boolean;
+  sortOrder: number;
 };
 
 export type CreatePlayerWarningResponse = {

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -109,6 +109,7 @@ export enum EPlayerWarningStatus {
   Sent = "Sent",
   Acknowledged = "Acknowledged",
   Cancelled = "Cancelled",
+  Undeliverable = "Undeliverable",
 }
 
 export enum EPlayerWarningSeverity {
@@ -136,6 +137,8 @@ export type PlayerWarning = {
   acknowledgedAt?: string;
   cancelledAt?: string;
   cancelledByBattleTag?: string;
+  undeliverableAt?: string;
+  undeliverableReason?: string;
 };
 
 export type PlayerWarningsGetRequest = {


### PR DESCRIPTION
Adds admin pages for sending player warnings and managing reusable warning templates.

Admins can search a player, pick a template or custom warning, send it, then track sent, acknowledged, and cancelled status.

Templates can be edited per locale with English fallback.
