### PR TITLE
feat(ranking): website per-mode rank render branch (P11-3)

### DIFF
--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -14,16 +14,37 @@ alongside the legacy "RP" ladder; each game mode uses exactly one, selected per 
 Selection rule, applied where rank is rendered: use the new system iff
 `progressionStartSeason != null && viewedSeason >= progressionStartSeason`, else RP. The value is the raw
 season (not a pre-resolved label) so a viewed past season resolves correctly. Precedent for a season-gated
-flag in this repo: `GATEWAY_REQUIRED_UNTIL_SEASON` (`src/constants.ts`). At this stage the flag is typed
-but not yet read by any component.
+flag in this repo: `GATEWAY_REQUIRED_UNTIL_SEASON` (`src/constants.ts`). The selection is implemented by
+the `useRankingSystem` composable (`src/composables/useRankingSystem.ts`), which exposes
+`resolveRankingSystem(gameMode, viewedSeason)` and ensures `activeModes` is loaded.
 
 ## New rank fields (`Ranking.progression`, `ModeStat.progression`)
 
 `Ranking` (`src/store/ranking/types.ts`) and `ModeStat` (`src/store/player/types.ts`) carry an optional
 `progression?: { league, division, points, apexPoints } | null` alongside the legacy RP fields, fetched
 over the existing ladder / game-mode-stats endpoints. `null` means the entity has no progression rank for
-that season/mode → render RP. The fields are typed but not yet rendered (the per-mode render branch is a
-later step). Additive: existing RP rendering is unaffected.
+that season/mode → render as Unranked. These fields drive the progression display (see Rendering below).
+Additive: existing RP rendering is unaffected.
+
+## Rendering
+
+`ProgressionRank` (`src/components/ladder/ProgressionRank.vue`) renders a progression rank: the league icon
+(`LeagueIcon`) plus, for the regular leagues, the division and a points-in-division bar (0–100); for the
+apex leagues (Master / Grand Master) the apex points instead. League icons and the league/division
+vocabulary are shared with the legacy ladder.
+
+The per-mode branch is applied wherever rank is shown:
+
+- Ladder grid (`src/components/ladder/RankingsGrid.vue`) — the rank column renders `ProgressionRank` for a
+  progression mode and its header reads "Rank" instead of "Level"; players sharing a rank share a position
+  number. `Rankings.vue` loads `activeModes` so the grid can resolve the per-mode flag.
+- Profile league card (`src/components/player/PlayerLeague.vue`) — the league badge, division, and points
+  come from `progression`.
+- Profile mode-stats table (`src/components/player/ModeStatsGrid.vue`) — the rank cell renders per row; its
+  shared column header reads "Rank".
+
+A progression mode is a clean cutover: it never shows the legacy RP "Level". An entity with no progression
+rank yet (`progression == null`) renders as Unranked.
 
 ## File reference
 
@@ -32,3 +53,6 @@ later step). Additive: existing RP rendering is unaffected.
 | `ActiveGameMode` type | `src/store/ranking/types.ts` |
 | `ProgressionRank` type | `src/store/ranking/types.ts` |
 | Fetch + store | `src/services/RankingService.ts`, `src/store/ranking/store.ts` |
+| Per-mode selection | `src/composables/useRankingSystem.ts`, `src/helpers/progression-rank.ts` |
+| Progression renderer | `src/components/ladder/ProgressionRank.vue` |
+| Render sites | `src/components/ladder/RankingsGrid.vue`, `src/components/player/PlayerLeague.vue`, `src/components/player/ModeStatsGrid.vue`, `src/views/Rankings.vue` |

