### PR TITLE
Toggle in-game/real time + pause duration in replay chat log

### DIFF
--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -2,18 +2,34 @@
   <v-container>
     <v-card-title class="d-flex align-center ga-3">
       <span>Chat Log</span>
-      <div class="d-flex align-center ga-2 text-body-2 text-medium-emphasis">
-        <span :class="{ 'text-high-emphasis': !showRealTime }">Game time</span>
-        <v-switch
-          v-model="showRealTime"
-          density="compact"
-          hide-details
-          inset
-          color="primary"
-          class="flex-grow-0"
-        />
-        <span :class="{ 'text-high-emphasis': showRealTime }">Real time</span>
-      </div>
+      <v-tooltip
+        v-if="!loading && timeline.length > 0"
+        location="top"
+        content-class="w3-tooltip elevation-1"
+        max-width="300"
+      >
+        <template v-slot:activator="{ props }">
+          <div
+            v-bind="props"
+            class="d-flex align-center ga-2 font-friz-medium text-body-2 ml-6"
+          >
+            <span class="text-uppercase" :class="showRealTime ? 'text-grey' : 'text-w3-gold'">Game time</span>
+            <v-switch
+              v-model="showRealTime"
+              density="compact"
+              hide-details
+              color="w3-gold"
+              base-color="w3-gold"
+              class="flex-grow-0"
+            />
+            <span class="text-uppercase" :class="showRealTime ? 'text-w3-gold' : 'text-grey'">Real time</span>
+          </div>
+        </template>
+        <span>
+          In-game time freezes while the game is paused; real time keeps advancing.
+          The two differ by the total time the game spent paused.
+        </span>
+      </v-tooltip>
     </v-card-title>
     <v-card-text>
       <v-row v-if="loading" justify="center" class="ma-1">

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -1,15 +1,19 @@
 <template>
   <v-container>
-    <v-card-title class="d-flex align-center justify-space-between">
-      Chat Log
-      <v-switch
-        v-model="showRealTime"
-        label="Real time"
-        density="compact"
-        hide-details
-        color="primary"
-        class="flex-grow-0"
-      />
+    <v-card-title class="d-flex align-center ga-3">
+      <span>Chat Log</span>
+      <div class="d-flex align-center ga-2 text-body-2 text-medium-emphasis">
+        <span :class="{ 'text-high-emphasis': !showRealTime }">Game time</span>
+        <v-switch
+          v-model="showRealTime"
+          density="compact"
+          hide-details
+          inset
+          color="primary"
+          class="flex-grow-0"
+        />
+        <span :class="{ 'text-high-emphasis': showRealTime }">Real time</span>
+      </div>
     </v-card-title>
     <v-card-text>
       <v-row v-if="loading" justify="center" class="ma-1">

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -20,7 +20,7 @@
               hide-details
               :color="realTimeColor"
               :base-color="gameTimeColor"
-              class="flex-grow-0"
+              class="flex-grow-0 mx-2"
             />
             <span class="text-uppercase" :class="showRealTime ? `text-${realTimeColor}` : 'text-grey'">Real time</span>
           </div>

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -1,6 +1,16 @@
 <template>
   <v-container>
-    <v-card-title>Chat Log</v-card-title>
+    <v-card-title class="d-flex align-center justify-space-between">
+      Chat Log
+      <v-switch
+        v-model="showRealTime"
+        label="Real time"
+        density="compact"
+        hide-details
+        color="primary"
+        class="flex-grow-0"
+      />
+    </v-card-title>
     <v-card-text>
       <v-row v-if="loading" justify="center" class="ma-1">
         <v-progress-circular indeterminate />
@@ -35,6 +45,7 @@
             :type="item.event.type"
             :playerName="getPlayerName(item.event.playerId)"
             :leaveReason="item.event.leaveReason"
+            :pauseDurationMs="resumeDurationFor(item.event)"
           />
         </template>
       </v-row>
