### PR TITLE
Match history search: only suggest players you share games with

### DIFF
--- a/src/components/common/GlobalSearch.vue
+++ b/src/components/common/GlobalSearch.vue
@@ -63,6 +63,7 @@ import SeasonBadge from "@/components/player/SeasonBadge.vue";
 import { PlayerSearchInfo } from "@/store/globalSearch/types";
 import { useGlobalSearchStore } from "@/store/globalSearch/store";
 import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
 import { mdiMagnify } from "@mdi/js";
 import { Intersect } from "vuetify/directives";
 
@@ -75,6 +76,7 @@ export default defineComponent({
     intersect: Intersect,
   },
   setup() {
+    const { t } = useI18n();
     const router = useRouter();
     const searchModel = ref<PlayerSearchInfo | null>(null);
     const search = ref<string>("");
@@ -131,13 +133,13 @@ export default defineComponent({
 
     const noDataText = computed<string>(() => {
       if (!search.value || search.value.length < 3) {
-        return "Type at least 3 letters";
+        return t("components_common_playersearch.typeAtLeast3Letters");
       }
       if (isLoading.value) {
-        return "Loading...";
+        return t("components_common_playersearch.loading");
       }
 
-      return "No player found";
+      return t("components_common_playersearch.noPlayerFound");
     });
 
     const players = computed<PlayerSearchInfo[]>(() => globalSearchStore.players);

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -39,7 +39,7 @@
             {{ battleTagName(item.raw.battleTag) }}<span class="text-medium-emphasis">{{ battleTagNumber(item.raw.battleTag) }}</span>
           </v-list-item-title>
           <v-list-item-subtitle v-if="item.raw.matchCount !== undefined">
-            {{ matchCountText(item.raw.matchCount) }}
+            {{ subtitleText(item.raw) }}
           </v-list-item-subtitle>
         </v-list-item>
       </template>
@@ -68,6 +68,8 @@ type SearchedPlayer = {
   battleTag: string;
   // Only set when searching within a player's match history.
   matchCount?: number;
+  wins?: number;
+  losses?: number;
 };
 
 export default defineComponent({
@@ -216,13 +218,19 @@ export default defineComponent({
       return mode ? (t(`gameModes.${EGameMode[props.gameMode]}`) || mode.name) : "";
     });
 
-    // The count is scoped to the active mode filter; a zero says which mode is
-    // empty, so a suggestion never looks like it has no shared matches at all.
-    function matchCountText(count: number): string {
+    // The count and record are scoped to the active mode filter; a zero says
+    // which mode is empty, so a suggestion never looks like it has no shared
+    // matches at all.
+    function subtitleText(player: SearchedPlayer): string {
+      const count = player.matchCount ?? 0;
       if (count === 0 && searchModeName.value) {
         return t("components_common_playersearch.noModeMatches", { mode: searchModeName.value });
       }
-      return t("components_common_playersearch.matchCount", count);
+      const countText = t("components_common_playersearch.matchCount", count);
+      if (count === 0 || player.wins === undefined || player.losses === undefined) {
+        return countText;
+      }
+      return `${countText} · ${t("components_common_playersearch.record", { wins: player.wins, losses: player.losses })}`;
     }
 
     watch(selected, onSelect);
@@ -290,7 +298,7 @@ export default defineComponent({
       getAvatarUrlFor,
       battleTagName,
       battleTagNumber,
-      matchCountText,
+      subtitleText,
       clearSearch,
       submitSearch,
     };

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -31,11 +31,15 @@
       @keydown.enter.prevent="submitSearch"
     >
       <!-- Same look as the global search results: round avatar, battleTag on
-           top and a second line underneath (here the shared game count). -->
+           top (its #number dimmed) and a second line underneath (here the
+           shared match count). -->
       <template v-slot:item="{ props: itemProps, item }">
-        <v-list-item :prepend-avatar="getAvatarUrlFor(item.raw.battleTag)" v-bind="itemProps">
-          <v-list-item-subtitle v-if="item.raw.matchCount">
-            {{ item.raw.matchCount }} {{ item.raw.matchCount === 1 ? "game" : "games" }}
+        <v-list-item :prepend-avatar="getAvatarUrlFor(item.raw.battleTag)" v-bind="{ ...itemProps, title: undefined }">
+          <v-list-item-title>
+            {{ battleTagName(item.raw.battleTag) }}<span class="text-medium-emphasis">{{ battleTagNumber(item.raw.battleTag) }}</span>
+          </v-list-item-title>
+          <v-list-item-subtitle v-if="item.raw.matchCount !== undefined">
+            {{ matchCountText(item.raw.matchCount) }}
           </v-list-item-subtitle>
         </v-list-item>
       </template>
@@ -51,8 +55,10 @@ import MatchService from "@/services/MatchService";
 import PersonalSettingsService from "@/services/PersonalSettingsService";
 import { ProfilePicture } from "@/store/personalSettings/types";
 import { getAvatarUrl } from "@/helpers/url-functions";
-import { EAvatarCategory } from "@/store/types";
+import { EAvatarCategory, EGameMode } from "@/store/types";
 import { Gateways } from "@/store/ranking/types";
+import { useRankingStore } from "@/store/ranking/store";
+import { useI18n } from "vue-i18n";
 
 import { mdiMagnify } from "@mdi/js";
 
@@ -115,8 +121,17 @@ export default defineComponent({
       // 0 = GateWay.Undefined on the backend, i.e. no gateway filter.
       default: 0,
     },
+    // Scopes each suggestion's match count to one game mode. Opponents without
+    // matches in that mode are still suggested, with a "No <mode> matches" line.
+    gameMode: {
+      type: Number as PropType<EGameMode>,
+      required: false,
+      default: EGameMode.UNDEFINED,
+    },
   },
   setup: (props, context) => {
+    const { t } = useI18n();
+    const rankingStore = useRankingStore();
     const input = ref<string>("");
     const isLoading = ref<boolean>(false);
     const SEARCH_DELAY = 500;
@@ -132,7 +147,7 @@ export default defineComponent({
     async function dispatchSearch(val: string) {
       const token = ++searchToken;
       const players: SearchedPlayer[] = isOpponentSearch.value
-        ? await MatchService.searchOpponents(props.opponentOf, val, props.season, props.gateway)
+        ? await MatchService.searchOpponents(props.opponentOf, val, props.season, props.gateway, props.gameMode)
         : await ProfileService.searchPlayer(val.toLowerCase());
       if (token !== searchToken) return;
       searchedPlayers.value = players;
@@ -140,9 +155,9 @@ export default defineComponent({
       loadProfilePictures(players.map((player) => player.battleTag));
     }
 
-    // Keep opponent results in sync with the table when the season or gateway
-    // changes: re-run a typed search, otherwise drop the now-stale list.
-    watch(() => [props.season, props.gateway], () => {
+    // Keep opponent results in sync with the table when the season, gateway or
+    // game mode changes: re-run a typed search, otherwise drop the now-stale list.
+    watch(() => [props.season, props.gateway, props.gameMode], () => {
       if (!isOpponentSearch.value) return;
       const current = input.value && input.value !== selected.value ? input.value : "";
       if (current.length >= minSearchLength.value) {
@@ -178,6 +193,33 @@ export default defineComponent({
         hash = (hash * 31 + battleTag.charCodeAt(i)) | 0;
       }
       return getAvatarUrl(EAvatarCategory.STARTER, (Math.abs(hash) % 5) + 1, false);
+    }
+
+    // "Rampage#2131" -> "Rampage" + "#2131", so the number can be dimmed.
+    function battleTagName(battleTag: string): string {
+      const hashIndex = battleTag.lastIndexOf("#");
+      return hashIndex === -1 ? battleTag : battleTag.slice(0, hashIndex);
+    }
+
+    function battleTagNumber(battleTag: string): string {
+      const hashIndex = battleTag.lastIndexOf("#");
+      return hashIndex === -1 ? "" : battleTag.slice(hashIndex);
+    }
+
+    // Same display name the mode filter uses (translation first, API name as fallback).
+    const searchModeName = computed<string>(() => {
+      if (props.gameMode === EGameMode.UNDEFINED) return "";
+      const mode = rankingStore.activeModes.find((activeMode) => activeMode.id === props.gameMode);
+      return mode ? (t(`gameModes.${EGameMode[props.gameMode]}`) || mode.name) : "";
+    });
+
+    // The count is scoped to the active mode filter; a zero says which mode is
+    // empty, so a suggestion never looks like it has no shared matches at all.
+    function matchCountText(count: number): string {
+      if (count === 0 && searchModeName.value) {
+        return t("components_common_playersearch.noModeMatches", { mode: searchModeName.value });
+      }
+      return t("components_common_playersearch.matchCount", count);
     }
 
     watch(selected, onSelect);
@@ -238,6 +280,9 @@ export default defineComponent({
       isLoading,
       searchedPlayers,
       getAvatarUrlFor,
+      battleTagName,
+      battleTagNumber,
+      matchCountText,
       clearSearch,
       submitSearch,
     };

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -14,6 +14,7 @@
       :density="density"
       :items="searchedPlayers"
       item-title="battleTag"
+      item-value="battleTag"
       :no-data-text="noDataText"
       :loading="isLoading"
       :autofocus="setAutofocus"
@@ -28,7 +29,17 @@
       @click:clear="clearSearch"
       @click:append-inner="submitSearch"
       @keydown.enter.prevent="submitSearch"
-    />
+    >
+      <!-- Same look as the global search results: round avatar, battleTag on
+           top and a second line underneath (here the shared game count). -->
+      <template v-slot:item="{ props: itemProps, item }">
+        <v-list-item :prepend-avatar="getAvatarUrlFor(item.raw.battleTag)" v-bind="itemProps">
+          <v-list-item-subtitle v-if="item.raw.matchCount">
+            {{ item.raw.matchCount }} {{ item.raw.matchCount === 1 ? "game" : "games" }}
+          </v-list-item-subtitle>
+        </v-list-item>
+      </template>
+    </v-autocomplete>
   </div>
 </template>
 
@@ -36,11 +47,22 @@
 import { computed, defineComponent, ref, watch, PropType } from "vue";
 import debounce from "debounce";
 import ProfileService from "@/services/ProfileService";
+import MatchService from "@/services/MatchService";
+import PersonalSettingsService from "@/services/PersonalSettingsService";
+import { ProfilePicture } from "@/store/personalSettings/types";
+import { getAvatarUrl } from "@/helpers/url-functions";
+import { EAvatarCategory } from "@/store/types";
+import { Gateways } from "@/store/ranking/types";
 
 import { mdiMagnify } from "@mdi/js";
-import { PlayerProfile } from "@/store/player/types";
 
 type SearchDensity = "default" | "comfortable" | "compact";
+
+type SearchedPlayer = {
+  battleTag: string;
+  // Only set when searching within a player's match history.
+  matchCount?: number;
+};
 
 export default defineComponent({
   name: "PlayerSearch",
@@ -74,20 +96,88 @@ export default defineComponent({
       type: String,
       required: false,
       default: "Search BattleTag",
-    }
+    },
+    // When set to a battleTag, only players sharing matches with it are searched
+    // (scoped to season/gateway), so no result ever leads to an empty match list.
+    opponentOf: {
+      type: String,
+      required: false,
+      default: "",
+    },
+    season: {
+      type: Number,
+      required: false,
+      default: -1,
+    },
+    gateway: {
+      type: Number as PropType<Gateways>,
+      required: false,
+      // 0 = GateWay.Undefined on the backend, i.e. no gateway filter.
+      default: 0,
+    },
   },
   setup: (props, context) => {
     const input = ref<string>("");
     const isLoading = ref<boolean>(false);
     const SEARCH_DELAY = 500;
     const debouncedSearch = debounce((val: string) => dispatchSearch(val), SEARCH_DELAY);
-    const searchedPlayers = ref<PlayerProfile[]>([]);
+    const searchedPlayers = ref<SearchedPlayer[]>([]);
     const selected = ref<string>();
+    const profilePictures = ref<Record<string, ProfilePicture | undefined>>({});
+    let searchToken = 0;
+
+    const isOpponentSearch = computed<boolean>(() => !!props.opponentOf);
+    const minSearchLength = computed<number>(() => (isOpponentSearch.value ? 1 : 3));
 
     async function dispatchSearch(val: string) {
-      const players = await ProfileService.searchPlayer(val.toLowerCase());
+      const token = ++searchToken;
+      const players: SearchedPlayer[] = isOpponentSearch.value
+        ? await MatchService.searchOpponents(props.opponentOf, val, props.season, props.gateway)
+        : await ProfileService.searchPlayer(val.toLowerCase());
+      if (token !== searchToken) return;
       searchedPlayers.value = players;
       isLoading.value = false;
+      loadProfilePictures(players.map((player) => player.battleTag));
+    }
+
+    // Keep opponent results in sync with the table when the season or gateway
+    // changes: re-run a typed search, otherwise drop the now-stale list.
+    watch(() => [props.season, props.gateway], () => {
+      if (!isOpponentSearch.value) return;
+      const current = input.value && input.value !== selected.value ? input.value : "";
+      if (current.length >= minSearchLength.value) {
+        dispatchSearch(current);
+      } else {
+        searchedPlayers.value = [];
+      }
+    });
+
+    async function loadProfilePictures(battleTags: string[]): Promise<void> {
+      const newTags = battleTags.filter((tag) => !(tag in profilePictures.value));
+      if (newTags.length === 0) return;
+      for (const tag of newTags) {
+        profilePictures.value[tag] = undefined;
+      }
+
+      const settings = await PersonalSettingsService.retrievePersonalSettingSummaries(newTags);
+      for (const setting of settings) {
+        profilePictures.value[setting.id] = setting.profilePicture;
+      }
+    }
+
+    function getAvatarUrlFor(battleTag: string): string {
+      const pfp = profilePictures.value[battleTag];
+      if (pfp) {
+        return getAvatarUrl(pfp.race, pfp.pictureId, pfp.isClassic);
+      }
+
+      // Players without personal settings get the same default the backend uses:
+      // a starter avatar (1-5), derived from the battleTag so it is stable across renders.
+      let hash = 0;
+      for (let i = 0; i < battleTag.length; i++) {
+        hash = (hash * 31 + battleTag.charCodeAt(i)) | 0;
+      }
+      return getAvatarUrl(EAvatarCategory.STARTER, (Math.abs(hash) % 5) + 1, false);
     }
 
     watch(selected, onSelect);
@@ -110,7 +200,10 @@ export default defineComponent({
     watch(input, onInput);
 
     function onInput(val: string): void {
-      if (!val || val.length < 3) {
+      // Selecting a player writes their battleTag back into the search field;
+      // don't fire (and reopen) a new search for it.
+      if (val && val === selected.value) return;
+      if (!val || val.length < minSearchLength.value) {
         searchedPlayers.value = [];
         return;
       }
@@ -127,12 +220,15 @@ export default defineComponent({
       selected
     });
 
-    const noDataText = computed<string>(() =>
-      (!input.value || input.value.length < 3)
-        ? "Type at least 3 letters"
-        : isLoading.value
-          ? "Loading..."
-          : "No player found");
+    const noDataText = computed<string>(() => {
+      if (!input.value || input.value.length < minSearchLength.value) {
+        return isOpponentSearch.value ? "Type to search" : "Type at least 3 letters";
+      }
+      if (isLoading.value) {
+        return "Loading...";
+      }
+      return isOpponentSearch.value ? "No opponents found" : "No player found";
+    });
 
     return {
       mdiMagnify,
@@ -141,6 +237,7 @@ export default defineComponent({
       noDataText,
       isLoading,
       searchedPlayers,
+      getAvatarUrlFor,
       clearSearch,
       submitSearch,
     };

--- a/src/components/common/PlayerSearch.vue
+++ b/src/components/common/PlayerSearch.vue
@@ -7,8 +7,8 @@
       :class="classes"
       menu-icon=""
       :append-inner-icon="mdiMagnify"
-      :label="showFloatingLabel ? searchLabel : undefined"
-      :placeholder="showFloatingLabel ? undefined : searchLabel"
+      :label="showFloatingLabel ? label : undefined"
+      :placeholder="showFloatingLabel ? undefined : label"
       :persistent-placeholder="!showFloatingLabel"
       :single-line="!showFloatingLabel"
       :density="density"
@@ -98,10 +98,12 @@ export default defineComponent({
       required: false,
       default: "default",
     },
+    // Empty = the localized "Search BattleTag" default (see `label` below;
+    // a prop default cannot call `t()`).
     searchLabel: {
       type: String,
       required: false,
-      default: "Search BattleTag",
+      default: "",
     },
     // When set to a battleTag, only players sharing matches with it are searched
     // (scoped to season/gateway), so no result ever leads to an empty match list.
@@ -143,6 +145,7 @@ export default defineComponent({
 
     const isOpponentSearch = computed<boolean>(() => !!props.opponentOf);
     const minSearchLength = computed<number>(() => (isOpponentSearch.value ? 1 : 3));
+    const label = computed<string>(() => props.searchLabel || t("components_common_playersearch.searchLabel"));
 
     async function dispatchSearch(val: string) {
       const token = ++searchToken;
@@ -264,18 +267,23 @@ export default defineComponent({
 
     const noDataText = computed<string>(() => {
       if (!input.value || input.value.length < minSearchLength.value) {
-        return isOpponentSearch.value ? "Type to search" : "Type at least 3 letters";
+        return isOpponentSearch.value
+          ? t("components_common_playersearch.typeToSearch")
+          : t("components_common_playersearch.typeAtLeast3Letters");
       }
       if (isLoading.value) {
-        return "Loading...";
+        return t("components_common_playersearch.loading");
       }
-      return isOpponentSearch.value ? "No opponents found" : "No player found";
+      return isOpponentSearch.value
+        ? t("components_common_playersearch.noOpponentsFound")
+        : t("components_common_playersearch.noPlayerFound");
     });
 
     return {
       mdiMagnify,
       selected,
       input,
+      label,
       noDataText,
       isLoading,
       searchedPlayers,

--- a/src/components/matches/MatchesGrid.vue
+++ b/src/components/matches/MatchesGrid.vue
@@ -120,7 +120,7 @@
           </tr>
           <tr v-if="!matches || matches.length == 0">
             <td :colspan="emptyStateColspan" class="text-center">
-              {{ $t("components_matches_matchesgrid.nomatchesfound") }}
+              {{ emptyText || $t("components_matches_matchesgrid.nomatchesfound") }}
             </td>
           </tr>
         </tbody>
@@ -199,6 +199,12 @@ export default defineComponent({
     itemsPerPage: {
       type: Number,
       required: true,
+    },
+    // Overrides the generic "no matches found" empty-state text.
+    emptyText: {
+      type: String,
+      required: false,
+      default: undefined,
     },
     alwaysLeftName: {
       type: String,

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -14,6 +14,9 @@
               :showFloatingLabel="false"
               density="compact"
               searchLabel="Search Opponents"
+              :opponentOf="battleTag"
+              :season="selectedSeasonId"
+              :gateway="gateway"
               @playerFound="playerFound"
               @searchCleared="searchCleared"
             />
@@ -256,11 +259,13 @@ import { computed, defineComponent, onMounted, ref, watch } from "vue";
 import { onBeforeRouteLeave } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { loadActiveGameModes, activeGameModesWithAll, type IGameModeBrief } from "@/composables/GameModesMixin";
+import type { Gateways } from "@/store/ranking/types";
 import MatchesGrid from "@/components/matches/MatchesGrid.vue";
 import { EGameMode, ERaceEnum, type Match, type PlayerInTeam, type Team } from "@/store/types";
 import PlayerSearch from "@/components/common/PlayerSearch.vue";
 import { usePlayerStore } from "@/store/player/store";
 import { useRankingStore } from "@/store/ranking/store";
+import { useRootStateStore } from "@/store/rootState/store";
 import HeroSelect from "@/components/matches/HeroSelect.vue";
 import { useCommonStore } from "@/store/common/store";
 import { getAsset } from "@/helpers/url-functions";
@@ -292,6 +297,7 @@ export default defineComponent({
     const { t } = useI18n();
     const playerStore = usePlayerStore();
     const rankingsStore = useRankingStore();
+    const rootStateStore = useRootStateStore();
     const commonStore = useCommonStore();
     const tableOptionsStore = useTableOptionsStore();
     const isLoadingMatches = ref<boolean>(false);
@@ -299,6 +305,8 @@ export default defineComponent({
     const hasResolvedInitialMatches = ref<boolean>(false);
 
     const battleTag = computed<string>(() => decodeURIComponent(props.id));
+    const selectedSeasonId = computed<number>(() => playerStore.selectedSeason?.id ?? -1);
+    const gateway = computed<Gateways>(() => rootStateStore.gateway);
     const totalMatches = computed<number>(() => playerStore.totalMatches);
     const matches = computed<Match[]>(() => playerStore.matches);
     const selectedHeroes = computed<number[]>(() => playerStore.selectedHeroes);
@@ -642,6 +650,8 @@ export default defineComponent({
       matches,
       totalMatches,
       battleTag,
+      selectedSeasonId,
+      gateway,
       onPageChanged,
       showHeroIcons,
       showRelativeStartTime,

--- a/src/components/player/tabs/PlayerMatchesTab.vue
+++ b/src/components/player/tabs/PlayerMatchesTab.vue
@@ -17,6 +17,7 @@
               :opponentOf="battleTag"
               :season="selectedSeasonId"
               :gateway="gateway"
+              :gameMode="selectedGameMode"
               @playerFound="playerFound"
               @searchCleared="searchCleared"
             />
@@ -243,6 +244,7 @@
       v-model="matches"
       :total-matches="totalMatches"
       :items-per-page="50"
+      :empty-text="matchesEmptyText"
       :always-left-name="battleTag"
       only-show-enemy
       :is-player-profile="true"
@@ -307,6 +309,7 @@ export default defineComponent({
     const battleTag = computed<string>(() => decodeURIComponent(props.id));
     const selectedSeasonId = computed<number>(() => playerStore.selectedSeason?.id ?? -1);
     const gateway = computed<Gateways>(() => rootStateStore.gateway);
+    const selectedGameMode = computed<EGameMode>(() => playerStore.profileMatchesGameMode);
     const totalMatches = computed<number>(() => playerStore.totalMatches);
     const matches = computed<Match[]>(() => playerStore.matches);
     const selectedHeroes = computed<number[]>(() => playerStore.selectedHeroes);
@@ -526,6 +529,13 @@ export default defineComponent({
       return ((opponentWins.value / matches.value.length) * 100).toFixed(1);
     });
 
+    // With an opponent and a mode filter both active, an empty result deserves
+    // a more specific message than the grid's generic "no matches found".
+    const matchesEmptyText = computed<string | undefined>(() =>
+      playerStore.opponentTag && selectedGameMode.value !== EGameMode.UNDEFINED
+        ? t("components_player_tabs_matchhistorytab.noModeMatchesVsOpponent", { mode: selectedGameModeName.value })
+        : undefined);
+
     function setSelectedGameModeForSearch(mode: IGameModeBrief): void {
       const gameMode = Number.isNaN(mode.id) ? EGameMode.UNDEFINED : mode.id;
       playerStore.SET_PROFILE_MATCHES_GAME_MODE(gameMode);
@@ -652,6 +662,8 @@ export default defineComponent({
       battleTag,
       selectedSeasonId,
       gateway,
+      selectedGameMode,
+      matchesEmptyText,
       onPageChanged,
       showHeroIcons,
       showRelativeStartTime,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -536,6 +536,7 @@ const en = {
     noPlayerFound: "No player found",
     noOpponentsFound: "No opponents found",
     matchCount: "no matches | {n} match | {n} matches",
+    record: "{wins}W - {losses}L",
     noModeMatches: "No {mode} matches",
   },
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -524,6 +524,15 @@ const en = {
     calibrating: "Calibrating",
   },
 
+  components_player_tabs_matchhistorytab: {
+    noModeMatchesVsOpponent: "No {mode} matches against this opponent",
+  },
+
+  components_common_playersearch: {
+    matchCount: "no matches | {n} match | {n} matches",
+    noModeMatches: "No {mode} matches",
+  },
+
   proxies: {
     eu_east3_via_eu_central2: "EU East 3 via EU Central 2",
     asia_east_via_cn_east: "Asia East via CN East",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -529,6 +529,12 @@ const en = {
   },
 
   components_common_playersearch: {
+    searchLabel: "Search BattleTag",
+    typeToSearch: "Type to search",
+    typeAtLeast3Letters: "Type at least 3 letters",
+    loading: "Loading...",
+    noPlayerFound: "No player found",
+    noOpponentsFound: "No opponents found",
     matchCount: "no matches | {n} match | {n} matches",
     noModeMatches: "No {mode} matches",
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,11 +10,36 @@ import "@/scss/main.scss";
 
 const pinia = createPinia();
 
+// Slavic languages need "few" (2-4) and "many" forms; messages using these
+// rules carry four variants: "zero | one | few | many". Locales without a
+// rule here keep vue-i18n's default (zero | one | other). Clamped so a
+// message that only has the English three (or fewer) forms — e.g. an en
+// fallback while a translation is missing from the sheet — still resolves.
+function slavicPluralRule(endsInOneIsSingular: boolean) {
+  return (choice: number, choicesLength: number): number => {
+    const index = (() => {
+      if (choice === 0) return 0;
+      const teen = choice % 100 > 10 && choice % 100 < 20;
+      if (!teen && (endsInOneIsSingular ? choice % 10 === 1 : choice === 1)) return 1;
+      if (!teen && choice % 10 >= 2 && choice % 10 <= 4) return 2;
+      return 3;
+    })();
+    return Math.min(index, choicesLength - 1);
+  };
+}
+
 const i18n = createI18n({
   legacy: false,
   locale: "en",
   fallbackLocale: "en",
   messages: languages,
+  pluralRules: {
+    // ru/ua/sr: 21, 31, ... take the singular form; pl reserves it for exactly 1.
+    ru: slavicPluralRule(true),
+    ua: slavicPluralRule(true),
+    sr: slavicPluralRule(true),
+    pl: slavicPluralRule(false),
+  },
 });
 
 const app = createApp(App);

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -96,14 +96,17 @@ export default class MatchService {
   }
 
   // Searches the players someone shares matches with in the given season,
-  // ordered by shared match count. An empty search returns the most played opponents.
+  // ordered by shared match count. An empty search returns the most played
+  // opponents. matchCount is scoped to the game mode (all modes when UNDEFINED);
+  // opponents without matches in that mode still appear, with matchCount 0.
   public static async searchOpponents(
     battleTag: string,
     search: string,
     season: number,
     gateway: Gateways,
+    gameMode: EGameMode = EGameMode.UNDEFINED,
   ): Promise<OpponentInfo[]> {
-    const url = `${API_URL}api/matches/search-opponents?playerId=${encodeURIComponent(battleTag)}&search=${encodeURIComponent(search)}&season=${season}&gateWay=${gateway}`;
+    const url = `${API_URL}api/matches/search-opponents?playerId=${encodeURIComponent(battleTag)}&search=${encodeURIComponent(search)}&season=${season}&gateWay=${gateway}&gameMode=${gameMode}`;
 
     const response = await fetch(url);
     if (!response.ok) return [];

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -1,7 +1,7 @@
 import { EGameMode, ERaceEnum, Match, MatchDetail } from "@/store/types";
 import { API_URL } from "@/config/env";
 import { Gateways } from "@/store/ranking/types";
-import { Mmr } from "@/store/match/types";
+import { Mmr, OpponentInfo } from "@/store/match/types";
 
 export default class MatchService {
   static pageSize = 50;
@@ -92,6 +92,21 @@ export default class MatchService {
       return {} as Match;
     }
 
+    return await response.json();
+  }
+
+  // Searches the players someone shares matches with in the given season,
+  // ordered by shared match count. An empty search returns the most played opponents.
+  public static async searchOpponents(
+    battleTag: string,
+    search: string,
+    season: number,
+    gateway: Gateways,
+  ): Promise<OpponentInfo[]> {
+    const url = `${API_URL}api/matches/search-opponents?playerId=${encodeURIComponent(battleTag)}&search=${encodeURIComponent(search)}&season=${season}&gateWay=${gateway}`;
+
+    const response = await fetch(url);
+    if (!response.ok) return [];
     return await response.json();
   }
 

--- a/src/services/PersonalSettingsService.ts
+++ b/src/services/PersonalSettingsService.ts
@@ -1,5 +1,5 @@
 import { API_URL } from "@/config/env";
-import { PersonalSetting, ProfilePicture } from "@/store/personalSettings/types";
+import { PersonalSetting, PersonalSettingSummary, ProfilePicture } from "@/store/personalSettings/types";
 import { authorizedFetch } from "@/helpers/general";
 
 export default class PersonalSettingsService {
@@ -8,6 +8,15 @@ export default class PersonalSettingsService {
 
     const response = await fetch(url);
     if (!response.ok) return {} as PersonalSetting;
+    return await response.json();
+  }
+
+  public static async retrievePersonalSettingSummaries(battleTags: string[]): Promise<PersonalSettingSummary[]> {
+    if (battleTags.length === 0) return [];
+    const url = `${API_URL}api/personal-settings/${encodeURIComponent(battleTags.join(","))}/many`;
+
+    const response = await fetch(url);
+    if (!response.ok) return [];
     return await response.json();
   }
 

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -39,8 +39,11 @@ export type Mmr = {
 };
 
 // One result of the matches/search-opponents endpoint: a player who shares
-// finished matches with the searched player, and how many they share.
+// finished matches with the searched player, how many they share, and the
+// searched player's record across them (allies share the same result).
 export type OpponentInfo = {
   battleTag: string;
   matchCount: number;
+  wins: number;
+  losses: number;
 };

--- a/src/store/match/types.ts
+++ b/src/store/match/types.ts
@@ -37,3 +37,10 @@ export type Mmr = {
   min: number;
   max: number;
 };
+
+// One result of the matches/search-opponents endpoint: a player who shares
+// finished matches with the searched player, and how many they share.
+export type OpponentInfo = {
+  battleTag: string;
+  matchCount: number;
+};

--- a/src/store/personalSettings/types.ts
+++ b/src/store/personalSettings/types.ts
@@ -55,6 +55,14 @@ export type PersonalSetting = {
   aliasSettings: AkaSettings;
 };
 
+// Subset returned by the personal-settings "many" endpoint.
+export type PersonalSettingSummary = {
+  id: string;
+  countryCode?: string;
+  location?: string;
+  profilePicture: ProfilePicture;
+};
+
 export type ProfilePlayerSocials = {
   twitch: string;
   youtube: string;


### PR DESCRIPTION
Rework of #1100 based on the feedback there.

- the opponent search now only suggests players you actually have games with in the selected season (teammates in team games count too), so clicking a result can never land on 0 matches
- dropdown matches the global search look: round avatar, battleTag, and "12 matches · 6W - 6L" (shared matches + your record across them) on the line under it, sorted by games together
- dropped the hover card / MMR enrichment entirely — MMR was misleading without a mode filter anyway
- searching starts at 1 character (the query is scoped and cheap), nothing is fetched until you type
- also checked the "season switch resets the opponent" report: it doesn't reset — the filter persists and the head-to-head recalculates for the new season
- all strings localized (GlobalSearch's identical hardcoded ones too); en staged in en.ts, other languages go to the localization sheet. Plural rules added for ru/ua/pl/sr since the match count is the site's first real plural

Needs w3champions/website-backend#539.