### PR TITLE
Show pause/resume/leave events in replay chat log

### DIFF
--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -13,20 +13,28 @@
           </v-btn>
         </div>
       </v-alert>
-      <v-row v-else-if="!messages || messages.length === 0" class="ma-1">
-        <span class="text-medium-emphasis">This match had no chat messages.</span>
+      <v-row v-else-if="timeline.length === 0" class="ma-1">
+        <span class="text-medium-emphasis">This match had no chat messages or events.</span>
       </v-row>
       <v-row v-else class="ma-1">
-        <replay-chat-message
-          v-for="(item, index) in messages"
-          :key="index"
-          :time="item.time"
-          :sentBy="getSenderName(item)"
-          :team="getTeam(item)"
-          :content="item.content"
-          :scope="item.scope.type"
-          :sentTo="getPrivateRecipientName(item)"
-        />
+        <template v-for="(item, index) in timeline" :key="index">
+          <replay-chat-message
+            v-if="item.kind === 'message'"
+            :time="item.message.time"
+            :sentBy="getSenderName(item.message)"
+            :team="getTeam(item.message)"
+            :content="item.message.content"
+            :scope="item.message.scope.type"
+            :sentTo="getPrivateRecipientName(item.message)"
+          />
+          <replay-game-event-message
+            v-else
+            :time="item.event.time"
+            :type="item.event.type"
+            :playerName="getPlayerName(item.event.playerId)"
+            :reason="item.event.reason"
+          />
+        </template>
       </v-row>
     </v-card-text>
   </v-container>
