### PR TITLE
feat(ranking): render win-milestone bar on player profile (P8-3)

### DIFF
--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -46,13 +46,28 @@ The per-mode branch is applied wherever rank is shown:
 A progression mode is a clean cutover: it never shows the legacy RP "Level". An entity with no progression
 rank yet (`progression == null`) renders as Unranked.
 
+## Win-milestone bar (`ModeStat.milestone`)
+
+`ModeStat` (`src/store/player/types.ts`) carries an optional
+`milestone?: { currentWins, previousTarget, nextTarget } | null`, served on the profile game-mode-stats
+endpoint. It is a permanent, lifetime "always something to climb" win track, independent of rank — a raw
+progress bar toward the next round-number win milestone. `MilestoneProgress`
+(`src/components/ladder/MilestoneProgress.vue`) renders it as an in-band fill
+`(currentWins − previousTarget) / (nextTarget − previousTarget)` (so it resets after each milestone) with a
+`currentWins / nextTarget` label, echoing the RP "Level" bar's styling.
+
+It is **profile-only** and shown **in addition to** the rank (the milestone track is decoupled from rank):
+the bar mounts under the rank in the profile league card (`PlayerLeague.vue`) and the profile mode-stats
+table (`ModeStatsGrid.vue`), only for progression modes and only when `milestone != null`. The ladder grid
+does not show it. Additive: RP rendering and the progression-rank display are unaffected.
+
 ## File reference
 
 | Concern | Path |
 |---|---|
 | `ActiveGameMode` type | `src/store/ranking/types.ts` |
-| `ProgressionRank` type | `src/store/ranking/types.ts` |
+| `ProgressionRank` / `MilestoneProgress` types | `src/store/ranking/types.ts` |
 | Fetch + store | `src/services/RankingService.ts`, `src/store/ranking/store.ts` |
 | Per-mode selection | `src/composables/useRankingSystem.ts`, `src/helpers/progression-rank.ts` |
-| Progression renderer | `src/components/ladder/ProgressionRank.vue` |
+| Progression renderers | `src/components/ladder/ProgressionRank.vue`, `src/components/ladder/MilestoneProgress.vue` |
 | Render sites | `src/components/ladder/RankingsGrid.vue`, `src/components/player/PlayerLeague.vue`, `src/components/player/ModeStatsGrid.vue`, `src/views/Rankings.vue` |

--- a/src/components/ladder/MilestoneProgress.vue
+++ b/src/components/ladder/MilestoneProgress.vue
@@ -5,14 +5,14 @@
     :max="100"
     height="25"
     color="level-progress-gradient"
-    :aria-label="$t('components_ladder_milestoneprogress.ariawins')"
+    :aria-label="$t('components_ladder_milestoneprogress.arialabel', { current: milestoneProgress.currentWins, next: milestoneProgress.nextTarget })"
   >
     <strong>{{ milestoneProgress.currentWins }} / {{ milestoneProgress.nextTarget }}</strong>
   </v-progress-linear>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, type PropType } from "vue";
