### PR TITLE
feat(ranking): add progression rank fields to Ranking + ModeStat types (P11-2)

### DIFF
--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -17,9 +17,18 @@ season (not a pre-resolved label) so a viewed past season resolves correctly. Pr
 flag in this repo: `GATEWAY_REQUIRED_UNTIL_SEASON` (`src/constants.ts`). At this stage the flag is typed
 but not yet read by any component.
 
+## New rank fields (`Ranking.progression`, `ModeStat.progression`)
+
+`Ranking` (`src/store/ranking/types.ts`) and `ModeStat` (`src/store/player/types.ts`) carry an optional
+`progression?: { league, division, points, apexPoints } | null` alongside the legacy RP fields, fetched
+over the existing ladder / game-mode-stats endpoints. `null` means the entity has no progression rank for
+that season/mode → render RP. The fields are typed but not yet rendered (the per-mode render branch is a
+later step). Additive: existing RP rendering is unaffected.
+
 ## File reference
 
 | Concern | Path |
 |---|---|
 | `ActiveGameMode` type | `src/store/ranking/types.ts` |
+| `ProgressionRank` type | `src/store/ranking/types.ts` |
 | Fetch + store | `src/services/RankingService.ts`, `src/store/ranking/store.ts` |

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -1,5 +1,5 @@
 import { EGameMode, ERaceEnum, Match, timestampString } from "../types";
-import { Gateways, PlayerId, Season } from "@/store/ranking/types";
+import { Gateways, PlayerId, ProgressionRank, Season } from "@/store/ranking/types";
 
 export type PlayerState = {
   playerStatsRaceVersusRaceOnMap: PlayerStatsRaceOnMapVersusRace;
@@ -74,6 +74,7 @@ export type ModeStat = {
   rankingPoints: number;
   playerIds: PlayerId[];
   quantile: number;
+  progression?: ProgressionRank | null;
 };
 
 export interface WinLossesOnMap {

--- a/src/store/ranking/types.ts
+++ b/src/store/ranking/types.ts
@@ -55,6 +55,13 @@ export type League = {
   maxParticipantCount: number;
 };
 
+export type ProgressionRank = {
+  league: number;
+  division: number;
+  points: number;
+  apexPoints: number | null;
+};
+
 export type Ranking = {
   id: string;
   season: number;
@@ -69,6 +76,7 @@ export type Ranking = {
   gameMode: EGameMode;
   player: PlayerOverview;
   playersInfo: PlayerInfo[];
+  progression?: ProgressionRank | null;
 };
 
 export type CountryRanking = {


### PR DESCRIPTION
## Summary
Adds an optional `progression?: { league, division, points, apexPoints } | null` to the `Ranking` (ladder) and `ModeStat` (profile) store types, mirroring the new backend DTO fields so the frontend can receive the new rank **alongside** the legacy RP fields. `null` ⟹ no progression rank for that season/mode → render RP. Typed only — no render branch yet. Fully additive (the services raw-cast the JSON, so optional fields are transparent).

- `ProgressionRank` exported from `store/ranking/types.ts`, imported into `store/player/types.ts`.
- Per-repo doc updated (`docs/ranking.md`).

## Tests
No unit runner in this repo (unchanged). Verified green: `type-check-vue`, `lint`, `dprint`, `build`.

## Checklist
- [x] Targets `prj/new-ranking-system`
- [x] Additive optional types — no existing field/render changed
- [x] type-check + lint + dprint + build green
- [x] Per-repo doc updated