@@ -35,7 +43,8 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
-import { ReplayChatLog, ReplayMessage } from "@/store/admin/types";
+import ReplayGameEventMessage from "@/components/admin/replays/ReplayGameEventMessage.vue";
+import { ReplayChatLog, ReplayGameEvent, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
 import { OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import { useRoute } from "vue-router";
@@ -44,6 +53,7 @@ export default defineComponent({
   name: "AdminReplayChatLogMessages",
   components: {
     ReplayChatMessage,
+    ReplayGameEventMessage,
   },
   props: {
     matchId: {
@@ -59,12 +69,34 @@ export default defineComponent({
     const errorMessage = ref<string>("");
     const showLoginButton = ref(false);
 
-    const messages = computed<ReplayMessage[]>(() => log.value.messages);
+    type TimelineItem =
+      | { kind: "message"; time: number; message: ReplayMessage }
+      | { kind: "event"; time: number; event: ReplayGameEvent };
 
-    function getSenderName(message: ReplayMessage): string {
-      const name = log.value.players.find((x) => x.id == message.fromPlayer)?.name;
+    // Merge chat messages and game events into a single chronological list.
+    // Array.sort is stable, so messages and events sharing a timestamp keep insertion order.
+    const timeline = computed<TimelineItem[]>(() => {
+      const messages: TimelineItem[] = (log.value.messages ?? []).map((m) => ({
+        kind: "message",
+        time: m.time,
+        message: m,
+      }));
+      const events: TimelineItem[] = (log.value.events ?? []).map((e) => ({
+        kind: "event",
+        time: e.time,
+        event: e,
+      }));
+      return [...messages, ...events].sort((a, b) => a.time - b.time);
+    });
+
+    function getPlayerName(playerId: number): string {
+      const name = log.value.players.find((x) => x.id == playerId)?.name;
       if (name == undefined) return "UNKNOWN";
       return name;
+    }
+
+    function getSenderName(message: ReplayMessage): string {
+      return getPlayerName(message.fromPlayer);
     }
 
     function getTeam(message: ReplayMessage): number {
@@ -75,9 +107,7 @@ export default defineComponent({
 
     function getPrivateRecipientName(message: ReplayMessage): string | undefined {
       if (message.scope.id == null) return undefined;
-      const name = log.value.players.find((x) => x.id == message.scope.id)?.name;
-      if (name == undefined) return "UNKNOWN";
-      return name;
+      return getPlayerName(message.scope.id);
     }
 
     function promptLogin(): void {
@@ -120,10 +150,11 @@ export default defineComponent({
 
     return {
       loading,
-      messages,
+      timeline,
       getSenderName,
       getTeam,
       getPrivateRecipientName,
+      getPlayerName,
       errorMessage,
       showLoginButton,
       promptLogin,

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -32,7 +32,7 @@
             :time="item.event.time"
             :type="item.event.type"
             :playerName="getPlayerName(item.event.playerId)"
-            :reason="item.event.reason"
+            :leaveReason="item.event.leaveReason"
           />
         </template>
       </v-row>

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -11,8 +11,18 @@
 import { computed, PropType, defineComponent } from "vue";
 import { EReplayGameEventType } from "@/store/admin/types";
 
-// Subset of W3GS LeaveReason codes worth distinguishing in the chat log.
-const LEAVE_REASON_DISCONNECT = 0x01;
+// W3GS LeaveReason codes (flo crates/w3gs/src/protocol/constants.rs).
+// Mapped to a short suffix shown after "left the game".
+const LEAVE_REASON_LABELS: Record<number, string> = {
+  0x01: "disconnected",
+  0x07: "lost",
+  0x08: "all buildings destroyed",
+  0x09: "won",
+  0x0a: "draw",
+  0x0b: "observer",
+  0x0c: "invalid save game",
+  0x0d: "left lobby",
+};
 
 export default defineComponent({
   name: "ReplayGameEventMessage",
@@ -42,11 +52,12 @@ export default defineComponent({
           return `${props.playerName} paused the game`;
         case EReplayGameEventType.RESUME:
           return `${props.playerName} resumed the game`;
-        case EReplayGameEventType.LEAVE:
-          if (props.reason === LEAVE_REASON_DISCONNECT) {
-            return `${props.playerName} left the game (disconnected)`;
-          }
-          return `${props.playerName} left the game`;
+        case EReplayGameEventType.LEAVE: {
+          const label = props.reason === undefined ? undefined : LEAVE_REASON_LABELS[props.reason];
+          return label
+            ? `${props.playerName} left the game (${label})`
+            : `${props.playerName} left the game`;
+        }
         default:
           return "";
       }

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -1,0 +1,85 @@
+<template>
+  <v-container class="ma-0 pa-0">
+    <div class="text-medium-emphasis font-italic">
+      <span class="chat-time mr-2">[{{ formatTime(time) }}]</span>
+      <span>{{ icon }} {{ description }}</span>
+    </div>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { computed, PropType, defineComponent } from "vue";
+import { EReplayGameEventType } from "@/store/admin/types";
+
+// Subset of W3GS LeaveReason codes worth distinguishing in the chat log.
+const LEAVE_REASON_DISCONNECT = 0x01;
+
+export default defineComponent({
+  name: "ReplayGameEventMessage",
+  props: {
+    time: { type: Number, required: true },
+    type: { type: Number as PropType<EReplayGameEventType>, required: true },
+    playerName: { type: String, required: true },
+    reason: { type: Number, required: false, default: undefined },
+  },
+  setup(props) {
+    const icon = computed<string>(() => {
+      switch (props.type) {
+        case EReplayGameEventType.PAUSE:
+          return "⏸";
+        case EReplayGameEventType.RESUME:
+          return "▶";
+        case EReplayGameEventType.LEAVE:
+          return "⬅";
+        default:
+          return "";
+      }
+    });
+
+    const description = computed<string>(() => {
+      switch (props.type) {
+        case EReplayGameEventType.PAUSE:
+          return `${props.playerName} paused the game`;
+        case EReplayGameEventType.RESUME:
+          return `${props.playerName} resumed the game`;
+        case EReplayGameEventType.LEAVE:
+          if (props.reason === LEAVE_REASON_DISCONNECT) {
+            return `${props.playerName} left the game (disconnected)`;
+          }
+          return `${props.playerName} left the game`;
+        default:
+          return "";
+      }
+    });
+
+    // Example: 1500     -> 00:15
+    // Example: 15000000 -> 04:10:00
+    function formatTime(timeMs: number): string {
+      const totalSeconds = Math.floor(timeMs / 1000);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+
+      if (hours > 0) {
+        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+      }
+
+      return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    }
+
+    return {
+      icon,
+      description,
+      formatTime,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.chat-time {
+  display: inline-block;
+  width: 5rem;
+  font-family: monospace;
+}
+</style>

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -9,19 +9,18 @@
 
 <script lang="ts">
 import { computed, PropType, defineComponent } from "vue";
-import { EReplayGameEventType } from "@/store/admin/types";
+import { EReplayGameEventType, EReplayLeaveReason } from "@/store/admin/types";
 
-// W3GS LeaveReason codes (flo crates/w3gs/src/protocol/constants.rs).
-// Mapped to a short suffix shown after "left the game".
-const LEAVE_REASON_LABELS: Record<number, string> = {
-  0x01: "disconnected",
-  0x07: "lost",
-  0x08: "all buildings destroyed",
-  0x09: "won",
-  0x0a: "draw",
-  0x0b: "observer",
-  0x0c: "invalid save game",
-  0x0d: "left lobby",
+// Maps a LeaveReason enum value to the short suffix shown after "left the game".
+const LEAVE_REASON_LABELS: Partial<Record<EReplayLeaveReason, string>> = {
+  [EReplayLeaveReason.DISCONNECT]: "disconnected",
+  [EReplayLeaveReason.LOST]: "lost",
+  [EReplayLeaveReason.LOST_BUILDINGS]: "all buildings destroyed",
+  [EReplayLeaveReason.WON]: "won",
+  [EReplayLeaveReason.DRAW]: "draw",
+  [EReplayLeaveReason.OBSERVER]: "observer",
+  [EReplayLeaveReason.INVALID_SAVE_GAME]: "invalid save game",
+  [EReplayLeaveReason.LOBBY]: "left lobby",
 };
 
 export default defineComponent({
@@ -30,7 +29,7 @@ export default defineComponent({
     time: { type: Number, required: true },
     type: { type: Number as PropType<EReplayGameEventType>, required: true },
     playerName: { type: String, required: true },
-    reason: { type: Number, required: false, default: undefined },
+    leaveReason: { type: String as PropType<EReplayLeaveReason>, required: false, default: undefined },
   },
   setup(props) {
     const icon = computed<string>(() => {
@@ -53,7 +52,7 @@ export default defineComponent({
         case EReplayGameEventType.RESUME:
           return `${props.playerName} resumed the game`;
         case EReplayGameEventType.LEAVE: {
-          const label = props.reason === undefined ? undefined : LEAVE_REASON_LABELS[props.reason];
+          const label = props.leaveReason === undefined ? undefined : LEAVE_REASON_LABELS[props.leaveReason];
           return label
             ? `${props.playerName} left the game (${label})`
             : `${props.playerName} left the game`;

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -268,6 +268,22 @@ export type OverridesList = {
 export type ReplayChatLog = {
   players: ReplayPlayer[];
   messages: ReplayMessage[];
+  events: ReplayGameEvent[];
+};
+
+// Numeric values must mirror the backend ReplayGameEventType enum order
+// (System.Text.Json serializes enums as integers), same convention as EChatScope.
+export enum EReplayGameEventType {
+  PAUSE = 0,
+  RESUME = 1,
+  LEAVE = 2,
+}
+
+export type ReplayGameEvent = {
+  type: EReplayGameEventType;
+  time: number;
+  playerId: number;
+  reason?: number; // only present for LEAVE events (LeaveReason code)
 };
 
 export type ReplayPlayer = {

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -279,11 +279,25 @@ export enum EReplayGameEventType {
   LEAVE = 2,
 }
 
+// Snake_case LeaveReason strings emitted by the replay service. Mapped to
+// human-readable text in ReplayGameEventMessage.vue.
+export enum EReplayLeaveReason {
+  DISCONNECT = "disconnect",
+  LOST = "lost",
+  LOST_BUILDINGS = "lost_buildings",
+  WON = "won",
+  DRAW = "draw",
+  OBSERVER = "observer",
+  INVALID_SAVE_GAME = "invalid_save_game",
+  LOBBY = "lobby",
+  UNKNOWN = "unknown",
+}
+
 export type ReplayGameEvent = {
   type: EReplayGameEventType;
   time: number;
   playerId: number;
-  reason?: number; // only present for LEAVE events (LeaveReason code)
+  leaveReason?: EReplayLeaveReason; // only present for LEAVE events
 };
 
 export type ReplayPlayer = {


### PR DESCRIPTION
## What

Shows **pause / unpause / player-leave events** in the admin **View Game Chat** view, interleaved chronologically with chat messages as distinct system lines:

```
[12:34] PlayerX (All): gg
[12:51] ⏸ PlayerX paused the game
[12:48] ▶ PlayerX resumed the game
[15:02] ⬅ PlayerY left the game (disconnected)
```

## How

- **`src/store/admin/types.ts`**: `ReplayChatLog` gains `events: ReplayGameEvent[]`; new `ReplayGameEvent` type and **numeric** `EReplayGameEventType` enum (`PAUSE=0, RESUME=1, LEAVE=2`) — mirroring the backend enum order, the same convention as the existing numeric `EChatScope`. Leave events carry a `leaveReason` **string** enum (`EReplayLeaveReason`, snake_case values matching the replay service).
- **New `ReplayGameEventMessage.vue`**: renders one event as an italic, medium-emphasis system line, reusing the existing `[mm:ss]` monospace time prefix. Leave events render the W3GS `LeaveReason` code as a suffix — all eight known codes are mapped:

  | `leaveReason` | suffix |
  |------|--------|
  | `disconnect` | disconnected |
  | `lost` | lost |
  | `lost_buildings` | all buildings destroyed |
  | `won` | won |
  | `draw` | draw |
  | `observer` | observer |
  | `invalid_save_game` | invalid save game |
  | `lobby` | left lobby |

  Unknown (`unknown`) or absent reasons fall back to a plain "left the game".

  Note: at normal game end W3GS emits a `PlayerLeft` for every player with their result, so a finished match's log will end with `… (won)` / `… (lost)` lines. Accurate, but if that reads as noise we can suppress end-of-game result leaves and keep only mid-game disconnects.
- **`AdminReplayChatLogMessages.vue`**: replaces the messages-only loop with a computed `timeline` that merges `messages` + `events` and sorts by `time` (stable sort preserves intra-tick order). Reuses the existing player-name lookup for event player names, and guards `events ?? []` so older backend payloads (no events) still render.

## Testing

- `npm run lint` ✅
- `npm run dprint` ✅
- `vue-tsc --noEmit` ✅
- Manual smoke pending against a real match (no events / multiple pauses / mid-game disconnect vs normal game-end leave).

## Deploy / merge ordering (read before rolling out)

All three repos in this change are **additive and backward/forward-compatible**.

| Repo | Change | Safe out of order? |
|------|--------|--------------------|
| **replay-service** | emits new `events` array | yes |
| **website-backend** | passes `events` through (null until replay-service deploys) | yes |
| **website** (this PR) | renders events; guards `events ?? []` | yes — shows nothing extra if `events` is absent/null |

**Recommended deploy order:** `replay-service` → `website-backend` → `website` (UI last). This PR is safe to deploy before the others — it simply renders no events until the backend/replay service supply them. No rollback hazard.

Companion PRs:
- replay-service: https://github.com/w3champions/replay-service/pull/1
- website-backend: https://github.com/w3champions/website-backend/pull/536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
