### PR TITLE
feat(ranking): apex leaderboard + progression league navigation (P11-4)

### DIFF
--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -47,6 +47,50 @@ The per-mode branch is applied wherever rank is shown:
 A progression mode is a clean cutover: it never shows the legacy RP "Level". An entity with no progression
 rank yet (`progression == null`) renders as Unranked.
 
+## Ladder navigation (progression modes)
+
+For a progression mode, the rankings view (`src/views/Rankings.vue`) replaces the legacy RP league selector
+with the progression tier list and routes the selection to one of two views. The selector lists, best to
+worst: **Grand Master**, **Master**, then each regular league (Adept … Grass) split into divisions I–IV.
+The tier list comes from `progressionTiers()` / `progressionTierGroups()` (`src/helpers/progression-leagues.ts`).
+
+- **Apex tiers (Grand Master, Master)** open the apex leaderboard view (below).
+- **Non-apex tiers (league + division)** open the progression league ladder, rendered by
+  `ProgressionLadderGrid` (`src/components/ladder/ProgressionLadderGrid.vue`) from
+  `GET /api/ladder/progression?season=&gameMode=&league=&division=&race=`.
+
+Two controls adapt to the progression system:
+
+- The **gateway selector is hidden** for progression modes — progression standings are global
+  (gateway-agnostic).
+- The **race selector appears only for the race-split 1v1 ladder**, i.e. from the race-split start season
+  onward (`RACE_SPLIT_START_SEASON`, `src/constants.ts`, mirroring the backend). Its value is passed to the
+  progression-ladder request; the apex leaderboard is pooled across races and ignores it.
+
+The legacy RP ladder navigation is unchanged: RP modes keep the existing league selector, gateway selector,
+and `RankingsGrid` render. The progression behaviour is purely additive and branched per mode.
+
+### Why a separate grid for the progression ladder
+
+The progression-ladder endpoint intentionally returns rows **without** the legacy per-player overview that
+the RP ladder carries — each row exposes only `playersInfo` plus the `progression` object. Because the
+legacy `RankingsGrid` is built around that per-player overview, the non-apex progression ladder uses a
+dedicated `ProgressionLadderGrid` that renders from `playersInfo` + `progression`, leaving the RP grid
+untouched. This is a deliberate contract choice; the two grids stay independent.
+
+## Apex leaderboard view
+
+`ApexLeaderboardGrid` (`src/components/ladder/ApexLeaderboardGrid.vue`) renders the public apex leaderboard:
+the **Grand Master** and **Master** cohort for a mode, ordered by apex points. A **cutoff line** marks the
+boundary between the Grand Master cohort and the Master cohort, labelled with the cutoff apex points. Each
+row shows the position, league icon, player cell (from `playersInfo`), and apex points. The view is reached
+by selecting the Grand Master or Master tier for a progression mode.
+
+Data comes from `GET /api/ladder/apex?season=&gameMode=` (anonymous, gateway-agnostic), fetched via
+`RankingService.retrieveApexLeaderboard` into `rankingStore.apexLeaderboard`
+(`{ cutoffApexPoints, gmCount, players }`). While loading or when there is no data, the view shows a loading
+or empty state rather than the grid.
+
 ## File reference
 
 | Concern | Path |
@@ -57,3 +101,7 @@ rank yet (`progression == null`) renders as Unranked.
 | Per-mode selection | `src/composables/useRankingSystem.ts`, `src/helpers/progression-rank.ts` |
 | Progression renderer | `src/components/ladder/ProgressionRank.vue` |
 | Render sites | `src/components/ladder/RankingsGrid.vue`, `src/components/player/PlayerLeague.vue`, `src/components/player/ModeStatsGrid.vue`, `src/views/Rankings.vue` |
+| Progression tier list | `src/helpers/progression-leagues.ts` |
+| Progression ladder grid | `src/components/ladder/ProgressionLadderGrid.vue` |
+| Apex leaderboard grid | `src/components/ladder/ApexLeaderboardGrid.vue` |
+| Race-split start season | `src/constants.ts` (`RACE_SPLIT_START_SEASON`) |

--- a/src/components/ladder/ApexLeaderboardGrid.vue
+++ b/src/components/ladder/ApexLeaderboardGrid.vue
@@ -20,32 +20,13 @@
               <league-icon :league="entry.league" />
             </td>
             <td>
-              <div
+              <ladder-player-cell
                 v-for="(playerInfo, pIndex) in entry.playersInfo"
                 :key="playerInfo.battleTag"
-                class="d-inline-block rank-icon-container"
+                :playerInfo="playerInfo"
+                class="rank-icon-container"
                 :class="{ 'ml-3': pIndex > 0 }"
-              >
-                <div
-                  class="player-avatar mr-1 pa-0 race-icon"
-                  :title="getAvatarTitle(playerInfo)"
-                  :style="{ 'background-image': `url(${getPlayerIcon(playerInfo)})` }"
-                ></div>
-                <player-rank-info
-                  :player-id="{ name: playerInfo.battleTag.split('#')[0], battleTag: playerInfo.battleTag }"
-                  :alias="playerInfo.playerAkaData?.name ?? ''"
-                />
-                <div
-                  v-if="playerInfo.countryCode || playerInfo.location"
-                  class="d-inline-block ml-1"
-                >
-                  <country-flag-extended
-                    :countryCode="playerInfo.countryCode"
-                    :location="playerInfo.location"
-                    size="small"
-                  />
-                </div>
-              </div>
+              />
             </td>
             <td class="number-text text-end apex-points">
               {{ entry.apexPoints }}
@@ -84,20 +65,16 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
-import type { ApexLeaderboard, PlayerInfo } from "@/store/ranking/types";
-import { EAvatarCategory, ERaceEnum } from "@/store/types";
-import { getAsset, getAvatarUrl } from "@/helpers/url-functions";
+import type { ApexLeaderboard } from "@/store/ranking/types";
 import LeagueIcon from "@/components/ladder/LeagueIcon.vue";
-import PlayerRankInfo from "@/components/ladder/PlayerRankInfo.vue";
-import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
+import LadderPlayerCell from "@/components/ladder/LadderPlayerCell.vue";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "ApexLeaderboardGrid",
   components: {
     LeagueIcon,
-    PlayerRankInfo,
-    CountryFlagExtended,
+    LadderPlayerCell,
   },
   props: {
     apexLeaderboard: {
@@ -136,43 +113,9 @@ export default defineComponent({
         index < props.apexLeaderboard.players.length - 1;
     }
 
-    function getPlayerIcon(playerInfo: PlayerInfo): string {
-      if (hasSelectedIcon(playerInfo)) {
-        return getAvatarUrl(
-          playerInfo.selectedRace,
-          playerInfo.pictureId,
-          playerInfo.isClassicPicture,
-        );
-      }
-      return getRaceIcon(playerInfo.calculatedRace);
-    }
-
-    function getAvatarTitle(playerInfo: PlayerInfo): string {
-      if (hasSelectedIcon(playerInfo) && playerInfo.selectedRace <= ERaceEnum.UNDEAD) {
-        return ERaceEnum[playerInfo.selectedRace] ?? "";
-      }
-      return ERaceEnum[playerInfo.calculatedRace] ?? "";
-    }
-
-    function hasSelectedIcon(playerInfo: PlayerInfo): boolean {
-      return (
-        playerInfo.selectedRace !== undefined &&
-        playerInfo.selectedRace != null &&
-        playerInfo.pictureId !== undefined &&
-        playerInfo.pictureId != null &&
-        playerInfo.selectedRace !== EAvatarCategory.TOTAL
-      );
-    }
-
-    function getRaceIcon(race: ERaceEnum): string {
-      return getAsset(`raceIcons/${ERaceEnum[race]}.jpg`);
-    }
-
     return {
       headers,
       showCutoffAfter,
-      getPlayerIcon,
-      getAvatarTitle,
     };
   },
 });