+import { computed, defineComponent, type PropType } from "vue";
 import type { MilestoneProgress as MilestoneProgressType } from "@/store/ranking/types";
 
 export default defineComponent({

--- a/src/components/ladder/MilestoneProgress.vue
+++ b/src/components/ladder/MilestoneProgress.vue
@@ -1,0 +1,59 @@
+<template>
+  <v-progress-linear class="milestone-progress" :model-value="fillPercent" :max="100" height="25" color="level-progress-gradient">
+    <strong>{{ milestoneProgress.currentWins }} / {{ milestoneProgress.nextTarget }}</strong>
+  </v-progress-linear>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, type PropType } from "vue";
+import type { MilestoneProgress as MilestoneProgressType } from "@/store/ranking/types";
+
+export default defineComponent({
+  name: "MilestoneProgress",
+  components: {},
+  props: {
+    milestoneProgress: {
+      type: Object as PropType<MilestoneProgressType>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const fillPercent = computed<number>(() => {
+      const { currentWins, previousTarget, nextTarget } = props.milestoneProgress;
+      const span = nextTarget - previousTarget;
+      if (span <= 0) return 100;
+      return Math.min(100, Math.max(0, ((currentWins - previousTarget) / span) * 100));
+    });
+
+    return {
+      fillPercent,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.milestone-progress {
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.75);
+  border-radius: 3px;
+  min-width: 100px;
+  max-width: 200px;
+  text-shadow: -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white, 1px 1px 0 white;
+
+  :deep(.bg-level-progress-gradient) {
+    background-image: linear-gradient(white 0%, rgb(var(--v-theme-primary)) 40%, rgb(var(--v-theme-primary)) 60%, white 100%);
+  }
+
+  .v-theme--nightelf &, .v-theme--undead & {
+    background-color: black;
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    text-shadow: -1px -1px 0 black, 1px -1px 0 black, -1px 1px 0 black, 1px 1px 0 black;
+
+    :deep(.bg-level-progress-gradient) {
+      background-image: linear-gradient(black, rgb(var(--v-theme-primary)), black);
+    }
+  }
+}
+</style>

--- a/src/components/ladder/MilestoneProgress.vue
+++ b/src/components/ladder/MilestoneProgress.vue
@@ -5,7 +5,7 @@
     :max="100"
     height="25"
     color="level-progress-gradient"
-    :aria-label="$t('components_ladder_milestoneprogress.arialabel', { current: milestoneProgress.currentWins, next: milestoneProgress.nextTarget })"
+    :aria-label="`${milestoneProgress.currentWins} / ${milestoneProgress.nextTarget}`"
   >
     <strong>{{ milestoneProgress.currentWins }} / {{ milestoneProgress.nextTarget }}</strong>
   </v-progress-linear>

--- a/src/components/ladder/MilestoneProgress.vue
+++ b/src/components/ladder/MilestoneProgress.vue
@@ -1,5 +1,12 @@
 <template>
-  <v-progress-linear class="milestone-progress" :model-value="fillPercent" :max="100" height="25" color="level-progress-gradient">
+  <v-progress-linear
+    class="milestone-progress"
+    :model-value="fillPercent"
+    :max="100"
+    height="25"
+    color="level-progress-gradient"
+    :aria-label="$t('components_ladder_milestoneprogress.ariawins')"
+  >
     <strong>{{ milestoneProgress.currentWins }} / {{ milestoneProgress.nextTarget }}</strong>
   </v-progress-linear>
 </template>

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -42,7 +42,8 @@
             <progression-rank v-if="item.progression" :progression="item.progression" />
             <!-- Profile grid uses "-" for no-rank rows (matching the RP path below), unlike the ladder's "Unranked". -->
             <div v-else>-</div>
-            <milestone-progress v-if="item.milestone" :milestone-progress="item.milestone" />
+            <!-- win-milestone bar shows in addition to the rank bar (decoupled lifetime track) -->
+            <milestone-progress v-if="item.milestone" class="mt-1" :milestone-progress="item.milestone" />
           </template>
           <template v-else>
             <level-progress v-if="item.rank !== 0" :rp="item.rankingPoints" />

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -42,6 +42,7 @@
             <progression-rank v-if="item.progression" :progression="item.progression" />
             <!-- Profile grid uses "-" for no-rank rows (matching the RP path below), unlike the ladder's "Unranked". -->
             <div v-else>-</div>
+            <milestone-progress v-if="item.milestone" :milestone-progress="item.milestone" />
           </template>
           <template v-else>
             <level-progress v-if="item.rank !== 0" :rp="item.rankingPoints" />
@@ -61,6 +62,7 @@ import { EGameMode } from "@/store/types";
 import { ModeStat } from "@/store/player/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
+import MilestoneProgress from "@/components/ladder/MilestoneProgress.vue";
 import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
 import { useRankingSystem, type RankingSystem } from "@/composables/useRankingSystem";
 import { usePlayerStore } from "@/store/player/store";
@@ -72,6 +74,7 @@ export default defineComponent({
   components: {
     RaceIcon,
     LevelProgress,
+    MilestoneProgress,
     ProgressionRank,
   },
   props: {

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -39,6 +39,7 @@
             <!-- A progression mode with no rank yet is unranked, so it never reaches here (gated by isRanked above). -->
             <progression-rank v-if="hasProgressionRank && modeStat.progression" :progression="modeStat.progression" />
             <level-progress v-else-if="!isProgression" :rp="modeStat.rankingPoints" />
+            <milestone-progress v-if="isProgression && modeStat.milestone" :milestone-progress="modeStat.milestone" />
           </v-col>
         </span>
       </div>
@@ -58,6 +59,7 @@ import { ModeStat } from "@/store/player/types";
 import RecentPerformance from "@/components/player/RecentPerformance.vue";
 import { getProfileUrl } from "@/helpers/url-functions";
 import LevelProgress from "@/components/ladder/LevelProgress.vue";
+import MilestoneProgress from "@/components/ladder/MilestoneProgress.vue";
 import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
 import { useRankingSystem } from "@/composables/useRankingSystem";
 import { leagueName as leagueNameForOrder } from "@/helpers/progression-rank";
@@ -72,6 +74,7 @@ export default defineComponent({
   components: {
     RecentPerformance,
     LevelProgress,
+    MilestoneProgress,
     ProgressionRank,
   },
   props: {

--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -39,7 +39,8 @@
             <!-- A progression mode with no rank yet is unranked, so it never reaches here (gated by isRanked above). -->
             <progression-rank v-if="hasProgressionRank && modeStat.progression" :progression="modeStat.progression" />
             <level-progress v-else-if="!isProgression" :rp="modeStat.rankingPoints" />
-            <milestone-progress v-if="isProgression && modeStat.milestone" :milestone-progress="modeStat.milestone" />
+            <!-- win-milestone bar shows in addition to the rank bar (decoupled lifetime track) -->
+            <milestone-progress v-if="isProgression && modeStat.milestone" class="mt-1" :milestone-progress="modeStat.milestone" />
           </v-col>
         </span>
       </div>

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -279,7 +279,7 @@ const data = {
       level: "Level",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Race",
@@ -859,7 +859,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
@@ -1372,7 +1372,7 @@ const data = {
       rp: "랭킹 포인트",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "종족",
@@ -1829,7 +1829,7 @@ const data = {
       level: "等级",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "种族",
@@ -2357,7 +2357,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasse",
@@ -2850,7 +2850,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",
@@ -3396,7 +3396,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
@@ -3925,7 +3925,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Raça",
@@ -4459,7 +4459,7 @@ const data = {
       rp: "RP",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Race",
@@ -4998,7 +4998,7 @@ const data = {
       level: "Nivo",
     },
     components_ladder_milestoneprogress: {
-      ariawins: "Wins to next milestone",
+      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -278,9 +278,6 @@ const data = {
       rp: "RP",
       level: "Level",
     },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
-    },
     components_ladder_rankingsracedistribution: {
       race: "Race",
       numberofplayers: "Number of players",
@@ -858,9 +855,6 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
-    },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
       numberofplayers: "Количество игроков",
@@ -1371,9 +1365,6 @@ const data = {
       mmr: "MMR",
       rp: "랭킹 포인트",
     },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
-    },
     components_ladder_rankingsracedistribution: {
       race: "종족",
       numberofplayers: "플레이어 수",
@@ -1827,9 +1818,6 @@ const data = {
       mmr: "MMR对战积分",
       rp: "RP活跃度积分",
       level: "等级",
-    },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "种族",
@@ -2356,9 +2344,6 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
-    },
     components_ladder_rankingsracedistribution: {
       race: "Rasse",
       numberofplayers: "Spieleranzahl",
@@ -2848,9 +2833,6 @@ const data = {
       winrate: "% wygranych",
       mmr: "MMR",
       rp: "RP",
-    },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",
@@ -3395,9 +3377,6 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
-    },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
       numberofplayers: "Кількість гравців",
@@ -3923,9 +3902,6 @@ const data = {
       winrate: "Winrate",
       mmr: "MMR",
       rp: "RP",
-    },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Raça",
@@ -4457,9 +4433,6 @@ const data = {
       winrate: "Pourcentage de victoire",
       mmr: "MMR",
       rp: "RP",
-    },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Race",
@@ -4996,9 +4969,6 @@ const data = {
       mmr: "MMR",
       rp: "RP",
       level: "Nivo",
-    },
-    components_ladder_milestoneprogress: {
-      arialabel: "{current} / {next} wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",

--- a/src/locales/data.ts
+++ b/src/locales/data.ts
@@ -278,6 +278,9 @@ const data = {
       rp: "RP",
       level: "Level",
     },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
+    },
     components_ladder_rankingsracedistribution: {
       race: "Race",
       numberofplayers: "Number of players",
@@ -855,6 +858,9 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
+    },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
       numberofplayers: "Количество игроков",
@@ -1365,6 +1371,9 @@ const data = {
       mmr: "MMR",
       rp: "랭킹 포인트",
     },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
+    },
     components_ladder_rankingsracedistribution: {
       race: "종족",
       numberofplayers: "플레이어 수",
@@ -1818,6 +1827,9 @@ const data = {
       mmr: "MMR对战积分",
       rp: "RP活跃度积分",
       level: "等级",
+    },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "种族",
@@ -2344,6 +2356,9 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
+    },
     components_ladder_rankingsracedistribution: {
       race: "Rasse",
       numberofplayers: "Spieleranzahl",
@@ -2833,6 +2848,9 @@ const data = {
       winrate: "% wygranych",
       mmr: "MMR",
       rp: "RP",
+    },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",
@@ -3377,6 +3395,9 @@ const data = {
       mmr: "MMR",
       rp: "RP",
     },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
+    },
     components_ladder_rankingsracedistribution: {
       race: "Раса",
       numberofplayers: "Кількість гравців",
@@ -3902,6 +3923,9 @@ const data = {
       winrate: "Winrate",
       mmr: "MMR",
       rp: "RP",
+    },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Raça",
@@ -4433,6 +4457,9 @@ const data = {
       winrate: "Pourcentage de victoire",
       mmr: "MMR",
       rp: "RP",
+    },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Race",
@@ -4969,6 +4996,9 @@ const data = {
       mmr: "MMR",
       rp: "RP",
       level: "Nivo",
+    },
+    components_ladder_milestoneprogress: {
+      ariawins: "Wins to next milestone",
     },
     components_ladder_rankingsracedistribution: {
       race: "Rasa",

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -1,5 +1,5 @@
 import { EGameMode, ERaceEnum, Match, timestampString } from "../types";
-import { Gateways, PlayerId, ProgressionRank, Season } from "@/store/ranking/types";
+import { Gateways, MilestoneProgress, PlayerId, ProgressionRank, Season } from "@/store/ranking/types";
 
 export type PlayerState = {
   playerStatsRaceVersusRaceOnMap: PlayerStatsRaceOnMapVersusRace;
@@ -75,6 +75,7 @@ export type ModeStat = {
   playerIds: PlayerId[];
   quantile: number;
   progression?: ProgressionRank | null;
+  milestone?: MilestoneProgress | null;
 };
 
 export interface WinLossesOnMap {

--- a/src/store/ranking/types.ts
+++ b/src/store/ranking/types.ts
@@ -62,6 +62,12 @@ export type ProgressionRank = {
   apexPoints: number | null;
 };
 
+export type MilestoneProgress = {
+  currentWins: number;
+  previousTarget: number;
+  nextTarget: number;
+};
+
 export type Ranking = {
   id: string;
   season: number;


### PR DESCRIPTION
Renders the win-milestone progress bar on the player profile for progression modes, fed by the new `milestone` field served on the profile game-mode-stats DTO (website-backend P8-3, [#531](https://github.com/w3champions/website-backend/pull/531)).

## What

- New `MilestoneProgress.vue` (`src/components/ladder/`) — a raw-wins progress bar to the next round-number milestone, echoing the RP "Level" bar styling. In-band fill `(currentWins − previousTarget)/(nextTarget − previousTarget)` so it resets after each milestone; label `currentWins / nextTarget`.
- `MilestoneProgress` type + `ModeStat.milestone` field (deserializes automatically from the DTO, like the existing `progression` field).
- Mounted **profile-only**, shown **in addition to** the rank (the milestone track is decoupled from rank): `PlayerLeague.vue` (card) + `ModeStatsGrid.vue` (grid), gated to progression modes with a non-null milestone. Ladder grid untouched.
- Parameterized `aria-label` with the win counts; i18n key in all 10 language blocks.

## Verification (no unit runner in this repo)

Verified via `npm run lint` + `npm run dprint` + `npm run type-check-vue` + `npm run build` — all green. **Visual check pending on the PR** (no display in the build environment): confirm the bar renders under the rank on a progression-mode profile (card + grid), resets per milestone, and RP modes show no milestone bar.

## Checklist

- [x] Targets `prj/new-ranking-system`
- [x] Task: P8-3 (website half)
- [x] No unit runner — verified via type-check-vue + lint + dprint + build (visual pending on PR)
- [x] Hard constraints: additive · profile-only (ladder untouched) · gated by `progressionStartSeason` + non-null milestone · public/private boundary · no new flag
- [x] Per-repo doc updated (`docs/ranking.md` — win-milestone bar)