### PR TITLE
Fix 1v1 match detail regressions and polish

### DIFF
--- a/src/components/match-details/MatchDetailHeroRow.vue
+++ b/src/components/match-details/MatchDetailHeroRow.vue
@@ -45,17 +45,17 @@
         </div>
         <div v-if="durationMinutes > 0" class="resource-rates resource-rates--left">
           <div class="resource-rate-line">
-            <span :style="resourceRates.xp.winnerStyle">{{ resourceRates.xp.winner }}</span>
+            <span :class="resourceRates.xp.winnerClass">{{ resourceRates.xp.winner }}</span>
             <img src="/assets/icons/stat-plus-icon.png" width="16" height="16" alt="XP" />
             <span class="rate-label">XP/min</span>
           </div>
           <div class="resource-rate-line">
-            <span :style="resourceRates.gold.winnerStyle">{{ resourceRates.gold.winner }}</span>
+            <span :class="resourceRates.gold.winnerClass">{{ resourceRates.gold.winner }}</span>
             <img src="/assets/icons/stat-gold-icon.png" width="16" height="16" alt="Gold" />
             <span class="rate-label">Gold/min</span>
           </div>
           <div class="resource-rate-line">
-            <span :style="resourceRates.lumber.winnerStyle">{{ resourceRates.lumber.winner }}</span>
+            <span :class="resourceRates.lumber.winnerClass">{{ resourceRates.lumber.winner }}</span>
             <img src="/assets/icons/stat-lumber-icon.png" width="16" height="16" alt="Lumber" />
             <span class="rate-label">Lumber/min</span>
           </div>
@@ -163,17 +163,17 @@
           <div class="resource-rate-line">
             <span class="rate-label">XP/min</span>
             <img src="/assets/icons/stat-plus-icon.png" width="16" height="16" alt="XP" />
-            <span :style="resourceRates.xp.loserStyle">{{ resourceRates.xp.loser }}</span>
+            <span :class="resourceRates.xp.loserClass">{{ resourceRates.xp.loser }}</span>
           </div>
           <div class="resource-rate-line">
             <span class="rate-label">Gold/min</span>
             <img src="/assets/icons/stat-gold-icon.png" width="16" height="16" alt="Gold" />
-            <span :style="resourceRates.gold.loserStyle">{{ resourceRates.gold.loser }}</span>
+            <span :class="resourceRates.gold.loserClass">{{ resourceRates.gold.loser }}</span>
           </div>
           <div class="resource-rate-line">
             <span class="rate-label">Lumber/min</span>
             <img src="/assets/icons/stat-lumber-icon.png" width="16" height="16" alt="Lumber" />
-            <span :style="resourceRates.lumber.loserStyle">{{ resourceRates.lumber.loser }}</span>
+            <span :class="resourceRates.lumber.loserClass">{{ resourceRates.lumber.loser }}</span>
           </div>
         </div>
       </div>