--- a/src/components/ladder/ApexLeaderboardGrid.vue
+++ b/src/components/ladder/ApexLeaderboardGrid.vue
@@ -1,0 +1,251 @@
+<template>
+  <div class="elevation-1">
+    <table v-if="apexLeaderboard.players.length > 0" class="custom-table">
+      <thead>
+        <tr class="w3-mid-emphasis">
+          <td
+            v-for="header in headers"
+            :key="header.name"
+            :style="{ width: header.width, 'min-width': header.minWidth }"
+          >
+            {{ header.text }}
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="(entry, index) in apexLeaderboard.players" :key="entry.rankNumber">
+          <tr class="w3-mid-emphasis">
+            <td class="number-text">{{ entry.rankNumber }}.</td>
+            <td>
+              <league-icon :league="entry.league" />
+            </td>
+            <td>
+              <div
+                v-for="(playerInfo, pIndex) in entry.playersInfo"
+                :key="playerInfo.battleTag"
+                class="d-inline-block rank-icon-container"
+                :class="{ 'ml-3': pIndex > 0 }"
+              >
+                <div
+                  class="player-avatar mr-1 pa-0 race-icon"
+                  :title="getAvatarTitle(playerInfo)"
+                  :style="{ 'background-image': `url(${getPlayerIcon(playerInfo)})` }"
+                ></div>
+                <player-rank-info
+                  :player-id="{ name: playerInfo.battleTag.split('#')[0], battleTag: playerInfo.battleTag }"
+                  :alias="playerInfo.playerAkaData?.name ?? ''"
+                />
+                <div
+                  v-if="playerInfo.countryCode || playerInfo.location"
+                  class="d-inline-block ml-1"
+                >
+                  <country-flag-extended
+                    :countryCode="playerInfo.countryCode"
+                    :location="playerInfo.location"
+                    size="small"
+                  />
+                </div>
+              </div>
+            </td>
+            <td class="number-text text-end apex-points">
+              {{ entry.apexPoints }}
+            </td>
+          </tr>
+          <tr
+            v-if="showCutoffAfter(index)"
+            :key="`cutoff-${index}`"
+            class="apex-cutoff-row"
+          >
+            <td colspan="4" class="apex-cutoff-cell">
+              <div class="apex-cutoff-line">
+                <span class="apex-cutoff-label">
+                  {{ $t("components_ladder_apexleaderboardgrid.cutoff") }}
+                  <span v-if="apexLeaderboard.cutoffApexPoints != null" class="apex-cutoff-points">
+                    {{ apexLeaderboard.cutoffApexPoints }}
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+    <table v-else class="custom-table">
+      <tbody>
+        <tr>
+          <td colspan="4" class="text-center">
+            {{ $t("components_ladder_apexleaderboardgrid.noplayers") }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import type { ApexLeaderboard, PlayerInfo } from "@/store/ranking/types";
+import { EAvatarCategory, ERaceEnum } from "@/store/types";
+import { getAsset, getAvatarUrl } from "@/helpers/url-functions";
+import LeagueIcon from "@/components/ladder/LeagueIcon.vue";
+import PlayerRankInfo from "@/components/ladder/PlayerRankInfo.vue";
+import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
+import { useI18n } from "vue-i18n";
+
+export default defineComponent({
+  name: "ApexLeaderboardGrid",
+  components: {
+    LeagueIcon,
+    PlayerRankInfo,
+    CountryFlagExtended,
+  },
+  props: {
+    apexLeaderboard: {
+      type: Object as PropType<ApexLeaderboard>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { t } = useI18n();
+
+    const headers = [
+      {
+        name: "Rank",
+        text: t("components_ladder_rankingsgrid.rank"),
+        width: "25px",
+      },
+      {
+        name: "League",
+        text: t("components_ladder_apexleaderboardgrid.league"),
+        width: "30px",
+      },
+      {
+        name: "Player",
+        text: t("components_ladder_rankingsgrid.player"),
+        minWidth: "170px",
+      },
+      {
+        name: "ApexPoints",
+        text: t("components_ladder_apexleaderboardgrid.apexpoints"),
+        width: "80px",
+      },
+    ];
+
+    function showCutoffAfter(index: number): boolean {
+      return index === props.apexLeaderboard.gmCount - 1 &&
+        index < props.apexLeaderboard.players.length - 1;
+    }
+
+    function getPlayerIcon(playerInfo: PlayerInfo): string {
+      if (hasSelectedIcon(playerInfo)) {
+        return getAvatarUrl(
+          playerInfo.selectedRace,
+          playerInfo.pictureId,
+          playerInfo.isClassicPicture,
+        );
+      }
+      return getRaceIcon(playerInfo.calculatedRace);
+    }
+
+    function getAvatarTitle(playerInfo: PlayerInfo): string {
+      if (hasSelectedIcon(playerInfo) && playerInfo.selectedRace <= ERaceEnum.UNDEAD) {
+        return ERaceEnum[playerInfo.selectedRace] ?? "";
+      }
+      return ERaceEnum[playerInfo.calculatedRace] ?? "";
+    }
+
+    function hasSelectedIcon(playerInfo: PlayerInfo): boolean {
+      return (
+        playerInfo.selectedRace !== undefined &&
+        playerInfo.selectedRace != null &&
+        playerInfo.pictureId !== undefined &&
+        playerInfo.pictureId != null &&
+        playerInfo.selectedRace !== EAvatarCategory.TOTAL
+      );
+    }
+
+    function getRaceIcon(race: ERaceEnum): string {
+      return getAsset(`raceIcons/${ERaceEnum[race]}.jpg`);
+    }
+
+    return {
+      headers,
+      showCutoffAfter,
+      getPlayerIcon,
+      getAvatarTitle,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.rank-icon-container {
+  vertical-align: middle;
+}
+
+.apex-points {
+  font-weight: 700;
+  min-width: 60px;
+}
+
+.apex-cutoff-row {
+  pointer-events: none;
+}
+
+.apex-cutoff-cell {
+  padding: 0 !important;
+}
+
+.apex-cutoff-line {
+  position: relative;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 2px;
+    background: linear-gradient(
+      to right,
+      transparent 0%,
+      rgb(var(--v-theme-warning)) 15%,
+      rgb(var(--v-theme-warning)) 85%,
+      transparent 100%
+    );
+    opacity: 0.75;
+  }
+}
+
+.apex-cutoff-label {
+  position: relative;
+  z-index: 1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 10px;
+  border-radius: 3px;
+  background-color: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-warning));
+  border: 1px solid rgba(var(--v-theme-warning), 0.4);
+  white-space: nowrap;
+}
+
+.apex-cutoff-points {
+  margin-left: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 768px) {
+  .rank-icon-container {
+    margin-top: 5px;
+    margin-left: 0 !important;
+  }
+}
+</style>

--- a/src/components/ladder/LadderPlayerCell.vue
+++ b/src/components/ladder/LadderPlayerCell.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="ladder-player-cell">
+    <div
+      class="player-avatar mr-1 pa-0 race-icon"
+      :title="getAvatarTitle(playerInfo)"
+      :style="{ 'background-image': `url(${getPlayerIcon(playerInfo)})` }"
+    ></div>
+    <player-rank-info
+      :player-id="{ name: playerInfo.battleTag.split('#')[0], battleTag: playerInfo.battleTag }"
+      :alias="playerInfo.playerAkaData?.name ?? ''"
+    />
+    <div
+      v-if="playerInfo.countryCode || playerInfo.location"
+      class="d-inline-block ml-1"
+    >
+      <country-flag-extended
+        :countryCode="playerInfo.countryCode"
+        :location="playerInfo.location"
+        size="small"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import type { PlayerInfo } from "@/store/ranking/types";
+import PlayerRankInfo from "@/components/ladder/PlayerRankInfo.vue";
+import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
+import { usePlayerAvatar } from "@/composables/usePlayerAvatar";
+
+// A single ladder player cell: race/avatar icon + name (with profile link) + country flag.
+// Renders from a PlayerInfo (used by the apex + progression ladders, where the per-player
+// overview is absent and rows are built from playersInfo).
+export default defineComponent({
+  name: "LadderPlayerCell",
+  components: {
+    PlayerRankInfo,
+    CountryFlagExtended,
+  },
+  props: {
+    playerInfo: {
+      type: Object as PropType<PlayerInfo>,
+      required: true,
+    },
+  },
+  setup() {
+    const { getPlayerIcon, getAvatarTitle } = usePlayerAvatar();
+    return { getPlayerIcon, getAvatarTitle };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.ladder-player-cell {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/src/components/ladder/ProgressionLadderGrid.vue
+++ b/src/components/ladder/ProgressionLadderGrid.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="elevation-1">
+    <table v-if="rankings.length > 0" class="custom-table">
+      <thead>
+        <tr class="w3-mid-emphasis">
+          <td
+            v-for="header in headers"
+            :key="header.name"
+            :style="{ width: header.width, 'min-width': header.minWidth }"
+          >
+            {{ header.text }}
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="item in rankings"
+          :id="`listitem_${item.rankNumber}`"
+          :key="item.rankNumber"
+          class="w3-mid-emphasis"
+        >
+          <td class="number-text">{{ item.rankNumber }}.</td>
+          <td class="d-md-flex">
+            <div
+              v-for="(playerInfo, index) in item.playersInfo"
+              :key="playerInfo.battleTag"
+              class="rank-icon-container my-1"
+              :class="{ 'ml-md-3': index > 0 }"
+            >
+              <div
+                class="player-avatar mr-1 pa-0 race-icon"
+                :title="getAvatarTitle(playerInfo)"
+                :style="{ 'background-image': `url(${getPlayerIcon(playerInfo)})` }"
+              ></div>
+              <player-rank-info
+                :player-id="{ name: playerInfo.battleTag.split('#')[0], battleTag: playerInfo.battleTag }"
+                :alias="playerInfo.playerAkaData?.name ?? ''"
+              />
+              <div
+                v-if="playerInfo.countryCode || playerInfo.location"
+                class="ml-1"
+              >
+                <country-flag-extended
+                  :countryCode="playerInfo.countryCode"
+                  :location="playerInfo.location"
+                  size="small"
+                />
+              </div>
+            </div>
+          </td>
+          <td class="number-text text-center">
+            <progression-rank v-if="item.progression" :progression="item.progression" />
+            <span v-else>{{ $t("views_rankings.unranked") }}</span>
+          </td>
+          <td class="number-text text-end"><race-icon :race="item.race" /></td>
+          <td class="number-text text-end">
+            {{ item.playersInfo.map((p) => (p.clanId ? p.clanId : "-")).join("/") }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table v-else class="custom-table">
+      <tbody>
+        <tr>
+          <td colspan="5" class="text-center">
+            {{ $t("components_ladder_progressionladdergrid.noplayers") }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import type { PlayerInfo, Ranking } from "@/store/ranking/types";
+import { EAvatarCategory, ERaceEnum } from "@/store/types";
+import { getAsset, getAvatarUrl } from "@/helpers/url-functions";
+import PlayerRankInfo from "@/components/ladder/PlayerRankInfo.vue";
+import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
+import RaceIcon from "@/components/player/RaceIcon.vue";
+import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
+import { useI18n } from "vue-i18n";
+
+export default defineComponent({
+  name: "ProgressionLadderGrid",
+  components: {
+    PlayerRankInfo,
+    CountryFlagExtended,
+    RaceIcon,
+    ProgressionRank,
+  },
+  props: {
+    rankings: {
+      type: Array as PropType<Ranking[]>,
+      required: true,
+    },
+  },
+  setup() {
+    const { t } = useI18n();
+
+    const headers = [
+      { name: "Position", text: t("components_ladder_progressionladdergrid.position"), width: "25px" },
+      { name: "Player", text: t("components_ladder_rankingsgrid.player"), minWidth: "170px" },
+      { name: "Rank", text: t("components_ladder_rankingsgrid.rank"), width: "100px" },
+      { name: "Race", text: t("components_ladder_rankingsgrid.race"), width: "50px" },
+      { name: "Clan", text: t("components_ladder_rankingsgrid.clan"), width: "50px" },
+    ];
+
+    function getPlayerIcon(playerInfo: PlayerInfo): string {
+      if (hasSelectedIcon(playerInfo)) {
+        return getAvatarUrl(playerInfo.selectedRace, playerInfo.pictureId, playerInfo.isClassicPicture);
+      }
+      return getRaceIcon(playerInfo.calculatedRace);
+    }
+
+    function getAvatarTitle(playerInfo: PlayerInfo): string {
+      if (hasSelectedIcon(playerInfo) && playerInfo.selectedRace <= ERaceEnum.UNDEAD) {
+        return t(`races.${ERaceEnum[playerInfo.selectedRace]}`);
+      }
+      return t(`races.${ERaceEnum[playerInfo.calculatedRace]}`);
+    }
+
+    function hasSelectedIcon(playerInfo: PlayerInfo): boolean {
+      return (
+        playerInfo.selectedRace !== undefined &&
+        playerInfo.selectedRace != null &&
+        playerInfo.pictureId !== undefined &&
+        playerInfo.pictureId != null &&
+        playerInfo.selectedRace !== EAvatarCategory.TOTAL
+      );
+    }
+
+    function getRaceIcon(race: ERaceEnum): string {
+      return getAsset(`raceIcons/${ERaceEnum[race]}.jpg`);
+    }
+
+    return {
+      headers,
+      getPlayerIcon,
+      getAvatarTitle,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@media (max-width: 768px) {
+  .rank-icon-container {
+    margin-top: 5px;
+    margin-left: 0 !important;
+  }
+}
+</style>

--- a/src/components/ladder/ProgressionLadderGrid.vue
+++ b/src/components/ladder/ProgressionLadderGrid.vue
@@ -21,32 +21,13 @@
         >
           <td class="number-text">{{ item.rankNumber }}.</td>
           <td class="d-md-flex">
-            <div
+            <ladder-player-cell
               v-for="(playerInfo, index) in item.playersInfo"
               :key="playerInfo.battleTag"
+              :playerInfo="playerInfo"
               class="rank-icon-container my-1"
               :class="{ 'ml-md-3': index > 0 }"
-            >
-              <div
-                class="player-avatar mr-1 pa-0 race-icon"
-                :title="getAvatarTitle(playerInfo)"
-                :style="{ 'background-image': `url(${getPlayerIcon(playerInfo)})` }"
-              ></div>
-              <player-rank-info
-                :player-id="{ name: playerInfo.battleTag.split('#')[0], battleTag: playerInfo.battleTag }"
-                :alias="playerInfo.playerAkaData?.name ?? ''"
-              />
-              <div
-                v-if="playerInfo.countryCode || playerInfo.location"
-                class="ml-1"
-              >
-                <country-flag-extended
-                  :countryCode="playerInfo.countryCode"
-                  :location="playerInfo.location"
-                  size="small"
-                />
-              </div>
-            </div>
+            />
           </td>
           <td class="number-text text-center">
             <progression-rank v-if="item.progression" :progression="item.progression" />
@@ -73,11 +54,8 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
-import type { PlayerInfo, Ranking } from "@/store/ranking/types";
-import { EAvatarCategory, ERaceEnum } from "@/store/types";
-import { getAsset, getAvatarUrl } from "@/helpers/url-functions";
-import PlayerRankInfo from "@/components/ladder/PlayerRankInfo.vue";
-import CountryFlagExtended from "@/components/common/CountryFlagExtended.vue";
+import type { Ranking } from "@/store/ranking/types";
+import LadderPlayerCell from "@/components/ladder/LadderPlayerCell.vue";
 import RaceIcon from "@/components/player/RaceIcon.vue";
 import ProgressionRank from "@/components/ladder/ProgressionRank.vue";
 import { useI18n } from "vue-i18n";
@@ -85,8 +63,7 @@ import { useI18n } from "vue-i18n";
 export default defineComponent({
   name: "ProgressionLadderGrid",
   components: {
-    PlayerRankInfo,
-    CountryFlagExtended,
+    LadderPlayerCell,
     RaceIcon,
     ProgressionRank,
   },
@@ -107,38 +84,8 @@ export default defineComponent({
       { name: "Clan", text: t("components_ladder_rankingsgrid.clan"), width: "50px" },
     ];
 
-    function getPlayerIcon(playerInfo: PlayerInfo): string {
-      if (hasSelectedIcon(playerInfo)) {
-        return getAvatarUrl(playerInfo.selectedRace, playerInfo.pictureId, playerInfo.isClassicPicture);
-      }
-      return getRaceIcon(playerInfo.calculatedRace);
-    }
-
-    function getAvatarTitle(playerInfo: PlayerInfo): string {
-      if (hasSelectedIcon(playerInfo) && playerInfo.selectedRace <= ERaceEnum.UNDEAD) {
-        return t(`races.${ERaceEnum[playerInfo.selectedRace]}`);
-      }
-      return t(`races.${ERaceEnum[playerInfo.calculatedRace]}`);
-    }
-
-    function hasSelectedIcon(playerInfo: PlayerInfo): boolean {
-      return (
-        playerInfo.selectedRace !== undefined &&
-        playerInfo.selectedRace != null &&
-        playerInfo.pictureId !== undefined &&
-        playerInfo.pictureId != null &&
-        playerInfo.selectedRace !== EAvatarCategory.TOTAL
-      );
-    }
-
-    function getRaceIcon(race: ERaceEnum): string {
-      return getAsset(`raceIcons/${ERaceEnum[race]}.jpg`);
-    }
-
     return {
       headers,
-      getPlayerIcon,
-      getAvatarTitle,
     };
   },
 });

--- a/src/composables/usePlayerAvatar.ts
+++ b/src/composables/usePlayerAvatar.ts
@@ -1,0 +1,48 @@
+import type { PlayerInfo } from "@/store/ranking/types";
+import { EAvatarCategory, ERaceEnum } from "@/store/types";
+import { getAsset, getAvatarUrl } from "@/helpers/url-functions";
+import { useI18n } from "vue-i18n";
+
+interface UsePlayerAvatar {
+  // True when the player has a chosen avatar picture (not the default race-derived icon).
+  hasSelectedIcon: (playerInfo: PlayerInfo) => boolean;
+  // The avatar image URL: the selected picture if present, otherwise the calculated-race icon.
+  getPlayerIcon: (playerInfo: PlayerInfo) => string;
+  // The translated race label used as the avatar's title/tooltip.
+  getAvatarTitle: (playerInfo: PlayerInfo) => string;
+}
+
+// Shared avatar/icon logic for ladder player cells (apex + progression ladders).
+export function usePlayerAvatar(): UsePlayerAvatar {
+  const { t } = useI18n();
+
+  function hasSelectedIcon(playerInfo: PlayerInfo): boolean {
+    return (
+      playerInfo.selectedRace !== undefined
+      && playerInfo.selectedRace != null
+      && playerInfo.pictureId !== undefined
+      && playerInfo.pictureId != null
+      && playerInfo.selectedRace !== EAvatarCategory.TOTAL
+    );
+  }
+
+  function getRaceIcon(race: ERaceEnum): string {
+    return getAsset(`raceIcons/${ERaceEnum[race]}.jpg`);
+  }
+
+  function getPlayerIcon(playerInfo: PlayerInfo): string {
+    if (hasSelectedIcon(playerInfo)) {
+      return getAvatarUrl(playerInfo.selectedRace, playerInfo.pictureId, playerInfo.isClassicPicture);
+    }
+    return getRaceIcon(playerInfo.calculatedRace);
+  }
+
+  function getAvatarTitle(playerInfo: PlayerInfo): string {
+    if (hasSelectedIcon(playerInfo) && playerInfo.selectedRace <= ERaceEnum.UNDEAD) {
+      return t(`races.${ERaceEnum[playerInfo.selectedRace]}`);
+    }
+    return t(`races.${ERaceEnum[playerInfo.calculatedRace]}`);
+  }
+
+  return { hasSelectedIcon, getPlayerIcon, getAvatarTitle };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,10 @@ import { Gateways } from "@/store/ranking/types";
 
 export const GATEWAY_REQUIRED_UNTIL_SEASON = 5;
 
+// The first season the 1v1 ladder is split per race. Mirrors the backend's
+// GameModesHelper.RaceSplitStartSeason.
+export const RACE_SPLIT_START_SEASON = 2;
+
 export const isGatewayNeededForSeason = (seasonId: number): boolean => {
   return seasonId <= GATEWAY_REQUIRED_UNTIL_SEASON;
 };

--- a/src/helpers/progression-leagues.ts
+++ b/src/helpers/progression-leagues.ts
@@ -1,0 +1,67 @@
+import { LEAGUE_NAMES } from "@/helpers/progression-rank";
+
+// Apex leagues (Grand Master, Master) have no divisions; every other league has 4.
+export const APEX_LEAGUES = [0, 1] as const;
+export const DIVISIONS_PER_LEAGUE = 4;
+const LOWEST_LEAGUE = LEAGUE_NAMES.length - 1; // 8 = Grass
+
+export type ProgressionTier = {
+  league: number;
+  // Apex tiers (Grand Master / Master) carry no division.
+  division?: number;
+};
+
+// True for the apex tiers (Grand Master = 0, Master = 1), which are rendered as the
+// apex leaderboard and have no divisions.
+export function isApexTier(tier: ProgressionTier): boolean {
+  return APEX_LEAGUES.includes(tier.league as (typeof APEX_LEAGUES)[number]);
+}
+
+// The display label for a tier: the league name, plus the division number for non-apex tiers.
+export function tierLabel(tier: ProgressionTier): string {
+  const name = LEAGUE_NAMES[tier.league] ?? "";
+  if (isApexTier(tier) || tier.division == null) {
+    return name;
+  }
+  return `${name} ${tier.division}`;
+}
+
+// Stable identity for a tier, usable as a list key.
+export function tierKey(tier: ProgressionTier): string {
+  return isApexTier(tier) ? `apex-${tier.league}` : `${tier.league}-${tier.division}`;
+}
+
+// The ordered list of progression tiers, best to worst:
+//   Grand Master, Master, then leagues 2..8 each split into divisions 1..4.
+export function progressionTiers(): ProgressionTier[] {
+  const tiers: ProgressionTier[] = APEX_LEAGUES.map((league) => ({ league }));
+
+  for (let league = APEX_LEAGUES.length; league <= LOWEST_LEAGUE; league++) {
+    for (let division = 1; division <= DIVISIONS_PER_LEAGUE; division++) {
+      tiers.push({ league, division });
+    }
+  }
+
+  return tiers;
+}
+
+// Tiers grouped by league for a grouped selector: an ordered list of leagues, each with its
+// label, league index (icon), and the tiers under it (a single tier for apex leagues).
+export type ProgressionTierGroup = {
+  league: number;
+  label: string;
+  tiers: ProgressionTier[];
+};
+
+export function progressionTierGroups(): ProgressionTierGroup[] {
+  const groups = new Map<number, ProgressionTierGroup>();
+  for (const tier of progressionTiers()) {
+    let group = groups.get(tier.league);
+    if (!group) {
+      group = { league: tier.league, label: LEAGUE_NAMES[tier.league] ?? "", tiers: [] };
+      groups.set(tier.league, group);
+    }
+    group.tiers.push(tier);
+  }
+  return [...groups.values()];
+}

--- a/src/helpers/progression-leagues.ts
+++ b/src/helpers/progression-leagues.ts
@@ -1,20 +1,29 @@
 import { LEAGUE_NAMES } from "@/helpers/progression-rank";
+import { EProgressionLeague } from "@/store/types";
 
 // Apex leagues (Grand Master, Master) have no divisions; every other league has 4.
-export const APEX_LEAGUES = [0, 1] as const;
+export const APEX_LEAGUES = [EProgressionLeague.GrandMaster, EProgressionLeague.Master] as const;
+export const FIRST_DIVISION = 1;
 export const DIVISIONS_PER_LEAGUE = 4;
-const LOWEST_LEAGUE = LEAGUE_NAMES.length - 1; // 8 = Grass
+// The regular (non-apex) league range, best to worst, driven by the enum.
+const FIRST_NON_APEX_LEAGUE = EProgressionLeague.Adept;
+const LOWEST_LEAGUE = EProgressionLeague.Grass;
 
 export type ProgressionTier = {
-  league: number;
+  league: EProgressionLeague;
   // Apex tiers (Grand Master / Master) carry no division.
   division?: number;
 };
 
-// True for the apex tiers (Grand Master = 0, Master = 1), which are rendered as the
-// apex leaderboard and have no divisions.
+// True for the apex leagues (Grand Master, Master), which render as the apex leaderboard and
+// have no divisions.
+export function isApexLeague(league: EProgressionLeague): boolean {
+  return league === EProgressionLeague.GrandMaster || league === EProgressionLeague.Master;
+}
+
+// True for the apex tiers (their league is an apex league).
 export function isApexTier(tier: ProgressionTier): boolean {
-  return APEX_LEAGUES.includes(tier.league as (typeof APEX_LEAGUES)[number]);
+  return isApexLeague(tier.league);
 }
 
 // The display label for a tier: the league name, plus the division number for non-apex tiers.
@@ -32,12 +41,12 @@ export function tierKey(tier: ProgressionTier): string {
 }
 
 // The ordered list of progression tiers, best to worst:
-//   Grand Master, Master, then leagues 2..8 each split into divisions 1..4.
+//   Grand Master, Master, then each remaining league split into divisions 1..DIVISIONS_PER_LEAGUE.
 export function progressionTiers(): ProgressionTier[] {
   const tiers: ProgressionTier[] = APEX_LEAGUES.map((league) => ({ league }));
 
-  for (let league = APEX_LEAGUES.length; league <= LOWEST_LEAGUE; league++) {
-    for (let division = 1; division <= DIVISIONS_PER_LEAGUE; division++) {
+  for (let league = FIRST_NON_APEX_LEAGUE; league <= LOWEST_LEAGUE; league++) {
+    for (let division = FIRST_DIVISION; division < FIRST_DIVISION + DIVISIONS_PER_LEAGUE; division++) {
       tiers.push({ league, division });
     }
   }
@@ -45,16 +54,22 @@ export function progressionTiers(): ProgressionTier[] {
   return tiers;
 }
 
+// The default landing tier for a progression mode: the first division of the first non-apex league.
+export const DEFAULT_PROGRESSION_TIER: ProgressionTier = {
+  league: FIRST_NON_APEX_LEAGUE,
+  division: FIRST_DIVISION,
+};
+
 // Tiers grouped by league for a grouped selector: an ordered list of leagues, each with its
 // label, league index (icon), and the tiers under it (a single tier for apex leagues).
 export type ProgressionTierGroup = {
-  league: number;
+  league: EProgressionLeague;
   label: string;
   tiers: ProgressionTier[];
 };
 
 export function progressionTierGroups(): ProgressionTierGroup[] {
-  const groups = new Map<number, ProgressionTierGroup>();
+  const groups = new Map<EProgressionLeague, ProgressionTierGroup>();
   for (const tier of progressionTiers()) {
     let group = groups.get(tier.league);
     if (!group) {

--- a/src/helpers/progression-rank.ts
+++ b/src/helpers/progression-rank.ts
@@ -15,7 +15,8 @@ export function rankingSystemForSeason(
     : "rp";
 }
 
-// League index matches the legacy `leagueOrder` scale: 0 = Grandmaster (best) … 8 = Grass (worst).
+// Display labels indexed by `EProgressionLeague` (0 = Grand Master … 8 = Grass), which also
+// matches the legacy `leagueOrder` scale.
 export const LEAGUE_NAMES = [
   "grandmaster",
   "master",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -567,6 +567,11 @@ const en = {
     cutoff: "GM Cutoff",
     noplayers: "No players found.",
   },
+
+  components_ladder_progressionladdergrid: {
+    position: "#",
+    noplayers: "No players found.",
+  },
 };
 
 export default en;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -560,6 +560,13 @@ const en = {
     error_generic: "Something went wrong while signing you in. Please try again.",
     error_cta: "Back to Home",
   },
+
+  components_ladder_apexleaderboardgrid: {
+    league: "League",
+    apexpoints: "Apex Points",
+    cutoff: "GM Cutoff",
+    noplayers: "No players found.",
+  },
 };
 
 export default en;

--- a/src/services/RankingService.ts
+++ b/src/services/RankingService.ts
@@ -1,6 +1,6 @@
 import { ActiveGameMode, ApexLeaderboard, CountryRanking, Gateways, Ladder, Ranking, Season } from "@/store/ranking/types";
 import { API_URL } from "@/main";
-import { EGameMode } from "@/store/types";
+import { EGameMode, ERaceEnum } from "@/store/types";
 
 export default class RankingService {
   public static async retrieveRankings(
@@ -72,6 +72,25 @@ export default class RankingService {
     const response = await fetch(url);
     if (!response.ok) {
       return null;
+    }
+    return await response.json();
+  }
+
+  public static async retrieveProgressionLadder(
+    season: number,
+    gameMode: EGameMode,
+    league: number,
+    division: number,
+    race?: ERaceEnum,
+  ): Promise<Ranking[]> {
+    let url = `${API_URL}api/ladder/progression?season=${season}&gameMode=${gameMode}&league=${league}&division=${division}`;
+    if (race != null) {
+      url += `&race=${race}`;
+    }
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      return [];
     }
     return await response.json();
   }

--- a/src/services/RankingService.ts
+++ b/src/services/RankingService.ts
@@ -1,4 +1,4 @@
-import { ActiveGameMode, CountryRanking, Gateways, Ladder, Ranking, Season } from "@/store/ranking/types";
+import { ActiveGameMode, ApexLeaderboard, CountryRanking, Gateways, Ladder, Ranking, Season } from "@/store/ranking/types";
 import { API_URL } from "@/main";
 import { EGameMode } from "@/store/types";
 
@@ -55,6 +55,19 @@ export default class RankingService {
 
   public static async retrieveActiveGameModes(): Promise<ActiveGameMode[] | null> {
     const url = `${API_URL}api/ladder/active-modes`;
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  }
+
+  public static async retrieveApexLeaderboard(
+    season: number,
+    gameMode: EGameMode,
+  ): Promise<ApexLeaderboard | null> {
+    const url = `${API_URL}api/ladder/apex?season=${season}&gameMode=${gameMode}`;
 
     const response = await fetch(url);
     if (!response.ok) {

--- a/src/store/ranking/store.ts
+++ b/src/store/ranking/store.ts
@@ -1,4 +1,4 @@
-import type { ActiveGameMode, CountryRanking, Ladder, Ranking, RankingState, Season } from "./types";
+import type { ActiveGameMode, ApexLeaderboard, CountryRanking, Ladder, Ranking, RankingState, Season } from "./types";
 import { type DataTableOptions, EGameMode } from "../types";
 import { defineStore } from "pinia";
 import isEmpty from "lodash/isEmpty";
@@ -23,6 +23,8 @@ export const useRankingStore = defineStore("ranking", {
     selectedSeason: {} as Season,
     selectedCountry: "",
     activeModes: [] as ActiveGameMode[],
+    apexLeaderboard: null,
+    apexLoading: false,
   }),
   actions: {
     async retrieveRankings(options?: DataTableOptions, showLoading: boolean = true) {
@@ -122,6 +124,15 @@ export const useRankingStore = defineStore("ranking", {
         this.SET_ACTIVE_MODES(modes);
       }
     },
+    async retrieveApexLeaderboard(season: number, gameMode: EGameMode) {
+      this.SET_APEX_LOADING(true);
+      try {
+        const leaderboard = await RankingService.retrieveApexLeaderboard(season, gameMode);
+        this.SET_APEX_LEADERBOARD(leaderboard);
+      } finally {
+        this.SET_APEX_LOADING(false);
+      }
+    },
     SET_RANKINGS(rankings: Ranking[]): void {
       this.rankings = rankings;
     },
@@ -166,6 +177,12 @@ export const useRankingStore = defineStore("ranking", {
     },
     SET_LOADING(isLoading: boolean): void {
       this.loading = isLoading;
+    },
+    SET_APEX_LEADERBOARD(leaderboard: ApexLeaderboard | null): void {
+      this.apexLeaderboard = leaderboard;
+    },
+    SET_APEX_LOADING(isLoading: boolean): void {
+      this.apexLoading = isLoading;
     },
   },
 });

--- a/src/store/ranking/store.ts
+++ b/src/store/ranking/store.ts
@@ -1,5 +1,5 @@
 import type { ActiveGameMode, ApexLeaderboard, CountryRanking, Ladder, Ranking, RankingState, Season } from "./types";
-import { type DataTableOptions, EGameMode } from "../types";
+import { type DataTableOptions, EGameMode, ERaceEnum } from "../types";
 import { defineStore } from "pinia";
 import isEmpty from "lodash/isEmpty";
 import RankingService from "@/services/RankingService";
@@ -131,6 +131,22 @@ export const useRankingStore = defineStore("ranking", {
         this.SET_APEX_LEADERBOARD(leaderboard);
       } finally {
         this.SET_APEX_LOADING(false);
+      }
+    },
+    async retrieveProgressionLadder(
+      season: number,
+      gameMode: EGameMode,
+      league: number,
+      division: number,
+      race?: ERaceEnum,
+    ) {
+      this.SET_LOADING(true);
+      try {
+        const ladder = await RankingService.retrieveProgressionLadder(season, gameMode, league, division, race);
+        this.SET_TOTAL_RANKS(ladder.length);
+        this.SET_RANKINGS(ladder);
+      } finally {
+        this.SET_LOADING(false);
       }
     },
     SET_RANKINGS(rankings: Ranking[]): void {

--- a/src/store/ranking/types.ts
+++ b/src/store/ranking/types.ts
@@ -1,5 +1,5 @@
 import { WinLoss } from "@/store/overallStats/types";
-import { EGameMode, EGameModeType, ERaceEnum } from "@/store/types";
+import { EGameMode, EGameModeType, EProgressionLeague, ERaceEnum } from "@/store/types";
 import { AliasData } from "../player/types";
 
 export type RankingState = {
@@ -133,7 +133,8 @@ export interface CountryType {
 export type ApexLeaderboardEntry = {
   playersInfo: PlayerInfo[];
   apexPoints: number;
-  league: number;
+  // 0 = Grand Master, 1 = Master (see EProgressionLeague).
+  league: EProgressionLeague;
   rankNumber: number;
 };
 

--- a/src/store/ranking/types.ts
+++ b/src/store/ranking/types.ts
@@ -18,6 +18,8 @@ export type RankingState = {
   selectedSeason: Season;
   selectedCountry: string;
   activeModes: ActiveGameMode[];
+  apexLeaderboard: ApexLeaderboard | null;
+  apexLoading: boolean;
 };
 
 export type Ladder = {
@@ -126,3 +128,16 @@ export interface CountryType {
   country: string;
   countryCode: string;
 }
+
+export type ApexLeaderboardEntry = {
+  playersInfo: PlayerInfo[];
+  apexPoints: number;
+  league: number;
+  rankNumber: number;
+};
+
+export type ApexLeaderboard = {
+  cutoffApexPoints: number | null;
+  gmCount: number;
+  players: ApexLeaderboardEntry[];
+};

--- a/src/store/ranking/types.ts
+++ b/src/store/ranking/types.ts
@@ -90,6 +90,7 @@ export type CountryRanking = {
 };
 
 export interface PlayerInfo {
+  battleTag: string;
   calculatedRace: ERaceEnum;
   selectedRace: number;
   pictureId: number;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -186,6 +186,20 @@ export enum EGameModeType {
   NON_MELEE = "NON_MELEE",
 }
 
+// Progression league index (matches the legacy `leagueOrder` scale: 0 = best, 8 = worst).
+// Grand Master and Master are the apex leagues (no divisions); the rest have divisions 1..4.
+export enum EProgressionLeague {
+  GrandMaster = 0,
+  Master = 1,
+  Adept = 2,
+  Diamond = 3,
+  Platinum = 4,
+  Gold = 5,
+  Silver = 6,
+  Bronze = 7,
+  Grass = 8,
+}
+
 export enum EPick {
   OVERALL,
   FIRST = 1,

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -280,7 +280,14 @@ import { useRankingStore } from "@/store/ranking/store";
 import { useMatchStore } from "@/store/match/store";
 import { useRootStateStore } from "@/store/rootState/store";
 import { useRankingSystem } from "@/composables/useRankingSystem";
-import { type ProgressionTier, isApexTier, progressionTierGroups, tierKey, tierLabel } from "@/helpers/progression-leagues";
+import {
+  DEFAULT_PROGRESSION_TIER,
+  isApexTier,
+  type ProgressionTier,
+  progressionTierGroups,
+  tierKey,
+  tierLabel,
+} from "@/helpers/progression-leagues";
 import { mdiMagnify } from "@mdi/js";
 import { useRouter } from "vue-router";
 import noop from "lodash/noop";
@@ -336,9 +343,7 @@ export default defineComponent({
     const isProgrammaticSelection = ref<boolean>(false);
 
     const { resolveRankingSystem } = useRankingSystem();
-    // The first non-apex tier (Adept I) — the default landing tier for a progression mode.
-    const defaultProgressionTier: ProgressionTier = { league: 2, division: 1 };
-    const selectedTier = ref<ProgressionTier>(defaultProgressionTier);
+    const selectedTier = ref<ProgressionTier>(DEFAULT_PROGRESSION_TIER);
     const selectedRace = ref<ERaceEnum>(ERaceEnum.HUMAN);
 
     const isProgressionMode = computed<boolean>(() =>
@@ -588,7 +593,7 @@ export default defineComponent({
       if (resolveRankingSystem(gameMode, rankingsStore.selectedSeason.id) === "progression") {
         rankingsStore.SET_GAME_MODE(gameMode);
         rankingsStore.SET_PAGE(0);
-        selectedTier.value = defaultProgressionTier;
+        selectedTier.value = DEFAULT_PROGRESSION_TIER;
         await loadProgressionView();
         return;
       }
@@ -661,7 +666,7 @@ export default defineComponent({
       if (isProgressionMode.value) {
         // Progression modes render the apex leaderboard or progression league ladder rather than
         // the RP ladder. Start at the default tier and load its view.
-        selectedTier.value = defaultProgressionTier;
+        selectedTier.value = DEFAULT_PROGRESSION_TIER;
         await loadProgressionView();
       } else if (alreadyLoaded) {
         // Data is already current — scroll immediately, then silently refresh in background
@@ -719,7 +724,7 @@ export default defineComponent({
       // If the current mode renders the progression system in the newly selected season, load the
       // progression view (reset to the default tier) and skip the RP league selection below.
       if (resolveRankingSystem(rankingsStore.gameMode, season.id) === "progression") {
-        selectedTier.value = defaultProgressionTier;
+        selectedTier.value = DEFAULT_PROGRESSION_TIER;
         await loadProgressionView();
         return;
       }

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -651,6 +651,13 @@ export default defineComponent({
         rankingsStore.setLeague(ladders.value[0].id);
       }
 
+      // Apply the route's game mode to the store before the load branch, so isProgressionMode
+      // resolves against the requested mode (not the store default) on a direct URL load / refresh.
+      // Plain mutation (no RP fetch here); the branch below performs the actual load.
+      if (hasGameMode) {
+        rankingsStore.SET_GAME_MODE(props.gamemode);
+      }
+
       if (isProgressionMode.value) {
         // Progression modes render the apex leaderboard or progression league ladder rather than
         // the RP ladder. Start at the default tier and load its view.

--- a/src/views/Rankings.vue
+++ b/src/views/Rankings.vue
@@ -44,7 +44,8 @@
           :gameMode="selectedGameMode"
           @gameModeChanged="onGameModeChanged"
         />
-        <v-menu location="right" transition="fade-transition">
+        <!-- RP league selector (legacy ranking system) -->
+        <v-menu v-if="!isProgressionMode" location="right" transition="fade-transition">
           <template v-slot:activator="{ props }">
             <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
               <league-icon :league="selectedLeagueOrder" />
@@ -72,6 +73,70 @@
                     <league-icon :league="listLeagueIcon(item)" />
                     {{ item.name }}
                     {{ item.division !== 0 ? item.division : null }}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-card-text>
+          </v-card>
+        </v-menu>
+        <!-- Progression tier selector (Grand Master / Master / league + division) -->
+        <v-menu v-else location="right" transition="fade-transition">
+          <template v-slot:activator="{ props }">
+            <v-btn tile class="w3-dropdown-button" style="background-color: transparent" v-bind="props">
+              <league-icon :league="selectedTier.league" />
+              <span class="text-capitalize">{{ selectedTierLabel }}</span>
+            </v-btn>
+          </template>
+          <v-card>
+            <v-card-text>
+              <v-list>
+                <v-list-item>
+                  <v-list-item-title>
+                    {{ $t("views_rankings.selectleague") }}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+              <v-divider />
+              <v-list density="compact" class="overflow-y-auto" style="max-height: 650px">
+                <template v-for="group in tierGroups" :key="group.league">
+                  <v-list-subheader class="text-capitalize d-flex align-center">
+                    <league-icon :league="group.league" />
+                    {{ group.label }}
+                  </v-list-subheader>
+                  <v-list-item
+                    v-for="tier in group.tiers"
+                    :key="tierKey(tier)"
+                    :active="tierKey(tier) === tierKey(selectedTier)"
+                    @click="selectTier(tier)"
+                  >
+                    <v-list-item-title class="text-capitalize">
+                      {{ tierLabel(tier) }}
+                    </v-list-item-title>
+                  </v-list-item>
+                </template>
+              </v-list>
+            </v-card-text>
+          </v-card>
+        </v-menu>
+        <!-- Race selector (progression race-split ladders only) -->
+        <v-menu v-if="showRaceSelector" location="right" transition="fade-transition">
+          <template v-slot:activator="{ props }">
+            <v-btn tile class="ml-3 w3-dropdown-button" style="background-color: transparent" v-bind="props">
+              <race-icon :race="selectedRace" />
+            </v-btn>
+          </template>
+          <v-card>
+            <v-card-text>
+              <v-list density="compact">
+                <v-list-item
+                  v-for="race in races"
+                  :key="race"
+                  :active="race === selectedRace"
+                  @click="selectRace(race)"
+                >
+                  <v-list-item-title class="d-flex align-center">
+                    <race-icon :race="race" />
+                    <span class="ml-2">{{ $t(`races.${ERaceEnum[race]}`) }}</span>
                   </v-list-item-title>
                 </v-list-item>
               </v-list>
@@ -147,15 +212,43 @@
         </div>
       </v-card-text>
       <v-card-text>
-        <div v-if="isRankingsLoading" class="d-flex justify-center py-10">
-          <v-progress-circular indeterminate color="primary" size="40" />
-        </div>
-        <rankings-grid
-          v-else
-          :rankings="rankings"
-          :ongoingMatches="ongoingMatchesMap"
-          :selectedRank="selectedRank"
-        />
+        <!-- Apex leaderboard (Grand Master / Master progression tiers) -->
+        <template v-if="isApexView">
+          <div v-if="isApexLoading" class="d-flex justify-center py-10">
+            <v-progress-circular indeterminate color="primary" size="40" />
+          </div>
+          <apex-leaderboard-grid v-else-if="apexLeaderboard" :apexLeaderboard="apexLeaderboard" />
+          <div v-else class="elevation-1">
+            <table class="custom-table">
+              <tbody>
+                <tr>
+                  <td colspan="4" class="text-center">
+                    {{ $t("components_ladder_apexleaderboardgrid.noplayers") }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </template>
+        <!-- Progression league ladder (league + division progression tiers) -->
+        <template v-else-if="isProgressionMode">
+          <div v-if="isRankingsLoading" class="d-flex justify-center py-10">
+            <v-progress-circular indeterminate color="primary" size="40" />
+          </div>
+          <progression-ladder-grid v-else :rankings="rankings" />
+        </template>
+        <!-- RP ladder (legacy ranking system) -->
+        <template v-else>
+          <div v-if="isRankingsLoading" class="d-flex justify-center py-10">
+            <v-progress-circular indeterminate color="primary" size="40" />
+          </div>
+          <rankings-grid
+            v-else
+            :rankings="rankings"
+            :ongoingMatches="ongoingMatchesMap"
+            :selectedRank="selectedRank"
+          />
+        </template>
         <v-row v-if="showRaceDistribution">
           <v-col cols="12">
             <div class="mt-10">
@@ -177,12 +270,17 @@ import LeagueIcon from "@/components/ladder/LeagueIcon.vue";
 import GatewaySelect from "@/components/common/GatewaySelect.vue";
 import GameModeSelect from "@/components/common/GameModeSelect.vue";
 import RankingsGrid from "@/components/ladder/RankingsGrid.vue";
+import ProgressionLadderGrid from "@/components/ladder/ProgressionLadderGrid.vue";
+import ApexLeaderboardGrid from "@/components/ladder/ApexLeaderboardGrid.vue";
+import RaceIcon from "@/components/player/RaceIcon.vue";
 import RankingsRaceDistribution from "@/components/ladder/RankingsRaceDistribution.vue";
-import AppConstants, { getDefaultGatewayForSeason, isGatewayNeededForSeason } from "../constants";
+import AppConstants, { getDefaultGatewayForSeason, isGatewayNeededForSeason, RACE_SPLIT_START_SEASON } from "../constants";
 import { getProfileUrl } from "@/helpers/url-functions";
 import { useRankingStore } from "@/store/ranking/store";
 import { useMatchStore } from "@/store/match/store";
 import { useRootStateStore } from "@/store/rootState/store";
+import { useRankingSystem } from "@/composables/useRankingSystem";
+import { type ProgressionTier, isApexTier, progressionTierGroups, tierKey, tierLabel } from "@/helpers/progression-leagues";
 import { mdiMagnify } from "@mdi/js";
 import { useRouter } from "vue-router";
 import noop from "lodash/noop";
@@ -194,6 +292,9 @@ export default defineComponent({
     GatewaySelect,
     GameModeSelect,
     RankingsGrid,
+    ProgressionLadderGrid,
+    ApexLeaderboardGrid,
+    RaceIcon,
     RankingsRaceDistribution,
   },
   props: {
@@ -234,15 +335,44 @@ export default defineComponent({
     const playerIdToScroll = ref<string | undefined>(undefined);
     const isProgrammaticSelection = ref<boolean>(false);
 
-    const isGatewayNeeded = computed<boolean>(() => isGatewayNeededForSeason(rankingsStore.selectedSeason.id));
+    const { resolveRankingSystem } = useRankingSystem();
+    // The first non-apex tier (Adept I) — the default landing tier for a progression mode.
+    const defaultProgressionTier: ProgressionTier = { league: 2, division: 1 };
+    const selectedTier = ref<ProgressionTier>(defaultProgressionTier);
+    const selectedRace = ref<ERaceEnum>(ERaceEnum.HUMAN);
+
+    const isProgressionMode = computed<boolean>(() =>
+      resolveRankingSystem(rankingsStore.gameMode, rankingsStore.selectedSeason.id) === "progression"
+    );
+    // 1v1 is the only race-split ladder, and only from RACE_SPLIT_START_SEASON onward (mirrors the
+    // backend's UsesRaceInLadderKey: race-split mode AND season >= RaceSplitStartSeason).
+    const isRaceSplitMode = computed<boolean>(() =>
+      rankingsStore.gameMode === EGameMode.GM_1ON1 && rankingsStore.selectedSeason.id >= RACE_SPLIT_START_SEASON
+    );
+    const showRaceSelector = computed<boolean>(() => isProgressionMode.value && isRaceSplitMode.value);
+    const isApexView = computed<boolean>(() => isProgressionMode.value && isApexTier(selectedTier.value));
+    // The tier list is static (no reactive deps), so compute it once.
+    const tierGroups = progressionTierGroups();
+    const selectedTierLabel = computed<string>(() => tierLabel(selectedTier.value));
+
+    const races = [ERaceEnum.HUMAN, ERaceEnum.ORC, ERaceEnum.NIGHT_ELF, ERaceEnum.UNDEAD, ERaceEnum.RANDOM];
+
+    // Progression ladders are global (gateway-agnostic), so the gateway selector is hidden for them.
+    const isGatewayNeeded = computed<boolean>(() =>
+      !isProgressionMode.value && isGatewayNeededForSeason(rankingsStore.selectedSeason.id)
+    );
     const selectedSeason = computed<Season>(() => rankingsStore.selectedSeason);
     const seasons = computed<Season[]>(() => rankingsStore.seasons);
     const selectedGameMode = computed<EGameMode>(() => rankingsStore.gameMode);
     const selectedLeagueName = computed<string>(() => !selectedLeague.value?.name ? "" : selectedLeague.value?.name); // FIXME: selectedLeague.value?.name ?? ""
     const rankings = computed<Ranking[]>(() => rankingsStore.rankings);
     const searchRanks = computed<Ranking[]>(() => rankingsStore.searchRanks);
-    const showRaceDistribution = computed<boolean>(() => rankingsStore.gameMode == EGameMode.GM_1ON1 && rankingsStore.selectedSeason?.id > 1);
+    const showRaceDistribution = computed<boolean>(() =>
+      !isProgressionMode.value && rankingsStore.gameMode == EGameMode.GM_1ON1 && rankingsStore.selectedSeason?.id > 1
+    );
     const isRankingsLoading = computed<boolean>(() => rankingsStore.loading);
+    const apexLeaderboard = computed(() => rankingsStore.apexLeaderboard);
+    const isApexLoading = computed<boolean>(() => rankingsStore.apexLoading);
 
     const ladders = computed<League[]>(() => {
       const league = rankingsStore.ladders?.filter((l) =>
@@ -292,6 +422,11 @@ export default defineComponent({
 
     async function refreshRankings() {
       await loadOngoingMatches();
+      // Progression modes use their own data sources (apex / progression ladder); the periodic
+      // refresh below is for the RP ladder only and would otherwise clobber the progression view.
+      if (isProgressionMode.value) {
+        return;
+      }
       await getRefreshRankings();
       await getLadders();
     }
@@ -313,6 +448,14 @@ export default defineComponent({
       if (!rank) return;
       // Don't trigger side effects when selectedRank is set programmatically for scrolling
       if (isProgrammaticSelection.value) return;
+
+      // Search returns RP rows with a populated player; in a progression mode the RP setLeague
+      // path would overwrite the progression ladder, so route to the player's profile instead.
+      // Scroll-to-position within the progression ladder is a follow-up.
+      if (isProgressionMode.value) {
+        routeToProfilePage(rank.player.playerIds[0].battleTag);
+        return;
+      }
 
       if (!playerIsRanked(rank)) {
         routeToProfilePage(rank.player.playerIds[0].battleTag);
@@ -440,6 +583,15 @@ export default defineComponent({
     }
 
     async function onGameModeChanged(gameMode: EGameMode) {
+      // Progression modes do not use the RP ladder fetch in setGameMode; set the mode directly
+      // and load the progression view (default tier) instead.
+      if (resolveRankingSystem(gameMode, rankingsStore.selectedSeason.id) === "progression") {
+        rankingsStore.SET_GAME_MODE(gameMode);
+        rankingsStore.SET_PAGE(0);
+        selectedTier.value = defaultProgressionTier;
+        await loadProgressionView();
+        return;
+      }
       await rankingsStore.setGameMode(gameMode);
       if (ladders.value && ladders.value[0]) {
         await setLeague(ladders.value[0].id);
@@ -499,7 +651,12 @@ export default defineComponent({
         rankingsStore.setLeague(ladders.value[0].id);
       }
 
-      if (alreadyLoaded) {
+      if (isProgressionMode.value) {
+        // Progression modes render the apex leaderboard or progression league ladder rather than
+        // the RP ladder. Start at the default tier and load its view.
+        selectedTier.value = defaultProgressionTier;
+        await loadProgressionView();
+      } else if (alreadyLoaded) {
         // Data is already current — scroll immediately, then silently refresh in background
         await handlePlayerScroll();
         getRefreshRankings();
@@ -552,6 +709,14 @@ export default defineComponent({
       rootStateStore.setGateway(getDefaultGatewayForSeason(season.id, rootStateStore.gateway));
       await getLadders();
 
+      // If the current mode renders the progression system in the newly selected season, load the
+      // progression view (reset to the default tier) and skip the RP league selection below.
+      if (resolveRankingSystem(rankingsStore.gameMode, season.id) === "progression") {
+        selectedTier.value = defaultProgressionTier;
+        await loadProgressionView();
+        return;
+      }
+
       // Try to maintain the same league if it exists in the new season
       let leagueToSelect = 0;
       if (ladders.value && ladders.value.length > 0) {
@@ -574,6 +739,38 @@ export default defineComponent({
       rankingsStore.setLeague(league);
       await getRankings();
       await handlePlayerScroll();
+    }
+
+    // Load the data for the currently selected progression tier: the apex leaderboard for the
+    // Grand Master / Master tiers, otherwise the progression league/division ladder.
+    async function loadProgressionView() {
+      const season = rankingsStore.selectedSeason.id;
+      const gameMode = rankingsStore.gameMode;
+      if (isApexView.value) {
+        await rankingsStore.retrieveApexLeaderboard(season, gameMode);
+        return;
+      }
+      // Clear any previously loaded apex data so switching back to an apex tier never flashes a
+      // stale leaderboard before the fresh fetch resolves.
+      rankingsStore.SET_APEX_LEADERBOARD(null);
+      const race = showRaceSelector.value ? selectedRace.value : undefined;
+      await rankingsStore.retrieveProgressionLadder(
+        season,
+        gameMode,
+        selectedTier.value.league,
+        selectedTier.value.division ?? 1,
+        race,
+      );
+    }
+
+    async function selectTier(tier: ProgressionTier) {
+      selectedTier.value = tier;
+      await loadProgressionView();
+    }
+
+    async function selectRace(race: ERaceEnum) {
+      selectedRace.value = race;
+      await loadProgressionView();
     }
 
     function playerIsRanked(rank: Ranking): boolean {
@@ -615,6 +812,20 @@ export default defineComponent({
       ongoingMatchesMap,
       showRaceDistribution,
       isRankingsLoading,
+      isProgressionMode,
+      isApexView,
+      apexLeaderboard,
+      isApexLoading,
+      showRaceSelector,
+      selectedRace,
+      selectRace,
+      races,
+      tierGroups,
+      selectedTier,
+      selectedTierLabel,
+      selectTier,
+      tierKey,
+      tierLabel,
     };
   },
 });


### PR DESCRIPTION
Adds the public **apex leaderboard** and makes the ladder's league navigation **progression-aware** for progression modes. Client half of P11-4. Additive — the legacy RP ladder render and navigation are unchanged (branched per mode).

## Apex leaderboard view
New `ApexLeaderboardGrid.vue`: the Grand Master + Master cohort sorted by apex points, with a visible **GM cutoff line** between the GM cohort and Master. Reached by selecting the Grand Master / Master tier for a progression mode; data from `GET /api/ladder/apex` into `rankingStore.apexLeaderboard` (own `apexLoading`). Loading / data / empty states all handled.

## Progression league navigation
For a progression mode the league selector lists the **progression tiers** (Grand Master, Master, then leagues with divisions I–IV; grouped menu). Apex tiers route to the apex view; non-apex tiers render a new `ProgressionLadderGrid.vue` from `GET /api/ladder/progression`.
- **Dedicated `ProgressionLadderGrid`** (not `RankingsGrid`): that endpoint intentionally returns rows without the legacy per-player overview, so the grid renders from `playersInfo` + `progression` only — leaving `RankingsGrid` untouched (RP-safe by construction).
- Gateway selector **hidden** for progression modes (gateway-agnostic); race selector shown only for race-split 1v1 (season ≥ `RACE_SPLIT_START_SEASON`).

## Notes
- New `progression-leagues.ts` (pure tier helpers). i18n strings in `en.ts` (the Sheet-generated `data.ts` is untouched).
- New service methods guard `response.ok` (degrade to empty state, never throw).

## Checklist
- [x] Targets `prj/new-ranking-system`
- [x] Task: P11-4 (Workstreams D+E — website)
- [x] No test runner (website) → verified: `type-check-vue` · `lint --max-warnings=0` · `dprint` · `build` all clean
- [x] Visual: pending a screenshot pass (selector / non-apex page / apex cutoff / RP regression, light + dark, 1440/768) — to be attached; endpoints not yet live so verified with mock data
- [x] RP path **behavior-unchanged** (additive branch; `RankingsGrid.vue` not modified)
- [x] Public-repo boundary: whole diff + commit messages scanned — only league/division/points/apexPoints/Grand Master/Master/cutoff vocabulary
- [x] Per-repo doc updated (`docs/ranking.md`)