@@ -43,10 +54,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from "vue";
+import { computed, defineComponent, onMounted, provide, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
 import ReplayGameEventMessage from "@/components/admin/replays/ReplayGameEventMessage.vue";
-import { ReplayChatLog, ReplayGameEvent, ReplayMessage } from "@/store/admin/types";
+import { REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
+import { EReplayGameEventType, ReplayChatLog, ReplayGameEvent, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
 import { OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
 import { useRoute } from "vue-router";
@@ -71,6 +83,10 @@ export default defineComponent({
     const errorMessage = ref<string>("");
     const showLoginButton = ref(false);
 
+    // Toggle (switch at the top) shared with every ReplayLogTime via inject.
+    const showRealTime = ref(false);
+    provide(REPLAY_SHOW_REAL_TIME, showRealTime);
+
     type TimelineItem =
       | { kind: "message"; time: number; message: ReplayMessage }
       | { kind: "event"; time: number; event: ReplayGameEvent };
@@ -90,6 +106,26 @@ export default defineComponent({
       }));
       return [...messages, ...events].sort((a, b) => a.time - b.time);
     });
+
+    // Real-time duration of each resume's pause: resume.time - matching pause.time.
+    // Events arrive ordered by time, so the matching pause is the most recent one.
+    const resumeDurations = computed<Map<ReplayGameEvent, number>>(() => {
+      const durations = new Map<ReplayGameEvent, number>();
+      let lastPause: ReplayGameEvent | null = null;
+      for (const event of log.value.events ?? []) {
+        if (event.type === EReplayGameEventType.PAUSE) {
+          lastPause = event;
+        } else if (event.type === EReplayGameEventType.RESUME) {
+          if (lastPause) durations.set(event, event.time - lastPause.time);
+          lastPause = null;
+        }
+      }
+      return durations;
+    });
+
+    function resumeDurationFor(event: ReplayGameEvent): number | undefined {
+      return resumeDurations.value.get(event);
+    }
 
     function getPlayerName(playerId: number): string {
       const name = log.value.players.find((x) => x.id == playerId)?.name;
@@ -153,6 +189,8 @@ export default defineComponent({
     return {
       loading,
       timeline,
+      showRealTime,
+      resumeDurationFor,
       getSenderName,
       getTeam,
       getPrivateRecipientName,

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -77,7 +77,8 @@
 import { computed, defineComponent, onMounted, provide, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
 import ReplayGameEventMessage from "@/components/admin/replays/ReplayGameEventMessage.vue";
-import { GAME_TIME_COLOR, REAL_TIME_COLOR, REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
+import { useTheme } from "vuetify";
+import { REPLAY_SHOW_REAL_TIME, replayTimeColors } from "@/components/admin/replays/replayTime";
 import { EReplayGameEventType, ReplayChatLog, ReplayGameEvent, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
 import { OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
@@ -106,6 +107,11 @@ export default defineComponent({
     // Toggle (switch at the top) shared with every ReplayLogTime via inject.
     const showRealTime = ref(false);
     provide(REPLAY_SHOW_REAL_TIME, showRealTime);
+
+    // Per-mode accent colours, theme-aware (grey/blue on light, gold/blue on dark).
+    const theme = useTheme();
+    const gameTimeColor = computed(() => replayTimeColors(theme.current.value.dark).game);
+    const realTimeColor = computed(() => replayTimeColors(theme.current.value.dark).real);
 
     type TimelineItem =
       | { kind: "message"; time: number; message: ReplayMessage }
@@ -211,8 +217,8 @@ export default defineComponent({
       timeline,
       showRealTime,
       resumeDurationFor,
-      gameTimeColor: GAME_TIME_COLOR,
-      realTimeColor: REAL_TIME_COLOR,
+      gameTimeColor,
+      realTimeColor,
       getSenderName,
       getTeam,
       getPrivateRecipientName,

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -13,16 +13,16 @@
             v-bind="props"
             class="d-flex align-center ga-2 font-friz-medium text-body-2 ml-6"
           >
-            <span class="text-uppercase" :class="showRealTime ? 'text-grey' : 'text-w3-gold'">Game time</span>
+            <span class="text-uppercase" :class="showRealTime ? 'text-grey' : `text-${gameTimeColor}`">Game time</span>
             <v-switch
               v-model="showRealTime"
               density="compact"
               hide-details
-              color="w3-gold"
-              base-color="w3-gold"
+              :color="realTimeColor"
+              :base-color="gameTimeColor"
               class="flex-grow-0"
             />
-            <span class="text-uppercase" :class="showRealTime ? 'text-w3-gold' : 'text-grey'">Real time</span>
+            <span class="text-uppercase" :class="showRealTime ? `text-${realTimeColor}` : 'text-grey'">Real time</span>
           </div>
         </template>
         <span>
@@ -77,7 +77,7 @@
 import { computed, defineComponent, onMounted, provide, ref } from "vue";
 import ReplayChatMessage from "@/components/admin/replays/ReplayChatMessage.vue";
 import ReplayGameEventMessage from "@/components/admin/replays/ReplayGameEventMessage.vue";
-import { REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
+import { GAME_TIME_COLOR, REAL_TIME_COLOR, REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
 import { EReplayGameEventType, ReplayChatLog, ReplayGameEvent, ReplayMessage } from "@/store/admin/types";
 import { useReplayManagementStore } from "@/store/admin/replayManagement/store";
 import { OPEN_SIGN_IN_DIALOG_EVENT } from "@/constants/sso";
@@ -211,6 +211,8 @@ export default defineComponent({
       timeline,
       showRealTime,
       resumeDurationFor,
+      gameTimeColor: GAME_TIME_COLOR,
+      realTimeColor: REAL_TIME_COLOR,
       getSenderName,
       getTeam,
       getPrivateRecipientName,

--- a/src/components/admin/replays/AdminReplayChatLogMessages.vue
+++ b/src/components/admin/replays/AdminReplayChatLogMessages.vue
@@ -21,6 +21,7 @@
           <replay-chat-message
             v-if="item.kind === 'message'"
             :time="item.message.time"
+            :gameTime="item.message.gameTime"
             :sentBy="getSenderName(item.message)"
             :team="getTeam(item.message)"
             :content="item.message.content"
@@ -30,6 +31,7 @@
           <replay-game-event-message
             v-else
             :time="item.event.time"
+            :gameTime="item.event.gameTime"
             :type="item.event.type"
             :playerName="getPlayerName(item.event.playerId)"
             :leaveReason="item.event.leaveReason"

--- a/src/components/admin/replays/ReplayChatMessage.vue
+++ b/src/components/admin/replays/ReplayChatMessage.vue
@@ -1,12 +1,12 @@
 <template>
   <v-container class="ma-0 pa-0">
     <div v-if="isPrivate">
-      <span class="chat-time text-medium-emphasis mr-2">[{{ formatTime(time) }}]</span>
+      <replay-log-time :time="time" :game-time="gameTime" />
       <span class="font-weight-bold" :class="getTeamColor(team)">{{ sentBy }} (to {{ sentTo }}):</span>
       <span>{{ content }}</span>
     </div>
     <div v-else>
-      <span class="chat-time text-medium-emphasis mr-2">[{{ formatTime(time) }}]</span>
+      <replay-log-time :time="time" :game-time="gameTime" />
       <span class="font-weight-bold" :class="getTeamColor(team)">
         {{ sentBy }} ({{ scopeToString(scope) }}):
       </span>
@@ -18,12 +18,14 @@
 <script lang="ts">
 import { computed, PropType, defineComponent } from "vue";
 import { EChatScope } from "@/store/common/types";
+import ReplayLogTime from "@/components/admin/replays/ReplayLogTime.vue";
 
 export default defineComponent({
   name: "ReplayChatMessage",
-  components: {},
+  components: { ReplayLogTime },
   props: {
     time: { type: Number, required: true },
+    gameTime: { type: Number, required: true },
     sentBy: { type: String, required: true },
     team: { type: Number, required: true },
     content: { type: String, required: true },
@@ -63,36 +65,11 @@ export default defineComponent({
       }
     }
 
-    // Example: 1500     -> 00:15
-    // Example: 15000000 -> 04:10:00
-    function formatTime(timeMs: number): string {
-      const totalSeconds = Math.floor(timeMs / 1000);
-      const hours = Math.floor(totalSeconds / 3600);
-      const minutes = Math.floor((totalSeconds % 3600) / 60);
-      const seconds = totalSeconds % 60;
-
-      if (hours > 0) {
-        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-      }
-
-      return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-    }
-
-
     return {
       isPrivate,
       getTeamColor,
       scopeToString,
-      formatTime,
     };
   },
 });
 </script>
-
-<style scoped>
-.chat-time {
-  display: inline-block;
-  width: 5rem;
-  font-family: monospace;
-}
-</style>

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -11,6 +11,7 @@
 import { computed, PropType, defineComponent } from "vue";
 import { EReplayGameEventType, EReplayLeaveReason } from "@/store/admin/types";
 import ReplayLogTime from "@/components/admin/replays/ReplayLogTime.vue";
+import { formatPauseDuration } from "@/components/admin/replays/replayTime";
 
 // Maps a LeaveReason enum value to the short suffix shown after "left the game".
 const LEAVE_REASON_LABELS: Partial<Record<EReplayLeaveReason, string>> = {
@@ -33,6 +34,8 @@ export default defineComponent({
     type: { type: Number as PropType<EReplayGameEventType>, required: true },
     playerName: { type: String, required: true },
     leaveReason: { type: String as PropType<EReplayLeaveReason>, required: false, default: undefined },
+    // Real-time duration (ms) of the pause this resume ends; undefined otherwise.
+    pauseDurationMs: { type: Number, required: false, default: undefined },
   },
   setup(props) {
     const icon = computed<string>(() => {
@@ -53,7 +56,9 @@ export default defineComponent({
         case EReplayGameEventType.PAUSE:
           return `${props.playerName} paused the game`;
         case EReplayGameEventType.RESUME:
-          return `${props.playerName} resumed the game`;
+          return props.pauseDurationMs !== undefined
+            ? `${props.playerName} resumed the game (paused ${formatPauseDuration(props.pauseDurationMs)})`
+            : `${props.playerName} resumed the game`;
         case EReplayGameEventType.LEAVE: {
           const label = props.leaveReason === undefined ? undefined : LEAVE_REASON_LABELS[props.leaveReason];
           return label

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="ma-0 pa-0">
     <div class="text-medium-emphasis font-italic">
-      <span class="chat-time mr-2">[{{ formatTime(time) }}]</span>
+      <replay-log-time :time="time" :game-time="gameTime" />
       <span>{{ icon }} {{ description }}</span>
     </div>
   </v-container>
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, PropType, defineComponent } from "vue";
 import { EReplayGameEventType, EReplayLeaveReason } from "@/store/admin/types";
+import ReplayLogTime from "@/components/admin/replays/ReplayLogTime.vue";
 
 // Maps a LeaveReason enum value to the short suffix shown after "left the game".
 const LEAVE_REASON_LABELS: Partial<Record<EReplayLeaveReason, string>> = {
@@ -25,8 +26,10 @@ const LEAVE_REASON_LABELS: Partial<Record<EReplayLeaveReason, string>> = {
 
 export default defineComponent({
   name: "ReplayGameEventMessage",
+  components: { ReplayLogTime },
   props: {
     time: { type: Number, required: true },
+    gameTime: { type: Number, required: true },
     type: { type: Number as PropType<EReplayGameEventType>, required: true },
     playerName: { type: String, required: true },
     leaveReason: { type: String as PropType<EReplayLeaveReason>, required: false, default: undefined },
@@ -62,34 +65,10 @@ export default defineComponent({
       }
     });
 
-    // Example: 1500     -> 00:15
-    // Example: 15000000 -> 04:10:00
-    function formatTime(timeMs: number): string {
-      const totalSeconds = Math.floor(timeMs / 1000);
-      const hours = Math.floor(totalSeconds / 3600);
-      const minutes = Math.floor((totalSeconds % 3600) / 60);
-      const seconds = totalSeconds % 60;
-
-      if (hours > 0) {
-        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-      }
-
-      return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-    }
-
     return {
       icon,
       description,
-      formatTime,
     };
   },
 });
 </script>
-
-<style scoped>
-.chat-time {
-  display: inline-block;
-  width: 5rem;
-  font-family: monospace;
-}
-</style>

--- a/src/components/admin/replays/ReplayGameEventMessage.vue
+++ b/src/components/admin/replays/ReplayGameEventMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="ma-0 pa-0">
-    <div class="text-medium-emphasis font-italic">
+    <div class="text-medium-emphasis">
       <replay-log-time :time="time" :game-time="gameTime" />
       <span>{{ icon }} {{ description }}</span>
     </div>

--- a/src/components/admin/replays/ReplayLogTime.vue
+++ b/src/components/admin/replays/ReplayLogTime.vue
@@ -1,0 +1,52 @@
+<template>
+  <span class="replay-log-time text-medium-emphasis mr-2">
+    <span :title="gameTime !== time ? 'In-game time (clock was paused)' : 'In-game time'">
+      [{{ formatTime(gameTime) }}]
+    </span>
+    <span
+      v-if="gameTime !== time"
+      class="text-disabled ml-1"
+      title="Real time (advances during pauses)"
+    >{{ formatTime(time) }}</span>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "ReplayLogTime",
+  props: {
+    // Real elapsed time in ms (advances during pauses).
+    time: { type: Number, required: true },
+    // In-game clock in ms (frozen during pauses).
+    gameTime: { type: Number, required: true },
+  },
+  setup() {
+    // Example: 1500     -> 00:15
+    // Example: 15000000 -> 04:10:00
+    function formatTime(timeMs: number): string {
+      const totalSeconds = Math.floor(timeMs / 1000);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+
+      if (hours > 0) {
+        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+      }
+
+      return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    }
+
+    return { formatTime };
+  },
+});
+</script>
+
+<style scoped>
+.replay-log-time {
+  display: inline-block;
+  width: 8.5rem;
+  font-family: monospace;
+}
+</style>

--- a/src/components/admin/replays/ReplayLogTime.vue
+++ b/src/components/admin/replays/ReplayLogTime.vue
@@ -1,10 +1,10 @@
 <template>
-  <span class="replay-log-time text-medium-emphasis mr-2" :title="title">[{{ label }}]</span>
+  <span class="replay-log-time mr-2" :class="colorClass" :title="title">[{{ label }}]</span>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, inject, ref, Ref } from "vue";
-import { REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
+import { GAME_TIME_COLOR, REAL_TIME_COLOR, REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
 
 export default defineComponent({
   name: "ReplayLogTime",
@@ -20,6 +20,7 @@ export default defineComponent({
 
     const label = computed(() => formatTime(showRealTime.value ? props.time : props.gameTime));
     const title = computed(() => (showRealTime.value ? "Real time" : "In-game time"));
+    const colorClass = computed(() => `text-${showRealTime.value ? REAL_TIME_COLOR : GAME_TIME_COLOR}`);
 
     // Example: 1500     -> 00:15
     // Example: 15000000 -> 04:10:00
@@ -36,7 +37,7 @@ export default defineComponent({
       return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
     }
 
-    return { label, title };
+    return { label, title, colorClass };
   },
 });
 </script>
@@ -46,5 +47,8 @@ export default defineComponent({
   display: inline-block;
   width: 5rem;
   font-family: monospace;
+  /* Mute the per-mode accent so the timestamps read as a subtle grey-ish tint
+     rather than the bright label/switch colour. */
+  opacity: 0.6;
 }
 </style>

--- a/src/components/admin/replays/ReplayLogTime.vue
+++ b/src/components/admin/replays/ReplayLogTime.vue
@@ -4,7 +4,8 @@
 
 <script lang="ts">
 import { computed, defineComponent, inject, ref, Ref } from "vue";
-import { GAME_TIME_COLOR, REAL_TIME_COLOR, REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
+import { useTheme } from "vuetify";
+import { REPLAY_SHOW_REAL_TIME, replayTimeColors } from "@/components/admin/replays/replayTime";
 
 export default defineComponent({
   name: "ReplayLogTime",
@@ -17,10 +18,14 @@ export default defineComponent({
   setup(props) {
     // Toggled by the switch at the top of the chat log. Defaults to in-game time.
     const showRealTime = inject<Ref<boolean>>(REPLAY_SHOW_REAL_TIME, ref(false));
+    const theme = useTheme();
 
     const label = computed(() => formatTime(showRealTime.value ? props.time : props.gameTime));
     const title = computed(() => (showRealTime.value ? "Real time" : "In-game time"));
-    const colorClass = computed(() => `text-${showRealTime.value ? REAL_TIME_COLOR : GAME_TIME_COLOR}`);
+    const colorClass = computed(() => {
+      const colors = replayTimeColors(theme.current.value.dark);
+      return `text-${showRealTime.value ? colors.real : colors.game}`;
+    });
 
     // Example: 1500     -> 00:15
     // Example: 15000000 -> 04:10:00
@@ -47,8 +52,8 @@ export default defineComponent({
   display: inline-block;
   width: 5rem;
   font-family: monospace;
-  /* Mute the per-mode accent so the timestamps read as a subtle grey-ish tint
-     rather than the bright label/switch colour. */
-  opacity: 0.6;
+  /* Slightly mute the per-mode accent so the timestamps read a touch softer than
+     the bright label/switch colour. */
+  opacity: 0.85;
 }
 </style>

--- a/src/components/admin/replays/ReplayLogTime.vue
+++ b/src/components/admin/replays/ReplayLogTime.vue
@@ -1,18 +1,10 @@
 <template>
-  <span class="replay-log-time text-medium-emphasis mr-2">
-    <span :title="gameTime !== time ? 'In-game time (clock was paused)' : 'In-game time'">
-      [{{ formatTime(gameTime) }}]
-    </span>
-    <span
-      v-if="gameTime !== time"
-      class="text-disabled ml-1"
-      title="Real time (advances during pauses)"
-    >{{ formatTime(time) }}</span>
-  </span>
+  <span class="replay-log-time text-medium-emphasis mr-2" :title="title">[{{ label }}]</span>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { computed, defineComponent, inject, ref, Ref } from "vue";
+import { REPLAY_SHOW_REAL_TIME } from "@/components/admin/replays/replayTime";
 
 export default defineComponent({
   name: "ReplayLogTime",
@@ -22,7 +14,13 @@ export default defineComponent({
     // In-game clock in ms (frozen during pauses).
     gameTime: { type: Number, required: true },
   },
-  setup() {
+  setup(props) {
+    // Toggled by the switch at the top of the chat log. Defaults to in-game time.
+    const showRealTime = inject<Ref<boolean>>(REPLAY_SHOW_REAL_TIME, ref(false));
+
+    const label = computed(() => formatTime(showRealTime.value ? props.time : props.gameTime));
+    const title = computed(() => (showRealTime.value ? "Real time" : "In-game time"));
+
     // Example: 1500     -> 00:15
     // Example: 15000000 -> 04:10:00
     function formatTime(timeMs: number): string {
@@ -38,7 +36,7 @@ export default defineComponent({
       return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
     }
 
-    return { formatTime };
+    return { label, title };
   },
 });
 </script>
@@ -46,7 +44,7 @@ export default defineComponent({
 <style scoped>
 .replay-log-time {
   display: inline-block;
-  width: 8.5rem;
+  width: 5rem;
   font-family: monospace;
 }
 </style>

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -1,0 +1,14 @@
+import type { InjectionKey, Ref } from "vue";
+
+// Shared across the replay chat log rows: true = show real time, false = in-game time.
+// Provided by AdminReplayChatLogMessages (the toggle), injected by ReplayLogTime.
+export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayShowRealTime");
+
+// Format a pause duration (ms) as a short human string: "38s", "1m 5s".
+export function formatPauseDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -8,7 +8,8 @@ export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayS
 // label and the switch, and muted (lower opacity) for the timestamps, so a cropped
 // screenshot reveals the active mode. Prefix with "text-" for a text-colour class.
 export const GAME_TIME_COLOR = "w3-gold";
-export const REAL_TIME_COLOR = "light-blue";
+// A lighter blue so it reads at a similar brightness to the gold.
+export const REAL_TIME_COLOR = "light-blue-lighten-2";
 
 // Format a pause duration (ms) as a short human string: "38s", "1m 5s".
 export function formatPauseDuration(ms: number): string {

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -7,10 +7,15 @@ export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayS
 // Per-mode accent colour (Vuetify colour name). Used bright for the active toggle
 // label and the switch, and muted (lower opacity) for the timestamps, so a cropped
 // screenshot reveals the active mode. Prefix with "text-" for a text-colour class.
-// A darker amber-gold (not the bright theme gold) so it stays readable on the
-// light themes (orc/human) as well as the dark ones (undead/nightelf).
-export const GAME_TIME_COLOR = "amber-darken-2";
-export const REAL_TIME_COLOR = "light-blue-lighten-2";
+// Per-mode accent colours (Vuetify colour names), chosen by theme brightness so
+// they read on both: grey/blue on light themes (orc/human), gold/blue on dark
+// themes (undead/nightelf). Used bright for the label + switch, muted for the
+// timestamps. Prefix with "text-" for a text-colour class.
+export function replayTimeColors(isDark: boolean): { game: string; real: string } {
+  return isDark
+    ? { game: "w3-gold", real: "light-blue-lighten-2" }
+    : { game: "grey-darken-1", real: "light-blue-darken-2" };
+}
 
 // Format a pause duration (ms) as a short human string: "38s", "1m 5s".
 export function formatPauseDuration(ms: number): string {

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -7,8 +7,9 @@ export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayS
 // Per-mode accent colour (Vuetify colour name). Used bright for the active toggle
 // label and the switch, and muted (lower opacity) for the timestamps, so a cropped
 // screenshot reveals the active mode. Prefix with "text-" for a text-colour class.
-export const GAME_TIME_COLOR = "w3-gold";
-// A lighter blue so it reads at a similar brightness to the gold.
+// A darker amber-gold (not the bright theme gold) so it stays readable on the
+// light themes (orc/human) as well as the dark ones (undead/nightelf).
+export const GAME_TIME_COLOR = "amber-darken-2";
 export const REAL_TIME_COLOR = "light-blue-lighten-2";
 
 // Format a pause duration (ms) as a short human string: "38s", "1m 5s".

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -7,13 +7,13 @@ export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayS
 // Per-mode accent colour (Vuetify colour name). Used bright for the active toggle
 // label and the switch, and muted (lower opacity) for the timestamps, so a cropped
 // screenshot reveals the active mode. Prefix with "text-" for a text-colour class.
-// Per-mode accent colours (Vuetify colour names), chosen by theme brightness so
-// they read on both: grey/blue on light themes (orc/human), gold/blue on dark
-// themes (undead/nightelf). Used bright for the label + switch, muted for the
-// timestamps. Prefix with "text-" for a text-colour class.
+// Per-mode accent colours (Vuetify colour names): grey for in-game, blue for real
+// time, tuned by theme brightness so they read on both light themes (orc/human)
+// and dark themes (undead/nightelf). Used bright for the label + switch, muted for
+// the timestamps. Prefix with "text-" for a text-colour class.
 export function replayTimeColors(isDark: boolean): { game: string; real: string } {
   return isDark
-    ? { game: "w3-gold", real: "light-blue-lighten-2" }
+    ? { game: "grey-lighten-1", real: "light-blue-lighten-2" }
     : { game: "grey-darken-1", real: "light-blue-darken-2" };
 }
 

--- a/src/components/admin/replays/replayTime.ts
+++ b/src/components/admin/replays/replayTime.ts
@@ -4,6 +4,12 @@ import type { InjectionKey, Ref } from "vue";
 // Provided by AdminReplayChatLogMessages (the toggle), injected by ReplayLogTime.
 export const REPLAY_SHOW_REAL_TIME: InjectionKey<Ref<boolean>> = Symbol("replayShowRealTime");
 
+// Per-mode accent colour (Vuetify colour name). Used bright for the active toggle
+// label and the switch, and muted (lower opacity) for the timestamps, so a cropped
+// screenshot reveals the active mode. Prefix with "text-" for a text-colour class.
+export const GAME_TIME_COLOR = "w3-gold";
+export const REAL_TIME_COLOR = "light-blue";
+
 // Format a pause duration (ms) as a short human string: "38s", "1m 5s".
 export function formatPauseDuration(ms: number): string {
   const totalSeconds = Math.round(ms / 1000);

--- a/src/store/admin/types.ts
+++ b/src/store/admin/types.ts
@@ -295,7 +295,8 @@ export enum EReplayLeaveReason {
 
 export type ReplayGameEvent = {
   type: EReplayGameEventType;
-  time: number;
+  time: number; // real elapsed time (ms), advances during pauses
+  gameTime: number; // in-game clock (ms), frozen during pauses
   playerId: number;
   leaveReason?: EReplayLeaveReason; // only present for LEAVE events
 };
@@ -308,7 +309,8 @@ export type ReplayPlayer = {
 };
 
 export type ReplayMessage = {
-  time: number;
+  time: number; // real elapsed time (ms), advances during pauses
+  gameTime: number; // in-game clock (ms), frozen during pauses
   fromPlayer: number;
   scope: ReplayMessageScope;
   content: string;


### PR DESCRIPTION
## What

Two improvements to the replay chat log:

1. **A "Real time" toggle** at the top of the chat log switches every timestamp between the **in-game clock** (frozen while paused — matches the in-game replay clock) and **real elapsed time** (advances through pauses). Defaults to in-game.
2. **Pause duration on resume lines**, e.g. `▶ Grubby#1278 resumed the game (paused 38s)` — the real-time gap between a resume and its matching pause.

## Why

The replay's accumulated tick time is real elapsed time (it advances during a pause, because flo keeps relaying time increments while the simulation is frozen). The backend now sends both `time` (real) and `game_time` (in-game), so we can show either, and the difference between a pause and its resume is the real time the game sat paused.

## How

- `ReplayMessage` / `ReplayGameEvent` carry `gameTime` (from the backend `game_time`).
- New `ReplayLogTime.vue` renders one timestamp, picking the clock from an injected toggle (`replayTime.ts` holds the injection key). `AdminReplayChatLogMessages.vue` owns the switch and `provide`s the toggle.
- Pause duration is computed frontend-side: pairing each resume with the preceding pause in the (time-ordered) event list and showing `resume.time - pause.time`. No API change for the duration.

## Scope / ordering

The `gameTime` display depends on backend `game_time` pass-through (w3champions/website-backend#537) and the replay-service change emitting it (w3champions/replay-service#4); until those ship, in-game and real are equal so the toggle is a no-op and durations still work. Lint, dprint, vue-tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)