@@ -250,9 +250,9 @@ export default defineComponent({
       [...(props.heroesOfWinner || [])].reverse(),
     );
 
-    function compareColor(a: number, b: number): string {
+    function compareClass(a: number, b: number): string {
       if (props.notColorWinner || a === b) return "";
-      return a > b ? "var(--w3-won-color, #4caf50)" : "var(--w3-lost-color, #ff5252)";
+      return a > b ? "w3-won" : "w3-lost";
     }
 
     const resourceRates = computed(() => {
@@ -273,20 +273,20 @@ export default defineComponent({
         xp: {
           winner: Math.round(wXp / mins),
           loser: Math.round(lXp / mins),
-          winnerStyle: { color: compareColor(wXp, lXp) },
-          loserStyle: { color: compareColor(lXp, wXp) },
+          winnerClass: compareClass(wXp, lXp),
+          loserClass: compareClass(lXp, wXp),
         },
         gold: {
           winner: Math.round(wGold / mins),
           loser: Math.round(lGold / mins),
-          winnerStyle: { color: compareColor(wGold, lGold) },
-          loserStyle: { color: compareColor(lGold, wGold) },
+          winnerClass: compareClass(wGold, lGold),
+          loserClass: compareClass(lGold, wGold),
         },
         lumber: {
           winner: Math.round(wLumber / mins),
           loser: Math.round(lLumber / mins),
-          winnerStyle: { color: compareColor(wLumber, lLumber) },
-          loserStyle: { color: compareColor(lLumber, wLumber) },
+          winnerClass: compareClass(wLumber, lLumber),
+          loserClass: compareClass(lLumber, wLumber),
         },
       };
     });

--- a/src/components/match-details/MatchDetailOneVsOne.vue
+++ b/src/components/match-details/MatchDetailOneVsOne.vue
@@ -4,8 +4,8 @@
       <v-card-subtitle class="pa-0 text-uppercase opacity-100 d-flex align-center ga-2">
         <span v-if="isGatewayNeeded">{{ $t(`gatewayNames.${gateWay}`) }} · </span>
         <div class="ml-2 d-inline-flex align-center ga-1 vertical-middle">
-          <span class="ovo-season-label">Season</span>
-          <season-badge :season="seasonObject" />
+          <span class="ovo-season-label font-friz-medium">Season</span>
+          <season-badge :season="seasonObject" :tooltip-prefix="$t('views_rankings.season')" />
         </div>
       </v-card-subtitle>
       <div class="ml-2">
@@ -49,7 +49,7 @@
           class="ovo-flag"
         />
         <a
-          class="cursor-pointer ovo-name-link"
+          class="cursor-pointer ovo-name-link font-friz-medium"
           :class="player(0).won ? 'w3-won' : 'w3-lost'"
           @click="goToPlayer(player(0).battleTag)"
         >
@@ -61,7 +61,7 @@
           :big="true"
         />
       </div>
-      <div class="ovo-vs">VS</div>
+      <div class="ovo-vs font-friz-medium">VS</div>
       <div class="ovo-name ovo-name--right">
         <player-icon
           :race="player(1).race"
@@ -69,7 +69,7 @@
           :big="true"
         />
         <a
-          class="cursor-pointer ovo-name-link"
+          class="cursor-pointer ovo-name-link font-friz-medium"
           :class="player(1).won ? 'w3-won' : 'w3-lost'"
           @click="goToPlayer(player(1).battleTag)"
         >
@@ -331,10 +331,11 @@ export default defineComponent({
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
-
-    &:hover {
-      text-decoration: underline;
-    }
+    // Friz Medium's glyphs sit high in the line box, so they look too high
+    // next to the race icons. Trim the line-height and nudge down to center
+    // the glyphs against the icons (em-relative so it scales with font-size).
+    line-height: 1;
+    transform: translateY(0.13em);
   }
 }
 
@@ -360,11 +361,18 @@ export default defineComponent({
   padding: 0 8px;
   align-self: center;
   line-height: 1;
+  // Match the optical nudge applied to the player names (same font).
+  transform: translateY(0.13em);
 }
 
 .ovo-season-label {
   color: rgb(var(--v-theme-w3-gold));
-  font-family: "Friz Quadrata Std Medium";
+}
+
+// On light themes the gold has poor contrast, so use the on-surface color.
+.v-theme--human .ovo-season-label,
+.v-theme--orc .ovo-season-label {
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .ovo-league {
@@ -407,14 +415,15 @@ export default defineComponent({
   display: flex;
   align-items: center;
   gap: 6px;
+  // Padding gives the hover effect breathing room; the matching negative
+  // margin keeps the content aligned with the name/MMR rows.
+  padding: 4px 8px;
+  margin: -4px -8px;
+  border-radius: 4px;
   text-decoration: none;
   color: inherit;
   cursor: pointer;
-  transition: box-shadow 0.15s;
-
-  &:hover {
-    box-shadow: 0 0 10px rgba(var(--v-theme-on-surface), 0.3);
-  }
+  transition: box-shadow 0.15s, background-color 0.15s;
 }
 
 .ovo-mmr {
@@ -462,7 +471,7 @@ export default defineComponent({
   }
 
   .ovo-name {
-    font-size: 1em;
+    font-size: 1.25em;
     flex-wrap: wrap;
     row-gap: 2px;
 

--- a/src/components/match-details/MatchHeadToHead.vue
+++ b/src/components/match-details/MatchHeadToHead.vue
@@ -10,7 +10,7 @@
 
     <template v-else-if="stats.totalGames > 0">
       <!-- Score block: centered, player context already in match header above -->
-      <v-row justify="center" class="mt-4">
+      <v-row justify="center">
         <v-col cols="auto" class="text-center">
           <div class="d-flex justify-center align-center ga-6">
             <span class="text-body-2 score-name text-primary text-right">{{ playerName }}</span>
@@ -421,7 +421,6 @@ export default defineComponent({
   background-color: rgb(var(--v-theme-surface));
   z-index: 1;
   width: 100%;
-  margin-left: -8px;
   margin-right: -20px;
   padding: 8px 8px 6px;
   font-size: 0.7rem;
@@ -433,7 +432,6 @@ export default defineComponent({
 .match-list-scroll {
   max-height: 400px;
   overflow-y: auto;
-  padding: 0 0 8px 8px;
   scrollbar-width: thin;
   scrollbar-color: rgba(var(--v-theme-on-surface), 0.15) transparent;
   background-color: rgba(var(--v-theme-on-surface), 0.03);

--- a/src/components/match-details/ScoreStat.vue
+++ b/src/components/match-details/ScoreStat.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="score-stat-row">
-    <div class="score-stat-value text-right" :style="{ color: stat1Color }">
+    <div class="score-stat-value text-right" :class="stat1Class">
       {{ stat1 }}
     </div>
     <div class="score-stat-icon">
@@ -10,7 +10,7 @@
     <div class="score-stat-icon">
       <img :src="`/assets/icons/stat-${icon}-icon.png`" width="16" height="16" :alt="icon" />
     </div>
-    <div class="score-stat-value text-left" :style="{ color: stat2Color }">
+    <div class="score-stat-value text-left" :class="stat2Class">
       {{ stat2 }}
     </div>
   </div>
@@ -40,17 +40,17 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const stat1Color = computed(() => {
+    const stat1Class = computed(() => {
       if (props.stat1 === props.stat2) return "";
-      return props.stat1 > props.stat2 ? "var(--w3-won-color, #4caf50)" : "var(--w3-lost-color, #ff5252)";
+      return props.stat1 > props.stat2 ? "w3-won" : "w3-lost";
     });
 
-    const stat2Color = computed(() => {
+    const stat2Class = computed(() => {
       if (props.stat1 === props.stat2) return "";
-      return props.stat1 < props.stat2 ? "var(--w3-won-color, #4caf50)" : "var(--w3-lost-color, #ff5252)";
+      return props.stat1 < props.stat2 ? "w3-won" : "w3-lost";
     });
 
-    return { stat1Color, stat2Color };
+    return { stat1Class, stat2Class };
   },
 });
 </script>

--- a/src/components/player/RecentPerformance.vue
+++ b/src/components/player/RecentPerformance.vue
@@ -46,7 +46,7 @@ export default defineComponent({
       if (hideWinner.value) {
         return "w3-gold";
       }
-      return resultSymbol === "W" ? "green" : "red";
+      return resultSymbol === "W" ? "success" : "lost";
     }
 
     return { mdiShieldSwordOutline, getIconColor, shouldBlurIcon };

--- a/src/components/player/SeasonBadge.vue
+++ b/src/components/player/SeasonBadge.vue
@@ -2,14 +2,14 @@
   <v-tooltip v-if="season" location="top" content-class="w3-tooltip elevation-1">
     <template v-slot:activator="{ props }">
       <div
-        :class="['season-badge', 'cursor-pointer']"
+        :class="['season-badge', { 'cursor-pointer': !!onClick }]"
         :style="{ 'background-image': 'url(' + seasonBadgeBg + ')' }"
         v-bind="props"
         @click="() => onClick?.(season)"
       ></div>
     </template>
     <span>
-      {{ $t("components_player_seasonbadge.participatedinseason") }}
+      {{ tooltipPrefix ?? $t("components_player_seasonbadge.participatedinseason") }}
       {{ seasonId }}
     </span>
   </v-tooltip>
@@ -30,6 +30,11 @@ export default defineComponent({
     },
     onClick: {
       type: Function,
+      required: false,
+      default: undefined,
+    },
+    tooltipPrefix: {
+      type: String,
       required: false,
       default: undefined,
     },

--- a/src/scss/fonts/friz.scss
+++ b/src/scss/fonts/friz.scss
@@ -33,3 +33,19 @@
   src: url("/assets/fonts/friz-quadrata-std-bold-italic-587033d6d4298.woff2") format("woff2"),
   url("/assets/fonts/friz-quadrata-std-bold-italic-587033d6d4298.woff") format("woff");
 }
+
+.font-friz-bold {
+  font-family: "Friz Quadrata Std Bold";
+}
+
+.font-friz-italic {
+  font-family: "Friz Quadrata Std Italic";
+}
+
+.font-friz-medium {
+  font-family: "Friz Quadrata Std Medium";
+}
+
+.font-friz-bold-italic {
+  font-family: "Friz Quadrata Std Bold Italic";
+}

--- a/src/scss/light/orc.scss
+++ b/src/scss/light/orc.scss
@@ -5,6 +5,12 @@
     color: rgb(var(--v-theme-success-darken-2)) !important;
   }
 
+  // The base success green is too light on the orc background; use the same
+  // darker green as .w3-won so themed success text/icons stay legible.
+  .text-success {
+    color: rgb(var(--v-theme-success-darken-2)) !important;
+  }
+
   background: url("/assets/backgrounds/orc.jpg") no-repeat !important;
   background-attachment: fixed !important;
   background-size: cover !important;

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -126,7 +126,7 @@
               </v-card-title>
             </div>
           </div>
-          <div v-else-if="isCompleteGame && !matchIsFFA">
+          <div v-if="!isOneVsOne && isCompleteGame && !matchIsFFA">
             <match-detail-hero-row
               v-for="(player, index) in scoresOfWinners"
               :key="index"
@@ -161,7 +161,7 @@
               </v-col>
             </v-row>
           </div>
-          <div v-else-if="isCompleteGame && matchIsFFA">
+          <div v-if="isCompleteGame && matchIsFFA">
             <match-detail-hero-row
               v-for="(player, index) in scoresOfWinners"
               :key="index"


### PR DESCRIPTION
- Fix non-1v1 (4v4/FFA) match details disappearing: the redesign put the
  header and score sections in one v-else-if chain, so non-1v1 modes matched
  the header branch and never rendered hero rows/performance. Break the score
  blocks back out into independent v-ifs guarded by !isOneVsOne.
- Season label: use on-surface color on light (human/orc) themes where the
  gold had poor contrast.
- SeasonBadge: add tooltipPrefix prop so the 1v1 page shows "Season <n>"
  instead of "participated in season <n>", and only show the pointer cursor
  when an onClick handler is provided.
- 1v1 header: give the rank button a padded, rounded hover; match the player
  name links to the same hover style; fix names/VS vertical alignment against
  the race icons (Friz Medium sits high — trim line-height and nudge down).
- Rework won/lost coloring to the w3-won/w3-lost class approach instead of
  inline styles / a nonexistent --w3-won-color (ScoreStat, MatchDetailHeroRow),
  and use the success/lost theme tokens for RecentPerformance icons.
- Override .text-success on the orc theme to the darker success-darken-2 green
  for legibility, matching .w3-won.
