### PR TITLE
Optimize matches hero-icon toggle to remove render jank

### DIFF
--- a/src/components/matches/HeroIconRow.vue
+++ b/src/components/matches/HeroIconRow.vue
@@ -1,15 +1,30 @@
 <template>
-  <v-row v-if="props.show" no-gutters :class="['d-flex', 'ga-2']">
-    <v-col v-for="(hero, heroIndex) in heroList" :key="heroIndex">
-      <hero-icon :hero="hero" :firstHero="heroIndex === firstHeroIndex" :show-level="false" :size="props.size" :selectedHeroes="props.selectedHeroes" />
-    </v-col>
-  </v-row>
+  <div v-if="props.show" class="hero-icon-row d-flex ga-2">
+    <span
+      v-for="(hero, heroIndex) in heroList"
+      :key="heroIndex"
+      class="hero-icon-highlight-wrapper"
+      :class="{ highlighted: isHighlighted(hero) }"
+    >
+      <img
+        class="hero-img"
+        :src="heroSrc(hero)"
+        :width="props.size"
+        :height="props.size"
+        :data-tip="tooltipText(hero)"
+        loading="lazy"
+        decoding="async"
+        alt=""
+      />
+    </span>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { Hero } from "@/store/types";
-import HeroIcon from "@/components/match-details/HeroIcon.vue";
+import { getAsset } from "@/helpers/url-functions";
 
 const props = withDefaults(defineProps<{
   heroes: Hero[] | null;
@@ -21,6 +36,41 @@ const props = withDefaults(defineProps<{
   size: 128,
 });
 
+const { t } = useI18n();
+
 const heroList = computed<Hero[] | null>(() => props.left && props.heroes ? props.heroes.toReversed() : props.heroes);
-const firstHeroIndex = computed<number>(() => props.left && heroList.value ? heroList.value.length - 1 : 0);
+
+function heroSrc(hero: Hero): string {
+  return getAsset(`heroes/${hero.name}.png`);
+}
+
+function tooltipText(hero: Hero): string {
+  return `${t(`heroNames.${hero.name}`)} (${t("common.level")} ${hero.level})`;
+}
+
+function isHighlighted(hero: Hero): boolean {
+  return props.selectedHeroes.includes(hero.id ?? -1);
+}
 </script>
+
+<style lang="scss" scoped>
+.hero-img {
+  display: block;
+  object-fit: contain;
+}
+
+// Highlight wrapper mirrors the one in match-details/HeroIcon.vue, kept here so
+// the matches grid can render hero icons as plain <img> elements (no per-icon
+// v-img / v-tooltip) and stay cheap to mount/unmount when the heroes toggle flips.
+.hero-icon-highlight-wrapper {
+  display: inline-flex;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  transition: border-color 0.2s;
+}
+
+.hero-icon-highlight-wrapper.highlighted {
+  border-color: rgb(var(--v-theme-primary));
+  box-shadow: 0 0 6px 2px rgba(var(--v-theme-primary), 0.5);
+}
+</style>

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <div class="elevation-1 overflow-x-auto overflow-y-hidden">
+    <div
+      class="elevation-1 overflow-x-auto overflow-y-hidden"
+      @mouseover="onGridTipOver"
+      @mouseleave="onGridTipLeave"
+    >
       <table class="custom-table">
         <thead>
           <tr>
@@ -97,12 +101,7 @@
               <span class="text-caption">{{ mapNameFromMatch(item) }}</span>
             </td>
             <td class="text-right">
-              <v-tooltip location="top" content-class="w3-tooltip elevation-1">
-                <template v-slot:activator="{ props: tooltipProps }">
-                  <span class="start-time-text" v-bind="tooltipProps">{{ getStartTime(item) }}</span>
-                </template>
-                <span>{{ getStartTimeTooltip(item) }}</span>
-              </v-tooltip>
+              <span class="start-time-text" :data-tip="getStartTimeTooltip(item)">{{ getStartTime(item) }}</span>
             </td>
             <td class="text-right">
               <div class="d-flex flex-column text-right align-end">
@@ -127,6 +126,22 @@
         </tbody>
       </table>
     </div>
+    <!--
+      One shared tooltip re-targeted via event delegation (see onGridTipOver),
+      instead of a v-tooltip per hero icon / start time. Hero icons render as plain
+      <img> (no per-icon v-img/v-tooltip), so toggling the heroes switch doesn't
+      churn hundreds of overlay instances.
+    -->
+    <v-tooltip
+      :model-value="textTipOpen"
+      :activator="textTipActivator"
+      :open-on-hover="false"
+      location="top"
+      transition="none"
+      content-class="w3-tooltip elevation-1"
+    >
+      {{ textTipText }}
+    </v-tooltip>
     <div>
       <div class="text-center font-regular mt-2">
         {{ currentMatchesLowRange }} - {{ currentMatchesHighRange }} of
@@ -138,7 +153,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, type StyleValue, type PropType } from "vue";
+import { computed, defineComponent, type PropType, ref, type StyleValue } from "vue";
 import { useI18n } from "vue-i18n";
 import { EGameMode, type Match, type PlayerInTeam, type Team } from "@/store/types";
 import { GAME_MODES_FFA } from "@/store/constants";
@@ -227,6 +242,29 @@ export default defineComponent({
 
     const matches = computed<Match[]>(() => props.modelValue);
     const hideDurationSpoilers = computed<boolean>(() => spoilerFreeStore.hideDuration);
+
+    // Shared hover tooltip, re-anchored via event delegation instead of mounting a
+    // v-tooltip per hero icon. Elements opt in with a `data-tip` attribute (hero
+    // icons, start time); a single overlay is re-targeted to whichever one is
+    // hovered, so toggling the heroes switch doesn't churn hundreds of overlays.
+    const textTipActivator = ref<HTMLElement | undefined>(undefined);
+    const textTipText = ref<string>("");
+    const textTipOpen = ref<boolean>(false);
+
+    function onGridTipOver(event: MouseEvent): void {
+      const textEl = (event.target as Element | null)?.closest<HTMLElement>("[data-tip]");
+      if (textEl) {
+        textTipActivator.value = textEl;
+        textTipText.value = textEl.getAttribute("data-tip") ?? "";
+        textTipOpen.value = true;
+      } else {
+        textTipOpen.value = false;
+      }
+    }
+
+    function onGridTipLeave(): void {
+      textTipOpen.value = false;
+    }
 
     const currentMatchesLowRange = computed<number>(() => {
       if (props.totalMatches === 0) return 0;
@@ -417,6 +455,11 @@ export default defineComponent({
       showReplayDownload,
       hasServerInfo,
       hideDurationSpoilers,
+      textTipActivator,
+      textTipText,
+      textTipOpen,
+      onGridTipOver,
+      onGridTipLeave,
     };
   },
 });


### PR DESCRIPTION
## Problem

Toggling **Settings → Heroes** on the matches table janked hard — turning it on blocked the main thread for **~500–625 ms** (a visible half-second freeze).

Each row rendered hero icons through `HeroIcon` → `HeroPicture`, which wrapped every 24×24 icon in a Vuetify `v-img` **and** a `v-tooltip`. On a 50-match 1v1 page that's ~300 icons → ~300 `v-img` (each spinning up an `IntersectionObserver`, loading state, aspect-ratio sizing) + ~300 `v-tooltip` (each setting up overlay/transition machinery). Flipping the `v-if`-gated heroes row mounted/destroyed all of that synchronously.

## Change

- **Render hero icons as plain `<img>`** (24×24, `loading="lazy"`, `decoding="async"`) instead of `v-img` — no per-icon `IntersectionObserver`/overlay churn. The selected-hero highlight wrapper is preserved.
- **Replace the per-icon `v-tooltip` with one shared tooltip** in `MatchesGrid`, re-anchored on hover via event delegation. Elements opt in with a `data-tip` attribute; a single overlay (teleported to `<body>`, so it isn't clipped by the table's `overflow`) is re-targeted to whichever element is hovered. Styling is unchanged (`w3-tooltip elevation-1`, `location="top"`).
- The **start-time tooltip** now rides on the same shared tooltip via `data-tip`, removing another per-row overlay at near-zero cost.

`HeroPicture` / `HeroIcon` are untouched and still used on the match-detail and hero-select pages, where icons are large and few.

## Results (measured with Playwright, `longtask` observer)

| Toggle | Before | After |
|---|---|---|
| Heroes ON (worst case) | ~625 ms | **~55 ms** |

Verified functionally: heroes render correctly, the shared tooltip shows the right text (e.g. `Mountain King (Level 4)`) with identical styling, and selected-hero highlighting still works.

## Notes / things considered but not included

- **Image shrinking** was considered (icons are 128×128 source) but the 26 PNGs total only ~412 KB and are cached after first paint, so they don't meaningfully affect toggle jank — the component churn did.
- An MMR/rank tooltip consolidation was prototyped and **reverted**: A/B measurement showed it removed ~100 DOM overlays but contributed ~0 ms to the jank, not worth its complexity.
- The Now-Playing/Finished toggle ripple is only marginally helped here; the real lever there would be deferring the status store update a frame (left for a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)