--- a/src/components/ladder/ProgressionRank.vue
+++ b/src/components/ladder/ProgressionRank.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="progression-rank">
+    <league-icon :league="progression.league" />
+    <span v-if="isApex" class="progression-rank__apex number-text">{{ progression.apexPoints }}</span>
+    <v-progress-linear
+      v-else
+      class="progression-rank__bar"
+      :model-value="progression.points"
+      :max="100"
+      height="25"
+      color="level-progress-gradient"
+    >
+      <strong>{{ progression.division }} · {{ progression.points }}</strong>
+    </v-progress-linear>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from "vue";
+import type { ProgressionRank as ProgressionRankType } from "@/store/ranking/types";
+import LeagueIcon from "@/components/ladder/LeagueIcon.vue";
+import { isApexRank } from "@/helpers/progression-rank";
+
+export default defineComponent({
+  name: "ProgressionRank",
+  components: {
+    LeagueIcon,
+  },
+  props: {
+    progression: {
+      type: Object as PropType<ProgressionRankType>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const isApex = computed<boolean>(() => isApexRank(props.progression));
+    return {
+      isApex,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.progression-rank {
+  display: inline-flex;
+  align-items: center;
+}
+
+.progression-rank__apex {
+  margin-left: 4px;
+  font-weight: 700;
+}
+
+.progression-rank__bar {
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.75);
+  border-radius: 3px;
+  min-width: 100px;
+  max-width: 200px;
+  text-shadow: -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white, 1px 1px 0 white;
+
+  :deep(.bg-level-progress-gradient) {
+    background-image: linear-gradient(white 0%, rgb(var(--v-theme-primary)) 40%, rgb(var(--v-theme-primary)) 60%, white 100%);
+  }
+
+  .v-theme--nightelf &, .v-theme--undead & {
+    background-color: black;
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    text-shadow: -1px -1px 0 black, 1px -1px 0 black, -1px 1px 0 black, 1px 1px 0 black;
+
+    :deep(.bg-level-progress-gradient) {
+      background-image: linear-gradient(black, rgb(var(--v-theme-primary)), black);
+    }
+  }
+}
+</style>

--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -15,7 +15,7 @@
             @click="sortRankings(header.name, header.sortFunction)"
           >
             {{ header.text }}
-            <div v-if="header.text === sortColumn" class="sort-icon">
+            <div v-if="header.name === sortColumn" class="sort-icon">
               <v-icon v-if="isSortedAsc">{{ mdiChevronUp }}</v-icon>
               <v-icon v-if="!isSortedAsc">{{ mdiChevronDown }}</v-icon>
             </div>
@@ -32,7 +32,7 @@
             'w3-mid-emphasis': true,
           }"
         >
-          <td class="number-text">{{ item.rankNumber }}.</td>
+          <td class="number-text">{{ rowRank(item) }}.</td>
           <td class="d-md-flex">
             <div
               v-for="(playerId, index) in item.player.playerIds"
@@ -113,7 +113,11 @@
             </div>
           </td>
           <td class="number-text text-end">
-            <level-progress :rp="item.rankingPoints" />
+            <template v-if="system === 'progression'">
+              <progression-rank v-if="item.progression" :progression="item.progression" />
+              <span v-else>{{ $t("views_rankings.unranked") }}</span>
+            </template>
+            <level-progress v-else :rp="item.rankingPoints" />
           </td>
           <td class="number-text text-end"><race-icon :race="item.race" /></td>
           <td class="number-text text-end">
@@ -144,6 +148,9 @@ import LevelProgress from "@/components/ladder/LevelProgress.vue";
 import { mdiChevronDown, mdiChevronUp, mdiTwitch } from "@mdi/js";
 import { useI18n } from "vue-i18n";
 import { useRankingStore } from "@/store/ranking/store";
+import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
+import { useRankingSystem } from "@/composables/useRankingSystem";
+import { assignDisplayRanks, compareProgressionRank } from "@/helpers/progression-rank";
 import { useGoTo } from "vuetify";
 import type { InternalGoToOptions } from "vuetify/lib/composables/goto.mjs";
 
@@ -155,6 +162,7 @@ export default defineComponent({
     PlayerRankInfo,
     CountryFlagExtended,
     LevelProgress,
+    ProgressionRank,
   },
   props: {
     rankings: {
@@ -192,7 +200,27 @@ export default defineComponent({
       },
     });
 
-    const headers = [
+    const { resolveRankingSystem } = useRankingSystem();
+    const system = computed(() => resolveRankingSystem(rankingsStore.gameMode, rankingsStore.selectedSeason.id));
+
+    const displayRankByPlayerId = computed<Map<string, number> | null>(() => {
+      if (system.value !== "progression") return null;
+      // Ranks are assigned over the current view order; tie-grouping is only meaningful when
+      // the list is ordered by rank. Do not add an internal sort here.
+      const ranked = assignDisplayRanks(rankingsRef.value, (r) => r.progression);
+      const map = new Map<string, number>();
+      ranked.forEach(({ item, displayRank }) => map.set(item.player.id, displayRank));
+      return map;
+    });
+
+    function rowRank(item: Ranking): number {
+      if (system.value === "progression") {
+        return displayRankByPlayerId.value?.get(item.player.id) ?? item.rankNumber;
+      }
+      return item.rankNumber;
+    }
+
+    const headers = computed(() => [
       {
         name: "Rank",
         text: t("components_ladder_rankingsgrid.rank"),
@@ -215,11 +243,19 @@ export default defineComponent({
       },
       {
         name: "Level",
-        text: t("components_ladder_rankingsgrid.level"),
+        text: system.value === "progression"
+          ? t("components_ladder_rankingsgrid.rank")
+          : t("components_ladder_rankingsgrid.level"),
         align: "center",
         sortable: false,
         width: "100px",
         sortFunction: (a: Ranking, b: Ranking): number => {
+          if (system.value === "progression") {
+            if (!a.progression || !b.progression) {
+              return Number(Boolean(b.progression)) - Number(Boolean(a.progression));
+            }
+            return compareProgressionRank(a.progression, b.progression);
+          }
           return b.rankingPoints - a.rankingPoints;
         },
       },
@@ -295,7 +331,7 @@ export default defineComponent({
           return b.player.mmr - a.player.mmr;
         },
       },
-    ];
+    ]);
 
     const selectedRankRef = toRefs(props).selectedRank;
     watch(selectedRankRef, onSelectedRankChanged);
@@ -372,6 +408,7 @@ export default defineComponent({
 
     function goToRank(rank: Ranking): void {
       setTimeout(() => {
+        // DOM ids are anchored to the server-assigned rankNumber, not the displayed rank.
         const elementId = `listitem_${rank.rankNumber}`;
         const listItemOfPlayer = document.getElementById(elementId);
 
@@ -518,6 +555,8 @@ export default defineComponent({
       getLiveOpponent,
       sortRankings,
       rankingsRef,
+      system,
+      rowRank,
     };
   }
 });

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -38,8 +38,15 @@
           </div>
         </td>
         <td class="number-text text-center text-no-wrap" style="min-width: 100px">
-          <level-progress v-if="item.rank !== 0" :rp="item.rankingPoints" />
-          <div v-else>-</div>
+          <template v-if="rowSystem(item) === 'progression'">
+            <progression-rank v-if="item.progression" :progression="item.progression" />
+            <!-- Profile grid uses "-" for no-rank rows (matching the RP path below), unlike the ladder's "Unranked". -->
+            <div v-else>-</div>
+          </template>
+          <template v-else>
+            <level-progress v-if="item.rank !== 0" :rp="item.rankingPoints" />
+            <div v-else>-</div>
+          </template>
         </td>
       </tr>
     </template>
@@ -54,6 +61,9 @@ import { EGameMode } from "@/store/types";
 import { ModeStat } from "@/store/player/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
+import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
+import { useRankingSystem, type RankingSystem } from "@/composables/useRankingSystem";
+import { usePlayerStore } from "@/store/player/store";
 import isEmpty from "lodash/isEmpty";
 import { DataTableHeader } from "vuetify";
 
@@ -62,6 +72,7 @@ export default defineComponent({
   components: {
     RaceIcon,
     LevelProgress,
+    ProgressionRank,
   },
   props: {
     stats: {
@@ -71,6 +82,15 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
+
+    const playerStore = usePlayerStore();
+    const { resolveRankingSystem } = useRankingSystem();
+
+    // Plain method, not a computed: it is called per-row inside the table's render, whose
+    // reactive effect tracks the activeModes / selectedSeason reads, so rows re-render on change.
+    function rowSystem(item: ModeStat): RankingSystem {
+      return resolveRankingSystem(item.gameMode, playerStore.selectedSeason?.id ?? -1);
+    }
 
     const isAtMode = (mode: EGameMode): boolean => AT_modes().includes(mode);
 
@@ -135,10 +155,10 @@ export default defineComponent({
         value: "mmr",
       },
       {
-        title: t("components_player_modestatsgrid.level"),
+        title: t("components_ladder_rankingsgrid.rank"),
         align: "center",
         sortable: false,
-        tooltip: t("components_player_modestatsgrid.leveldesc"),
+        tooltip: t("components_ladder_rankingsgrid.rank"),
         value: "level",
       },
     ];
@@ -148,6 +168,7 @@ export default defineComponent({
       gameModeStatsCombined,
       EGameMode,
       getTopPercent,
+      rowSystem,
     };
   },
 });

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -7,7 +7,7 @@
   >
     <h2 class="LadderSummaryShowcase-title">
       {{ leagueMode }} {{ leagueName }}
-      {{ modeStat.division !== 0 ? modeStat.division : null }}
+      {{ divisionLabel }}
     </h2>
     <div class="LadderSummaryShowcase-subtitle">
       <div v-if="showAtPartner">
@@ -17,8 +17,8 @@
         <br v-if="showAtPartner" />
       </div>
       <span v-if="isRanked">
-        <span v-if="!smallMode">Rank</span>
-        <span v-if="!smallMode" class="number-text">{{ modeStat.rank }} |</span>
+        <span v-if="!smallMode && !isProgression">Rank</span>
+        <span v-if="!smallMode && !isProgression" class="number-text">{{ modeStat.rank }} |</span>
         <span class="w3-won">{{ modeStat.wins }}</span>
         -
         <span class="w3-lost">{{ modeStat.losses }}</span>
@@ -36,7 +36,9 @@
         </span>
         <span class="ml-2" style="font-size: 13px">
           <v-col>
-            <level-progress :rp="modeStat.rankingPoints" />
+            <!-- A progression mode with no rank yet is unranked, so it never reaches here (gated by isRanked above). -->
+            <progression-rank v-if="hasProgressionRank && modeStat.progression" :progression="modeStat.progression" />
+            <level-progress v-else-if="!isProgression" :rp="modeStat.rankingPoints" />
           </v-col>
         </span>
       </div>
@@ -56,6 +58,10 @@ import { ModeStat } from "@/store/player/types";
 import RecentPerformance from "@/components/player/RecentPerformance.vue";
 import { getProfileUrl } from "@/helpers/url-functions";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
+import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
+import { useRankingSystem } from "@/composables/useRankingSystem";
+import { leagueName as leagueNameForOrder } from "@/helpers/progression-rank";
+import type { ProgressionRank as ProgressionRankType } from "@/store/ranking/types";
 import { usePlayerStore } from "@/store/player/store";
 import { useRootStateStore } from "@/store/rootState/store";
 import { Gateways, PlayerId, Season } from "@/store/ranking/types";
@@ -66,6 +72,7 @@ export default defineComponent({
   components: {
     RecentPerformance,
     LevelProgress,
+    ProgressionRank,
   },
   props: {
     modeStat: {
@@ -94,12 +101,21 @@ export default defineComponent({
     const playerStore = usePlayerStore();
     const rootStateStore = useRootStateStore();
 
+    const { resolveRankingSystem } = useRankingSystem();
+    const progression = computed<ProgressionRankType | null>(() => props.modeStat.progression ?? null);
+    const isProgression = computed<boolean>(
+      () => resolveRankingSystem(props.modeStat.gameMode, playerStore.selectedSeason?.id ?? -1) === "progression",
+    );
+    const hasProgressionRank = computed<boolean>(() => isProgression.value && progression.value != null);
+
     const matches = ref<Match[]>([]);
     const playerId = computed<string>(() => battleTag.value);
     const leagueMode = computed<string>(() => t(`gameModes.${EGameMode[props.modeStat.gameMode]}`));
     const gameMode = computed<EGameMode>(() => props.modeStat.gameMode);
     const league = computed<number>(() => props.modeStat.leagueId);
-    const isRanked = computed<boolean>(() => props.modeStat.rank > 0);
+    const isRanked = computed<boolean>(() =>
+      isProgression.value ? progression.value != null : props.modeStat.rank > 0
+    );
 
     const gateWay = computed<Gateways>(() => rootStateStore.gateway);
     const selectedSeason = computed<Season>(() => playerStore.selectedSeason);
@@ -136,31 +152,19 @@ export default defineComponent({
     }
 
     const leagueName = computed<string>(() => {
-      if (!props.modeStat) return "";
       if (!isRanked.value) return "unranked";
-
-      switch (props.modeStat.leagueOrder) {
-        case 0:
-          return "grandmaster";
-        case 1:
-          return "master";
-        case 2:
-          return "adept";
-        case 3:
-          return "diamond";
-        case 4:
-          return "platinum";
-        case 5:
-          return "gold";
-        case 6:
-          return "silver";
-        case 7:
-          return "bronze";
-        case 8:
-          return "grass";
-        default:
-          return "";
+      if (hasProgressionRank.value && progression.value) {
+        return leagueNameForOrder(progression.value.league);
       }
+      return leagueNameForOrder(props.modeStat.leagueOrder);
+    });
+
+    const divisionLabel = computed<number | null>(() => {
+      if (!isRanked.value) return null;
+      const division = hasProgressionRank.value && progression.value
+        ? progression.value.division
+        : props.modeStat.division;
+      return division !== 0 ? division : null;
     });
 
     const lastTenMatchesPerformance = computed<("W" | "L")[]>(() => {
@@ -179,6 +183,9 @@ export default defineComponent({
 
     return {
       isRanked,
+      isProgression,
+      hasProgressionRank,
+      divisionLabel,
       navigateToLeague,
       leagueMode,
       leagueName,

--- a/src/composables/useRankingSystem.ts
+++ b/src/composables/useRankingSystem.ts
@@ -1,0 +1,31 @@
+import { useRankingStore } from "@/store/ranking/store";
+import { EGameMode } from "@/store/types";
+
+export type RankingSystem = "rp" | "progression";
+
+interface UseRankingSystem {
+  resolveRankingSystem: (gameMode: EGameMode, viewedSeason: number) => RankingSystem;
+}
+
+// Resolves which ranking system a (mode, viewedSeason) renders, and ensures the
+// per-mode flags are loaded. `retrieveActiveGameModes` is idempotent.
+export function useRankingSystem(): UseRankingSystem {
+  const rankingsStore = useRankingStore();
+
+  // Fire-and-forget; reactive consumers update when activeModes populate.
+  rankingsStore.retrieveActiveGameModes();
+
+  // Call this from a reactive context (computed / watchEffect / template): it reads the
+  // reactive activeModes, so a consumer re-evaluates once the (async, idempotent) load above
+  // resolves. Before activeModes is populated, every mode resolves to "rp".
+  function resolveRankingSystem(gameMode: EGameMode, viewedSeason: number): RankingSystem {
+    const mode = rankingsStore.activeModes.find((m) => m.id === gameMode);
+    const startSeason = mode?.progressionStartSeason;
+    if (startSeason != null && viewedSeason >= startSeason) {
+      return "progression";
+    }
+    return "rp";
+  }
+
+  return { resolveRankingSystem };
+}

--- a/src/helpers/progression-rank.ts
+++ b/src/helpers/progression-rank.ts
@@ -1,0 +1,73 @@
+import type { ProgressionRank } from "@/store/ranking/types";
+
+// League index matches the legacy `leagueOrder` scale: 0 = Grandmaster (best) … 8 = Grass (worst).
+export const LEAGUE_NAMES = [
+  "grandmaster",
+  "master",
+  "adept",
+  "diamond",
+  "platinum",
+  "gold",
+  "silver",
+  "bronze",
+  "grass",
+] as const;
+
+export function leagueName(league: number): string {
+  return LEAGUE_NAMES[league] ?? "";
+}
+
+// Apex (Master / Grand Master) is distinguished by a non-null apexPoints.
+export function isApexRank(progression: ProgressionRank): boolean {
+  return progression.apexPoints != null;
+}
+
+// Lower result = better rank. Lower league number is better; apex compares by apexPoints,
+// otherwise by division (lower better) then points (higher better).
+export function compareProgressionRank(a: ProgressionRank, b: ProgressionRank): number {
+  if (a.league !== b.league) return a.league - b.league;
+  const aApex = isApexRank(a);
+  const bApex = isApexRank(b);
+  // Within a league, apex (Master/Grand Master) always outranks non-apex.
+  if (aApex !== bApex) return aApex ? -1 : 1;
+  if (aApex && bApex) return (b.apexPoints ?? 0) - (a.apexPoints ?? 0);
+  if (a.division !== b.division) return a.division - b.division;
+  return b.points - a.points;
+}
+
+function sameProgressionRank(a: ProgressionRank, b: ProgressionRank): boolean {
+  return compareProgressionRank(a, b) === 0;
+}
+
+// Competition ranking (1, 2, 2, 4) over a list that is ALREADY ordered best-to-worst by
+// progression rank (no internal sort is performed; unsorted input produces incorrect ranks).
+// Consecutive entries with an identical rank share a position number. Entries without a
+// progression rank do not participate in tie-grouping for the entries that follow them.
+export function assignDisplayRanks<T>(
+  items: T[],
+  getProgression: (item: T) => ProgressionRank | null | undefined,
+): Array<{ item: T; displayRank: number }> {
+  const result: Array<{ item: T; displayRank: number }> = [];
+  let lastProgression: ProgressionRank | null = null;
+  let lastRank = 0;
+
+  items.forEach((item, index) => {
+    const progression = getProgression(item) ?? null;
+    let rank: number;
+    if (progression !== null && lastProgression !== null && sameProgressionRank(progression, lastProgression)) {
+      rank = lastRank;
+    } else {
+      rank = index + 1;
+    }
+    result.push({ item, displayRank: rank });
+    if (progression !== null) {
+      lastProgression = progression;
+      lastRank = rank;
+    } else {
+      // A rankless entry breaks the tie chain so an earlier rank can't bleed onto later entries.
+      lastProgression = null;
+    }
+  });
+
+  return result;
+}

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -474,6 +474,7 @@ export default defineComponent({
       }
 
       await rankingsStore.retrieveSeasons();
+      await rankingsStore.retrieveActiveGameModes();
 
       // Check if season is defined (also allow the value 0), otherwise we can use the first season
       if (hasSeason) {


### PR DESCRIPTION
## Summary
Branches each game mode's rank display between the legacy RP "Level" and the new progression rank, driven per mode by `progressionStartSeason` (`progression` shown iff `progressionStartSeason != null && viewedSeason >= progressionStartSeason`, else RP). Pure render off the existing `Ranking.progression` / `ModeStat.progression` fields — no data/service changes. RP modes render unchanged.

- New `useRankingSystem` composable resolves the per-mode system and ensures `activeModes` is loaded; new `ProgressionRank` component renders the rank (league icon + division + points bar, or apex points for Master/Grand Master). Shared league vocabulary/icons reused.
- Branched at the ladder grid (`RankingsGrid`), the profile league card (`PlayerLeague`), and the profile mode-stats table (`ModeStatsGrid`); `Rankings.vue` now loads active modes.
- Clean cutover: a progression mode never shows the RP "Level"; an entity with no progression rank yet renders as **Unranked**. Ladder keeps the position column with shared ("tie-aware") numbers for equal ranks; its rank column header reads "Rank".

## Tests
No unit runner in this repo (unchanged). Verified green: `type-check-vue`, `lint`, `dprint`, `build`. Manual visual pass on the ladder grid and player profile (light + dark themes, 1440/768), exercising steered, apex, and unranked cases.

## Checklist
- [x] Targets `prj/new-ranking-system`
- [x] Additive — RP rendering unchanged; progression rendering gated per mode
- [x] `type-check-vue` + `lint` + `dprint` + `build` green
- [x] Per-repo doc updated (`docs/ranking.md`)