### PR TITLE
Rework the player MMR timeline chart

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -12,6 +12,7 @@
     "**/package-lock.json",
     "**/*.js",
     "src/locales/data.ts",
+    "src/lib/chart-timestack",
     "components.d.ts",
     ".eslintrc.cjs",
     "scripts/key.ts"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default defineConfigWithVueTs([
   // vueTsConfigs.recommended,
   vueTsConfigs.recommendedTypeChecked,
   eslintPluginVue.configs["flat/recommended"],
-  globalIgnores(["**/dist/**", "src/locales/data.ts", "src/locales/en.ts", "public/env.js"]),
+  globalIgnores(["**/dist/**", "src/locales/data.ts", "src/locales/en.ts", "public/env.js", "src/lib/chart-timestack/**"]),
   {
     name: "eslint",
     files: ["*.{ts,mts,tsx,vue}", "**/*.{ts,mts,tsx,vue}"],

--- a/src/components/common/charts/TimelineChart.vue
+++ b/src/components/common/charts/TimelineChart.vue
@@ -1,0 +1,620 @@
+<template>
+  <div class="timeline-chart">
+    <!-- Always shown: the grid toggle applies to every chart, even one with no
+         range presets or markers of its own. -->
+    <div class="timeline-chart__ranges" :style="{ paddingRight: `${rightGutter}px` }">
+      <v-chip-group v-model="activeRange" mandatory selected-class="text-primary" density="comfortable">
+        <v-chip
+          v-for="preset in rangePresets"
+          :key="preset.key"
+          :value="preset.key"
+          size="small"
+          variant="outlined"
+        >
+          {{ preset.label }}
+        </v-chip>
+      </v-chip-group>
+      <div class="timeline-chart__toolbar-end">
+        <v-chip
+          v-if="markers.length"
+          size="small"
+          variant="outlined"
+          :style="showMarkers ? { borderColor: markerHue, color: markerHue } : undefined"
+          @click="showMarkers = !showMarkers"
+        >
+          Seasons
+        </v-chip>
+        <v-chip
+          size="small"
+          variant="outlined"
+          :class="{ 'text-primary': showGrid }"
+          @click="showGrid = !showGrid"
+        >
+          Grid
+        </v-chip>
+        <v-btn
+          v-if="zoomed"
+          size="small"
+          variant="text"
+          density="comfortable"
+          @click="resetZoom"
+        >
+          Reset zoom
+        </v-btn>
+      </div>
+    </div>
+
+    <div class="timeline-chart__canvas" :style="{ height: `${height}px` }">
+      <line-chart-generic ref="chartRef" :data="chartData" :options="chartOptions" :plugins="localPlugins" />
+    </div>
+
+    <ul class="timeline-chart__legend">
+      <li
+        v-for="entry in legendEntries"
+        :key="entry.key"
+        class="timeline-chart__legend-item"
+        :class="{ 'timeline-chart__legend-item--off': entry.hidden }"
+        :style="{ backgroundColor: entry.tint, borderColor: entry.edge }"
+        role="button"
+        tabindex="0"
+        @click="toggleSeries(entry.key)"
+        @keydown.enter="toggleSeries(entry.key)"
+        @keydown.space.prevent="toggleSeries(entry.key)"
+      >
+        <img v-if="entry.icon" class="timeline-chart__icon" :src="entry.icon" :alt="entry.label" />
+        <span v-else class="timeline-chart__swatch" :style="{ backgroundColor: entry.color }"></span>
+        <span class="timeline-chart__legend-label">{{ entry.label }}</span>
+        <span class="timeline-chart__legend-value">{{ entry.current }}</span>
+        <template v-if="entry.peak">
+          <span class="timeline-chart__legend-sep">·</span>
+          <span class="timeline-chart__legend-peak">peak {{ entry.peak.value }} on {{ entry.peak.date }}</span>
+        </template>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType, ref } from "vue";
+import {
+  Chart as ChartJS,
+  type ChartData,
+  type ChartOptions,
+  Filler,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  type ScriptableLineSegmentContext,
+  Tooltip,
+} from "chart.js";
+import zoomPlugin from "chartjs-plugin-zoom";
+import annotationPlugin from "chartjs-plugin-annotation";
+import { Line as LineChartGeneric } from "vue-chartjs";
+import { useTheme } from "vuetify";
+import { format } from "date-fns";
+import "@/lib/chart-timestack";
+import { DEF_TICK_GENERATORS } from "@/lib/chart-timestack";
+import { resyncPointer, timelineCrosshairPlugin } from "@/components/common/charts/timelineCrosshair";
+import { timelineWheelPanPlugin } from "@/components/common/charts/timelineWheelPan";
+import { withAlpha } from "@/components/common/charts/colors";
+import type { TimelineAxis, TimelineMarker, TimelinePoint, TimelineRangePreset, TimelineSeries } from "@/components/common/charts/types";
+
+ChartJS.register(LineController, LineElement, PointElement, LinearScale, Filler, Tooltip);
+
+// Scoped to this chart rather than registered globally: both draw and handle
+// events on every chart they are registered against, and the other charts on
+// the site neither want a crosshair nor expect to be zoomable.
+const sharedPlugins = [zoomPlugin, annotationPlugin, timelineCrosshairPlugin, timelineWheelPanPlugin];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// One point per calendar day is all the data has, so drop the generators that
+// would label hours and minutes: they invent a precision that isn't there.
+const dayResolutionTicks = (): typeof DEF_TICK_GENERATORS => DEF_TICK_GENERATORS.filter((gen) => gen.top.size >= DAY_MS);
+
+// A single neutral grey can't be subtle on one theme and visible on the other,
+// so tint from the background: light lines on dark, dark lines on light.
+const gridColors = (isDark: boolean): { grid: string; border: string } =>
+  isDark
+    ? { grid: "rgba(255, 255, 255, 0.12)", border: "rgba(255, 255, 255, 0.28)" }
+    : { grid: "rgba(0, 0, 0, 0.12)", border: "rgba(0, 0, 0, 0.30)" };
+
+// Season boundaries and the like. Outside the race palette so a boundary can't
+// be mistaken for a series, and darkened on the light theme where a bright amber
+// all but disappears.
+/** Grid-friendly step for the span: hundreds for ratings, units for levels. */
+const roundingStep = (span: number): number => Math.max(10 ** (Math.floor(Math.log10(span || 1)) - 1), 1);
+
+const markerColor = (isDark: boolean): string => (isDark ? "rgba(255, 193, 7, 0.65)" : "rgba(168, 94, 0, 0.75)");
+
+// Ring around the peak marker, so it reads against the plot on either theme.
+const markerRingColor = (isDark: boolean): string => (isDark ? "rgba(255, 255, 255, 0.85)" : "rgba(0, 0, 0, 0.7)");
+
+export default defineComponent({
+  name: "TimelineChart",
+  components: { LineChartGeneric },
+  props: {
+    series: {
+      type: Array as PropType<TimelineSeries[]>,
+      required: true,
+    },
+    axes: {
+      type: Array as PropType<TimelineAxis[]>,
+      required: true,
+    },
+    rangePresets: {
+      type: Array as PropType<TimelineRangePreset[]>,
+      default: () => [],
+    },
+    /** Segments spanning more than this many days are drawn dashed, so a long
+     * inactivity gap doesn't read as a held rating. */
+    gapDays: {
+      type: Number,
+      default: 14,
+    },
+    fill: {
+      type: Boolean,
+      default: false,
+    },
+    /** Vertical reference lines, e.g. season boundaries. */
+    markers: {
+      type: Array as PropType<TimelineMarker[]>,
+      default: () => [],
+    },
+    /** Floor on how far the x axis can be zoomed in, in days. */
+    minRangeDays: {
+      type: Number,
+      default: 7,
+    },
+    /** Carries every series flat to this time (epoch ms) with a synthetic
+     * trailing point. A rating still stands on days with no games, so an
+     * ongoing season should run to today rather than stopping at the last
+     * match. Excluded from peaks, markers and tooltip dates. */
+    extendTo: {
+      type: Number as PropType<number | null>,
+      default: null,
+    },
+    height: {
+      type: Number,
+      default: 360,
+    },
+  },
+  setup(props) {
+    const theme = useTheme();
+    const chartRef = ref<{ chart?: ChartJS<"line"> }>();
+    const hiddenKeys = ref<Set<string>>(new Set());
+    const zoomed = ref<boolean>(false);
+    const showMarkers = ref<boolean>(true);
+    const showGrid = ref<boolean>(true);
+
+    // Distance from the canvas edge to the plot area, so the toolbar lines up
+    // with the plot rather than sitting over a right-hand axis. Measured rather
+    // than guessed, because it depends on the widest tick label.
+    const rightGutter = ref<number>(0);
+
+    const localPlugins = [
+      ...sharedPlugins,
+      {
+        id: "timelineGutter",
+        afterLayout(chart: ChartJS) {
+          rightGutter.value = Math.max(chart.width - chart.chartArea.right, 0);
+        },
+      },
+    ];
+
+    const visibleSeries = computed<TimelineSeries[]>(() => props.series.filter((s) => s.points.length > 0));
+
+    const chart = (): ChartJS<"line"> | undefined => chartRef.value?.chart;
+
+    /**
+     * The full vertical extent of each axis, so zooming along x leaves the y
+     * axis alone. Letting it rescale to whatever is in view makes the line jump
+     * as you zoom, which reads as the data changing rather than the window.
+     * Hiding a series does recompute it, since that is a deliberate ask.
+     */
+    const axisBounds = computed<Record<string, { min: number; max: number; dataMin: number }>>(() => {
+      const bounds: Record<string, { min: number; max: number; dataMin: number }> = {};
+
+      for (const s of visibleSeries.value) {
+        if (hiddenKeys.value.has(s.key)) continue;
+        const id = s.yAxisID ?? props.axes[0].id;
+        for (const point of s.points) {
+          const current = bounds[id];
+          bounds[id] = current
+            ? { min: Math.min(current.min, point.y), max: Math.max(current.max, point.y), dataMin: 0 }
+            : { min: point.y, max: point.y, dataMin: 0 };
+        }
+      }
+
+      // A little air so a peak or trough doesn't sit against the frame, then
+      // snapped outwards to round numbers: pinning the axis means the extremes
+      // are labelled exactly, and raw padded values read as 2,794.1.
+      for (const id of Object.keys(bounds)) {
+        const { min, max } = bounds[id];
+        const padded = Math.max((max - min) * 0.06, 1);
+        const step = roundingStep(max - min + padded * 2);
+        bounds[id] = {
+          min: Math.floor((min - padded) / step) * step,
+          max: Math.ceil((max + padded) / step) * step,
+          dataMin: min,
+        };
+      }
+      return bounds;
+    });
+
+    const peakOf = (s: TimelineSeries): { point: TimelinePoint; index: number } => {
+      if (s.peak) {
+        const index = s.points.findIndex((p) => p.x === s.peak?.x);
+        return { point: s.peak, index };
+      }
+      let index = 0;
+      for (let i = 1; i < s.points.length; i++) {
+        if (s.points[i].y > s.points[index].y) index = i;
+      }
+      return { point: s.points[index], index };
+    };
+
+    const extendedPoints = (s: TimelineSeries): TimelinePoint[] => {
+      const last = s.points[s.points.length - 1];
+      if (props.extendTo == null || props.extendTo <= last.x) return s.points;
+      return [...s.points, { x: props.extendTo, y: last.y }];
+    };
+
+    const chartData = computed<ChartData<"line">>(() => ({
+      datasets: visibleSeries.value.map((s) => {
+        const peakIndex = peakOf(s).index;
+        const real = s.points.length;
+
+        // Only the peak gets a marker. Dots on every point added nothing the
+        // steps and the crosshair don't already show, and a density threshold
+        // meant a heavily played race lost its dots while the others kept
+        // theirs, which just looked broken.
+        const radiusAt = (index: number): number => (index === peakIndex && index < real ? 5 : 0);
+        const data = extendedPoints(s);
+
+        return {
+          label: s.label,
+          data,
+          yAxisID: s.yAxisID ?? props.axes[0].id,
+          hidden: hiddenKeys.value.has(s.key),
+          borderColor: s.color,
+          backgroundColor: s.color,
+          borderWidth: 1.5,
+          // 'before' holds each point's value until the next point and steps
+          // there, which is how a rating actually behaves. 'after' would step
+          // at the point itself, drawing the *next* value across the interval.
+          stepped: "before" as const,
+          fill: props.fill,
+          pointRadius: (ctx: { dataIndex: number }) => radiusAt(ctx.dataIndex),
+          // Matched to pointRadius so nothing resizes under the cursor. Left at
+          // zero, the active point vanished as the crosshair passed over it.
+          pointHoverRadius: (ctx: { dataIndex: number }) => radiusAt(ctx.dataIndex),
+          pointStyle: "rectRot" as const,
+          pointBorderWidth: (ctx: { dataIndex: number }) => (ctx.dataIndex === peakIndex ? 1.5 : 0),
+          pointBorderColor: markerRingColor(theme.current.value.dark),
+          segment: {
+            borderDash: (ctx: ScriptableLineSegmentContext) => {
+              const from = ctx.p0.parsed.x;
+              const to = ctx.p1.parsed.x;
+              if (from == null || to == null) return undefined;
+              return to - from > props.gapDays * DAY_MS ? [3, 3] : undefined;
+            },
+          },
+        };
+      }),
+    }));
+
+    const chartOptions = computed<ChartOptions<"line">>(() => {
+      const { grid, border } = gridColors(theme.current.value.dark);
+      const markerLine = markerColor(theme.current.value.dark);
+
+      return {
+        maintainAspectRatio: false,
+        animation: false,
+        normalized: true,
+        parsing: false,
+        // Room for a peak marker sitting on the newest point or at the very top.
+        layout: { padding: { right: 6, top: 6 } },
+        interaction: {
+          mode: "steppedIndex",
+          intersect: false,
+        },
+        scales: {
+          x: {
+            type: "timestack",
+            bounds: "data",
+            timestack: { make_tick_generators: dayResolutionTicks },
+            // No vertical gridlines: they run parallel to the season markers
+            // and make it hard to pick those out.
+            grid: { display: false },
+            border: { color: border },
+          },
+          ...Object.fromEntries(props.axes.map((axis) => [
+            axis.id,
+            {
+              type: "linear",
+              position: axis.position ?? "left",
+              beginAtZero: axis.beginAtZero ?? false,
+              min: axisBounds.value[axis.id]?.min,
+              max: axisBounds.value[axis.id]?.max,
+              title: axis.title ? { display: true, text: axis.title } : undefined,
+              ticks: {
+                // The padded range may dip below zero to leave room for the
+                // season captions, but neither a rating nor a level can be
+                // negative, so leave those ticks unlabelled rather than
+                // implying the value is possible.
+                callback(this: { getLabelForValue: (v: number) => string }, value: string | number) {
+                  const numeric = Number(value);
+                  const bounds = axisBounds.value[axis.id];
+                  if (bounds && bounds.dataMin >= 0 && numeric < 0) return null;
+                  return this.getLabelForValue(numeric);
+                },
+              },
+              // Only the first axis paints gridlines, or a second scale's lines
+              // cross the first's at unrelated values.
+              grid: { display: showGrid.value, drawOnChartArea: axis.id === props.axes[0].id, color: grid },
+              border: { color: border },
+              // Runs again after every zoom, so the vertical scale stays honest
+              // instead of magnifying a few points into dramatic swings.
+              afterDataLimits: (scale: { min: number; max: number }) => {
+                if (!axis.minRange) return;
+                const padding = (axis.minRange - (scale.max - scale.min)) / 2;
+                if (padding <= 0) return;
+                scale.min -= padding;
+                scale.max += padding;
+              },
+            },
+          ])),
+        },
+        plugins: {
+          legend: { display: false }, // Replaced by the HTML legend below the chart.
+          annotation: {
+            // Drawn under the data so a boundary never obscures a rating.
+            drawTime: "beforeDatasetsDraw",
+            annotations: Object.fromEntries((showMarkers.value ? props.markers : []).map((marker, i) => [
+              `marker${i}`,
+              {
+                type: "line",
+                xMin: marker.x,
+                xMax: marker.x,
+                borderColor: markerLine,
+                borderWidth: 1,
+                borderDash: [2, 3],
+                label: marker.label
+                  ? {
+                    display: true,
+                    content: marker.label,
+                    position: "start",
+                    backgroundColor: "transparent",
+                    color: markerLine,
+                    font: { size: 9 },
+                    padding: 2,
+                  }
+                  : { display: false },
+              },
+            ])),
+          },
+          tooltip: {
+            position: "crosshair",
+            displayColors: true,
+            titleFont: { size: 13 },
+            bodyFont: { size: 13 },
+            padding: 8,
+            // Highest first, so the rows sit in the same order as the lines do
+            // on screen at that moment.
+            itemSort: (a, b) => (b.parsed.y ?? 0) - (a.parsed.y ?? 0),
+            callbacks: {
+            // The heading is the most recent day played at or before the
+            // crosshair, not the crosshair's own date: between games nothing
+            // changed, so that day is what these values actually describe.
+              title: (items) => {
+                const played = Math.max(...items.map((item) => {
+                  const s = visibleSeries.value[item.datasetIndex];
+                  // A synthetic trailing point is not a game; report the last real one.
+                  return item.dataIndex >= s.points.length
+                    ? s.points[s.points.length - 1].x
+                    : (item.raw as { x: number }).x;
+                }));
+                if (!Number.isFinite(played)) return "";
+
+                // The marker at or before this point names the period it falls
+                // in, so a reading part way through a long series is placed
+                // without counting boundaries by eye.
+                const marker = [...props.markers].reverse().find((m) => m.x <= played);
+                const date = format(new Date(played), "MMM d, yyyy");
+                return marker?.label ? `${date}  ·  ${marker.label}` : date;
+              },
+              label: (item) => {
+                const series = visibleSeries.value[item.datasetIndex];
+                const raw = (item.raw as { y: number }).y;
+                return `${item.dataset.label}: ${series?.format ? series.format(raw) : raw}`;
+              },
+            },
+          },
+          zoom: {
+            // Both gestures slide the data under a stationary pointer, so the
+            // readout has to be re-resolved as they go, or it keeps reporting
+            // whatever was under the cursor when the gesture began.
+            pan: { enabled: true, mode: "x", onPan: ({ chart }) => resyncPointer(chart) },
+            zoom: {
+              wheel: { enabled: true },
+              pinch: { enabled: true },
+              mode: "x",
+              onZoom: ({ chart }) => resyncPointer(chart),
+              onZoomComplete: () => { zoomed.value = true; },
+            },
+            // Never zoom past the resolution of the data itself.
+            limits: { x: { min: "original", max: "original", minRange: props.minRangeDays * DAY_MS } },
+          },
+        },
+      };
+    });
+
+    const selectedRange = ref<string | undefined>(props.rangePresets.find((p) => p.default)?.key ?? props.rangePresets[0]?.key);
+
+    const activeRange = computed<string | undefined>({
+      get: () => selectedRange.value,
+      set: (key?: string) => {
+        if (!key) return;
+        selectedRange.value = key;
+        applyRange(key);
+      },
+    });
+
+    function dataExtent(): { min: number; max: number } | null {
+      let min = Infinity;
+      let max = -Infinity;
+      for (const s of visibleSeries.value) {
+        if (hiddenKeys.value.has(s.key)) continue;
+        min = Math.min(min, s.points[0].x);
+        max = Math.max(max, s.points[s.points.length - 1].x);
+      }
+      return Number.isFinite(min) && Number.isFinite(max) ? { min, max } : null;
+    }
+
+    function applyRange(key: string): void {
+      const instance = chart();
+      const preset = props.rangePresets.find((p) => p.key === key);
+      if (!instance || !preset) return;
+
+      if (preset.months == null) {
+        instance.resetZoom("none");
+        zoomed.value = false;
+        return;
+      }
+
+      const extent = dataExtent();
+      if (!extent) return;
+
+      const from = new Date(extent.max);
+      from.setMonth(from.getMonth() - preset.months);
+      instance.zoomScale("x", { min: Math.max(from.getTime(), extent.min), max: extent.max }, "none");
+      zoomed.value = false;
+    }
+
+    function resetZoom(): void {
+      chart()?.resetZoom("none");
+      zoomed.value = false;
+    }
+
+    function toggleSeries(key: string): void {
+      const next = new Set(hiddenKeys.value);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      hiddenKeys.value = next;
+    }
+
+    const legendEntries = computed(() => visibleSeries.value.map((s) => {
+      const last = s.points[s.points.length - 1];
+      const peak = peakOf(s).point;
+      return {
+        key: s.key,
+        label: s.label,
+        color: s.color,
+        icon: s.icon,
+        tint: withAlpha(s.color, 0.16),
+        edge: withAlpha(s.color, 0.55),
+        hidden: hiddenKeys.value.has(s.key),
+        current: s.format ? s.format(last.y) : String(last.y),
+        peak: {
+          value: s.format ? s.format(peak.y) : String(peak.y),
+          date: format(new Date(peak.x), "MMM d, yyyy"),
+        },
+      };
+    }));
+
+    return {
+      localPlugins,
+      rightGutter,
+      showMarkers,
+      showGrid,
+      markerHue: computed(() => markerColor(theme.current.value.dark)),
+      chartRef,
+      chartData,
+      chartOptions,
+      activeRange,
+      legendEntries,
+      resetZoom,
+      toggleSeries,
+      zoomed,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.timeline-chart__ranges {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.timeline-chart__toolbar-end {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.timeline-chart__canvas {
+  position: relative;
+}
+
+.timeline-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  list-style: none;
+  padding: 12px 0 0;
+  margin: 0;
+}
+
+.timeline-chart__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  // A tinted pill carries the series colour even when an icon replaces the
+  // swatch, which is otherwise the only thing tying a row to its line.
+  padding: 2px 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+
+  &--off {
+    opacity: 0.4;
+  }
+}
+
+.timeline-chart__icon {
+  height: 22px;
+  width: auto;
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+.timeline-chart__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+.timeline-chart__legend-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.timeline-chart__legend-peak {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+.timeline-chart__legend-sep {
+  opacity: 0.45;
+}
+</style>

--- a/src/components/common/charts/colors.ts
+++ b/src/components/common/charts/colors.ts
@@ -1,0 +1,19 @@
+const hexToRgba = (hex: string, alpha: number): string => {
+  const body = hex.replace("#", "");
+  const full = body.length === 3 ? body.split("").map((c) => c + c).join("") : body;
+  const value = parseInt(full, 16);
+  return `rgba(${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}, ${alpha})`;
+};
+
+/**
+ * Applies an alpha to a colour, whether it arrived as rgb() or as hex.
+ *
+ * Both turn up: fixed palettes tend to be written as rgb(), while colours read
+ * from the Vuetify theme come back as hex. Handling only one silently returns
+ * the colour unchanged, which turns an intended tint into a solid fill.
+ */
+export const withAlpha = (color: string, alpha: number): string => {
+  if (alpha === 1) return color;
+  if (color.startsWith("rgb(")) return color.replace("rgb(", "rgba(").replace(")", `, ${alpha})`);
+  return color.startsWith("#") ? hexToRgba(color, alpha) : color;
+};

--- a/src/components/common/charts/timelineCrosshair.ts
+++ b/src/components/common/charts/timelineCrosshair.ts
@@ -1,0 +1,171 @@
+import { Chart, type ChartEvent, type ChartType, Interaction, type InteractionItem, type InteractionModeFunction, type Plugin, Tooltip, type TooltipPositionerFunction } from "chart.js";
+import { getRelativePosition } from "chart.js/helpers";
+
+declare module "chart.js" {
+  interface InteractionModeMap {
+    steppedIndex: InteractionModeFunction;
+  }
+
+  interface TooltipPositionerMap {
+    crosshair: TooltipPositionerFunction<ChartType>;
+  }
+}
+
+/**
+ * Anchors the tooltip to the pointer rather than to the nearest element. With
+ * the steppedIndex mode the "nearest" element can be weeks to the left of the
+ * pointer, which drags the tooltip away from the crosshair it describes.
+ */
+Tooltip.positioners.crosshair = (_items, eventPosition) => eventPosition;
+
+export type TimelineCrosshairOptions = {
+  enabled?: boolean;
+  color?: string;
+  width?: number;
+  dash?: number[];
+  /** Draw a dot where the crosshair intersects each series. */
+  drawIntersections?: boolean;
+  intersectionRadius?: number;
+};
+
+const DEFAULTS: Required<TimelineCrosshairOptions> = {
+  enabled: true,
+  color: "rgba(150, 150, 150, 0.8)",
+  width: 1,
+  dash: [4, 4],
+  drawIntersections: true,
+  intersectionRadius: 4,
+};
+
+// The pointer's pixel position per chart. Kept outside the chart instance so it
+// survives re-renders without polluting the chart config.
+const pointer = new WeakMap<Chart, { x: number; y: number } | null>();
+
+/**
+ * Returns the value each series holds at the pointer's x position: for every
+ * visible dataset, the last point at or before the pointer.
+ *
+ * This is the correct readout for a stepped series, where a value persists
+ * until the next recorded point. The built-in "index" mode can't do this
+ * because it assumes every dataset shares one label array, which per-race MMR
+ * series do not.
+ */
+const steppedIndex: InteractionModeFunction = (chart, e, _options, useFinalPosition) => {
+  const position = getRelativePosition(e, chart);
+  const items: InteractionItem[] = [];
+
+  for (let datasetIndex = 0; datasetIndex < chart.data.datasets.length; datasetIndex++) {
+    if (!chart.isDatasetVisible(datasetIndex)) continue;
+
+    const points = chart.getDatasetMeta(datasetIndex).data;
+    if (!points.length) continue;
+
+    // Points are ordered by x ascending, so binary search for the last one at
+    // or before the pointer. Compare in pixel space to avoid reaching into the
+    // chart's internal parsed data.
+    let low = 0;
+    let high = points.length - 1;
+    let found = -1;
+    while (low <= high) {
+      const mid = (low + high) >> 1;
+      if (points[mid].getProps(["x"], useFinalPosition).x <= position.x) {
+        found = mid;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    if (found === -1) continue; // Pointer is before this series starts.
+    items.push({ element: points[found], datasetIndex, index: found });
+  }
+
+  return items;
+};
+
+Interaction.modes.steppedIndex = steppedIndex;
+
+/**
+ * Re-resolves the readout at the pointer's current position.
+ *
+ * Panning and zooming slide the data underneath a stationary pointer, but
+ * Chart.js only recomputes active elements in response to input events. Without
+ * this the tooltip and intersection dots keep reporting whatever sat under the
+ * cursor when the gesture began. Call it from the zoom plugin's hooks.
+ */
+export const resyncPointer = (chart: Chart): void => {
+  const position = pointer.get(chart);
+  if (!position) return;
+
+  const event = { type: "mousemove", ...position, native: null } as unknown as ChartEvent;
+  const items = steppedIndex(chart, event, { axis: "x", includeInvisible: false, intersect: false }, false);
+
+  chart.tooltip?.setActiveElements(items, position);
+  chart.setActiveElements(items);
+  chart.render();
+};
+
+export const timelineCrosshairPlugin: Plugin<"line"> = {
+  id: "timelineCrosshair",
+
+  // beforeEvent, not afterEvent, so the position is already current for
+  // anything the tooltip plugin does in its own afterEvent hook.
+  beforeEvent(chart, args) {
+    const previous = pointer.get(chart) ?? null;
+    const { event, inChartArea } = args;
+
+    let next = previous;
+    if (event.type === "mouseout" || !inChartArea) {
+      next = null;
+    } else if (event.type === "mousemove" && event.x != null && event.y != null) {
+      next = { x: event.x, y: event.y };
+    }
+
+    if (next?.x !== previous?.x || next?.y !== previous?.y) {
+      pointer.set(chart, next);
+      args.changed = true; // Repaint so the line tracks the pointer.
+    }
+
+    return true; // beforeEvent is cancelable; never cancel.
+  },
+
+  afterDatasetsDraw(chart, _args, pluginOptions) {
+    const options = { ...DEFAULTS, ...(pluginOptions as TimelineCrosshairOptions) };
+    if (!options.enabled) return;
+
+    const x = pointer.get(chart)?.x;
+    if (x == null) return;
+
+    const { ctx, chartArea } = chart;
+    if (x < chartArea.left || x > chartArea.right) return;
+
+    ctx.save();
+
+    ctx.beginPath();
+    ctx.setLineDash(options.dash);
+    ctx.lineWidth = options.width;
+    ctx.strokeStyle = options.color;
+    ctx.moveTo(x, chartArea.top);
+    ctx.lineTo(x, chartArea.bottom);
+    ctx.stroke();
+
+    if (options.drawIntersections) {
+      ctx.setLineDash([]);
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = options.color;
+      for (const item of chart.tooltip?.getActiveElements() ?? []) {
+        const dataset = chart.data.datasets[item.datasetIndex];
+        ctx.beginPath();
+        ctx.fillStyle = (dataset.borderColor as string) ?? options.color;
+        // The dot sits at the pointer, not at the point that supplied the
+        // value, because a stepped series holds that value across the gap.
+        ctx.arc(x, item.element.y, options.intersectionRadius, 0, Math.PI * 2);
+        ctx.fill();
+        // Ringed, or a dot in the series colour disappears into its own line.
+        ctx.stroke();
+      }
+    }
+
+    ctx.restore();
+  },
+};

--- a/src/components/common/charts/timelineWheelPan.ts
+++ b/src/components/common/charts/timelineWheelPan.ts
@@ -1,0 +1,53 @@
+import type { Chart, Plugin } from "chart.js";
+import { resyncPointer } from "@/components/common/charts/timelineCrosshair";
+
+/** chartjs-plugin-zoom adds these to the instance. */
+type Pannable = Chart & { pan?: (delta: { x?: number; y?: number }, scales?: unknown, transition?: string) => void };
+
+const handlers = new WeakMap<Chart, (event: WheelEvent) => void>();
+
+/**
+ * Sends horizontal wheel movement to panning instead of zooming.
+ *
+ * chartjs-plugin-zoom treats any wheel event as a zoom, so a sideways scroll —
+ * a trackpad swipe or a tilt wheel — zooms out whichever way it is pushed.
+ * Sideways obviously means "look further along", so it pans, and only vertical
+ * wheel movement is left to zoom.
+ *
+ * Registered on the capture phase so it can stop the zoom plugin's own listener
+ * from also seeing the event.
+ */
+export const timelineWheelPanPlugin: Plugin<"line"> = {
+  id: "timelineWheelPan",
+
+  afterInit(chart) {
+    const canvas = chart.canvas;
+    if (!canvas) return;
+
+    const onWheel = (event: WheelEvent): void => {
+      if (Math.abs(event.deltaX) <= Math.abs(event.deltaY)) return; // Leave vertical to the zoom plugin.
+
+      const pan = (chart as Pannable).pan;
+      if (!pan) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      // Pushing right should advance the view, which means moving the content
+      // the other way.
+      pan.call(chart, { x: -event.deltaX }, undefined, "none");
+      resyncPointer(chart);
+    };
+
+    canvas.addEventListener("wheel", onWheel, { capture: true, passive: false });
+    handlers.set(chart, onWheel);
+  },
+
+  afterDestroy(chart) {
+    const onWheel = handlers.get(chart);
+    if (onWheel && chart.canvas) {
+      chart.canvas.removeEventListener("wheel", onWheel, { capture: true });
+      handlers.delete(chart);
+    }
+  },
+};

--- a/src/components/common/charts/types.ts
+++ b/src/components/common/charts/types.ts
@@ -1,0 +1,46 @@
+export type TimelinePoint = {
+  /** Epoch milliseconds. */
+  x: number;
+  y: number;
+};
+
+export type TimelineSeries = {
+  key: string;
+  label: string;
+  color: string;
+  /** Defaults to the first configured axis. */
+  yAxisID?: string;
+  /** Must be ordered by x ascending. */
+  points: TimelinePoint[];
+  /** Overrides the client-side maximum. Use for a server-computed peak that
+   * excludes points recorded while the player was still calibrating. */
+  peak?: TimelinePoint;
+  format?: (value: number) => string;
+  /** Shown instead of the colour swatch in the legend, e.g. a race icon. */
+  icon?: string;
+};
+
+export type TimelineAxis = {
+  id: string;
+  title?: string;
+  position?: "left" | "right";
+  beginAtZero?: boolean;
+  /** Smallest span the axis will show. Without one, zooming in rescales to
+   * whatever is visible and turns a handful of points into dramatic swings. */
+  minRange?: number;
+};
+
+/** A vertical reference line, e.g. where one season gives way to the next. */
+export type TimelineMarker = {
+  /** Epoch milliseconds. */
+  x: number;
+  label?: string;
+};
+
+export type TimelineRangePreset = {
+  key: string;
+  label: string;
+  /** Months back from the newest data point; omit for the full range. */
+  months?: number;
+  default?: boolean;
+};

--- a/src/components/player/PlayerMmrRpTimelineChart.vue
+++ b/src/components/player/PlayerMmrRpTimelineChart.vue
@@ -1,24 +1,22 @@
 <template>
-  <div>
-    <line-chart
-      ref="chart"
-      :chart-data="mmrRpChartData"
-      :chart-options="chartOptions"
-    />
-  </div>
+  <!-- No range presets: a season is short enough to read whole. -->
+  <timeline-chart :series="series" :axes="axes" :extend-to="extendTo" />
 </template>
+
 <script lang="ts">
-import { computed, type PropType, defineComponent } from "vue";
+import { computed, defineComponent, onMounted, type PropType } from "vue";
 import type { PlayerMmrRpTimeline } from "@/store/player/types";
-import type { ChartData , ChartOptions, ScriptableContext } from "chart.js";
 import { parseJSON, startOfDay } from "date-fns";
 import { utcToZonedTime } from "date-fns-tz";
-import LineChart, { defaultOptions, defaultOptionsXAxis, getBackgroundColor } from "@/components/overall-statistics/LineChart.vue";
+import TimelineChart from "@/components/common/charts/TimelineChart.vue";
+import type { TimelineAxis, TimelineSeries } from "@/components/common/charts/types";
+import { usePlayerStore } from "@/store/player/store";
+import { useRankingStore } from "@/store/ranking/store";
 
 export default defineComponent({
   name: "PlayerMmrRpTimelineChart",
   components: {
-    LineChart,
+    TimelineChart,
   },
   props: {
     mmrRpTimeline: {
@@ -27,75 +25,78 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const mmrValues = computed<number[]>(() => props.mmrRpTimeline.mmrRpAtDates.map((m) => m.mmr));
-    const rpValues = computed<number[]>(() => props.mmrRpTimeline.mmrRpAtDates.map((m) => m.rp));
+    const playerStore = usePlayerStore();
+    const rankingStore = useRankingStore();
 
     // Workaround: prevent dates from moving into the next day due to timezone conversion.
-    const dates = computed<Date[]>(() => props.mmrRpTimeline.mmrRpAtDates.map((m) => startOfDay(utcToZonedTime(parseJSON(m.date), "UTC"))));
+    const toDay = (date: string): number => startOfDay(utcToZonedTime(parseJSON(date), "UTC")).getTime();
 
-    const chartOptions = computed<ChartOptions>(() => {
-      const options: ChartOptions = {
-        scales: {
-          x: defaultOptionsXAxis,
-          y: {
-            beginAtZero: false,
-            title: {
-              display: true,
-              text: "MMR",
-            },
-          },
-          y1: {
-            position: "right",
-            beginAtZero: false,
-            title: {
-              display: true,
-              text: "Level",
-            },
-          },
-        },
-      };
-      return { ...defaultOptions(), ...options };
+    onMounted(async (): Promise<void> => {
+      await rankingStore.retrieveSeasons(); // No-op once loaded.
     });
 
-    const mmrRpChartData = computed<ChartData<"line">>(() => {
-      return {
-        labels: dates.value,
-        datasets: [
-          {
-            yAxisID: "y",
-            label: "MMR",
-            data: mmrValues.value,
-            borderColor: "rgb(54, 162, 235)",
-            fill: true,
-            backgroundColor: (context: ScriptableContext<"line">) => getBackgroundColor(context, "rgb(54, 162, 235)"),
-            borderWidth: 1.0,
-            pointStyle: "circle",
-            pointRadius: 1.2,
-            pointBorderWidth: 1.8,
-            tension: 0.4, // Smooth line.
-            cubicInterpolationMode: "monotone",
-          },
-          {
-            yAxisID: "y1",
-            label: "Level",
-            data: rpValues.value,
-            borderColor: "rgb(150, 80, 100)",
-            fill: true,
-            backgroundColor: (context: ScriptableContext<"line">) => getBackgroundColor(context, "rgb(150, 80, 100)"),
-            borderWidth: 1.0,
-            pointStyle: "circle",
-            pointRadius: 1.2,
-            pointBorderWidth: 1.8,
-            tension: 0.4, // Smooth line.
-            cubicInterpolationMode: "monotone",
-          },
-        ],
-      };
+    // An ongoing season runs to today, so the time since the last game is
+    // visible instead of the chart stopping at the newest match. Past seasons
+    // end where their data ends.
+    const extendTo = computed<number | null>(() => {
+      const currentSeason = rankingStore.seasons[0]?.id;
+      if (currentSeason == null || playerStore.selectedSeason?.id !== currentSeason) return null;
+      return Date.now();
+    });
+
+    // Ranking points were rebuilt on a new scale partway through season 13
+    // (2022-11-29): before that a "Level" was in the thousands, after it the
+    // ceiling is somewhere in the 60s. Season 13 therefore holds both, and one
+    // legacy value flattens the axis for every real one. Where a series mixes
+    // the two, keep only the current scale; a series that is entirely legacy
+    // (season 12 and earlier) is left alone so those charts still plot.
+    const LEGACY_RP_THRESHOLD = 100;
+
+    const currentScaleRp = (entries: { rp: number | null }[]): ((rp: number) => boolean) => {
+      const hasCurrentScale = entries.some((e) => e.rp != null && e.rp < LEGACY_RP_THRESHOLD);
+      return (rp: number) => !hasCurrentScale || rp < LEGACY_RP_THRESHOLD;
+    };
+
+    const series = computed<TimelineSeries[]>(() => {
+      const entries = props.mmrRpTimeline.mmrRpAtDates ?? [];
+      const keepRp = currentScaleRp(entries);
+
+      return [
+        {
+          key: "mmr",
+          label: "MMR",
+          color: "rgb(54, 162, 235)",
+          yAxisID: "y",
+          points: entries.map((e) => ({ x: toDay(e.date), y: e.mmr })),
+          format: (value: number) => String(Math.round(value)),
+        },
+        {
+          key: "rp",
+          label: "Level",
+          color: "rgb(150, 80, 100)",
+          yAxisID: "y1",
+          points: entries.filter((e) => e.rp != null && keepRp(e.rp)).map((e) => ({ x: toDay(e.date), y: e.rp })),
+          format: (value: number) => value.toFixed(2),
+        },
+      ].filter((s) => s.points.length > 0);
+    });
+
+    // Only declare axes that a series actually uses, so dropping the Level
+    // series doesn't leave an orphaned right-hand axis.
+    const axes = computed<TimelineAxis[]>(() => {
+      const used = new Set(series.value.map((s) => s.yAxisID));
+      return ([
+        { id: "y", title: "MMR", minRange: 200 },
+        // Only meaningful against the current Level scale; a legacy series sits
+        // in the thousands, where a floor of 10 is a no-op anyway.
+        { id: "y1", title: "Level", position: "right" as const, minRange: 10 },
+      ]).filter((axis) => used.has(axis.id));
     });
 
     return {
-      mmrRpChartData,
-      chartOptions,
+      series,
+      axes,
+      extendTo,
     };
   },
 });

--- a/src/lib/chart-timestack/defgens.ts
+++ b/src/lib/chart-timestack/defgens.ts
@@ -1,0 +1,115 @@
+import type { TickGenerator} from './ticks';
+import { DaysTickGenerator, MonoTickGenerator, YearsTickGenerator } from './ticks';
+
+
+export const HMS: Intl.DateTimeFormatOptions = {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+};
+export const HM: Intl.DateTimeFormatOptions = {
+  hour: 'numeric',
+  minute: 'numeric',
+};
+export const MDAY: Intl.DateTimeFormatOptions = {
+  day: 'numeric',
+};
+export const MON: Intl.DateTimeFormatOptions = {
+  month: 'short',
+};
+export const YEAR: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+};
+
+export const YMD: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+};
+export const YM: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+};
+export const MD: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+};
+
+export const DEF_TICK_GENERATORS: TickGenerator[] = [
+  // seconds
+  new MonoTickGenerator(
+    { second: 1, align: 'second', maj_unit: 'minute', fmt: HMS, maj_fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { second: 5, align: 'minute', maj_unit: 'minute', fmt: HMS, maj_fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { second: 10, align: 'minute', maj_unit: 'minute', fmt: HMS, maj_fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { second: 30, align: 'minute', maj_unit: 'minute', fmt: HMS, maj_fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  // minutes
+  new MonoTickGenerator(
+    { minute: 1, align: 'minute', maj_unit: 'hour', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { minute: 5, align: 'hour', maj_unit: 'hour', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { minute: 10, align: 'hour', maj_unit: 'hour', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { minute: 15, align: 'hour', maj_unit: 'hour', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { minute: 30, align: 'hour', maj_unit: 'hour', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  // hours
+  new MonoTickGenerator(
+    { hour: 1, align: 'hour', maj_unit: 'day', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { hour: 3, align: 'day', maj_unit: 'day', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { hour: 6, align: 'day', maj_unit: 'day', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  new MonoTickGenerator(
+    { hour: 12, align: 'day', maj_unit: 'day', fmt: HM },
+    { unit: 'day', short_fmt: MD, long_fmt: YMD }
+  ),
+  // days
+  new MonoTickGenerator(
+    { day: 1, align: 'day', maj_unit: 'month', fmt: MDAY },
+    { unit: 'month', short_fmt: MON, long_fmt: YM }
+  ),
+  new DaysTickGenerator({ days: [1, 5, 10, 15, 20, 25], step: 5, fmt: MDAY }, { short_fmt: MON, long_fmt: YM }),
+  new DaysTickGenerator({ days: [1, 10, 20], step: 10, fmt: MDAY }, { short_fmt: MON, long_fmt: YM }),
+  new DaysTickGenerator({ days: [1, 15], step: 15, fmt: MDAY }, { short_fmt: MON, long_fmt: YM }),
+  // months. treats month duration as 30 days in default 'casual' mode
+  new MonoTickGenerator({ month: 1, align: 'month', maj_unit: 'year', fmt: MON }, { unit: 'year', short_fmt: YEAR }),
+  new MonoTickGenerator({ month: 3, align: 'year', maj_unit: 'year', fmt: MON }, { unit: 'year', short_fmt: YEAR }),
+  new MonoTickGenerator({ month: 6, align: 'year', maj_unit: 'year', fmt: MON }, { unit: 'year', short_fmt: YEAR }),
+  // years. year duration is 365 days by default
+  new YearsTickGenerator(1, { fmt: YEAR }),
+  new YearsTickGenerator(5, { fmt: YEAR }),
+  new YearsTickGenerator(10, { fmt: YEAR }),
+  new YearsTickGenerator(25, { fmt: YEAR }),
+  new YearsTickGenerator(50, { fmt: YEAR }),
+  new YearsTickGenerator(100, { fmt: YEAR }),
+  // fallback )
+  new YearsTickGenerator(1000, { fmt: YEAR }),
+];

--- a/src/lib/chart-timestack/index.ts
+++ b/src/lib/chart-timestack/index.ts
@@ -1,0 +1,26 @@
+// Taken from https://github.com/jkmnt/chartjs-scale-timestack
+// License: MIT
+// Modified to replace 'luxon' library usage with the native
+// Date object instead to avoid an additional dependency.
+// Modified to register the scale on CartesianScaleTypeRegistry rather than
+// ScaleTypeRegistry, so 'timestack' type-checks as an x axis on a line chart.
+
+import type { TimestackScaleOptions } from './scale';
+
+import { Chart } from 'chart.js';
+import { TimestackScale } from './scale';
+
+declare module 'chart.js' {
+  export interface CartesianScaleTypeRegistry {
+    timestack: {
+      options: TimestackScaleOptions;
+    };
+  }
+}
+
+Chart.register(TimestackScale);
+
+export type { TimestackScaleOptions } from './scale';
+export { TimestackScale, DEF_TOOLTIP_FORMAT } from './scale';
+export { TickGenerator, DaysTickGenerator, YearsTickGenerator } from './ticks';
+export { DEF_TICK_GENERATORS, HM, HMS, MD, MDAY, MON, YEAR, YM, YMD } from './defgens';

--- a/src/lib/chart-timestack/measure.ts
+++ b/src/lib/chart-timestack/measure.ts
@@ -1,0 +1,147 @@
+export interface DateObjectUnits {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+}
+export interface DateTimeJSOptions {
+  locale?: string;
+  timeZone?: string; // maps to Intl.DateTimeFormatOptions.timeZone
+}
+
+const _widest_dates_cache = new Map<string, Record<string, DateObjectUnits>>();
+const _widest_labels_cache = new Map<string, number>();
+
+function formatDate(dt: Date, format: Intl.DateTimeFormatOptions, opts: DateTimeJSOptions) {
+  const fmt = new Intl.DateTimeFormat(opts.locale, { timeZone: opts.timeZone, ...format });
+  return fmt.format(dt);
+}
+
+function makeDate(units: DateObjectUnits): Date {
+  const year = units.year ?? 2024;
+  const month = (units.month ?? 12) - 1; // JS Date month is 0-based
+  const day = units.day ?? 22;
+  const hour = units.hour ?? 23;
+  const minute = units.minute ?? 59;
+  const second = units.second ?? 59;
+  return new Date(year, month, day, hour, minute, second);
+}
+
+function _pick_widest_sample(
+  ctx: CanvasRenderingContext2D,
+  samples: Generator<Date>,
+  format: Intl.DateTimeFormatOptions,
+  opts: DateTimeJSOptions
+) {
+  let longest: [Date, number, string?] = [{} as any, 0];
+
+  for (const dt of samples) {
+    const text = formatDate(dt, format, opts);
+    const width = ctx.measureText(text).width;
+
+    if (width > longest[1]) longest = [dt, width, text];
+  }
+
+  return longest[0];
+}
+
+// The trick is: widest locals dates depend on months and weeks names only.
+// For the time part let's choose the daytime with two digits at each unit. These digits are better contain no narrow 1's.
+// Then the widest months (short and long) are found looping thru all 12 months.
+// The dates with widest weekdays ((short, long and narrow) are found in 20ths of these months. Then these dates are guaranteed to be the widest
+// even if month is rendered as number.
+export function find_widest_local_date(
+  key: string,
+  format: Intl.DateTimeFormatOptions,
+  ctx: CanvasRenderingContext2D,
+  opts: DateTimeJSOptions
+): DateObjectUnits {
+  const id = `${format.month}/${format.weekday}`;
+
+  const cached = _widest_dates_cache.get(key);
+  if (cached) return cached[id];
+
+  const widest_numeric_date: DateObjectUnits = { year: 2024, month: 12, day: 22, hour: 23, minute: 59, second: 59 };
+  const num = makeDate(widest_numeric_date);
+
+  function* months_candidates(base: Date) {
+    for (let i = 1; i <= 12; i++) yield new Date(base.getFullYear(), i - 1, base.getDate(), base.getHours(), base.getMinutes(), base.getSeconds());
+  }
+
+  const sm = _pick_widest_sample(ctx, months_candidates(num), { month: 'short' }, opts);
+  const lm = _pick_widest_sample(ctx, months_candidates(num), { month: 'long' }, opts);
+
+  function* weekdays_candidates(base: Date) {
+    for (let i = 22; i < 29; i++) yield new Date(base.getFullYear(), base.getMonth(), i, base.getHours(), base.getMinutes(), base.getSeconds());
+  }
+
+  const sm_sw = _pick_widest_sample(ctx, weekdays_candidates(sm), { weekday: 'short' }, opts);
+  const sm_lw = _pick_widest_sample(ctx, weekdays_candidates(sm), { weekday: 'long' }, opts);
+  const sm_nw = _pick_widest_sample(ctx, weekdays_candidates(sm), { weekday: 'narrow' }, opts);
+
+  const lm_sw = _pick_widest_sample(ctx, weekdays_candidates(lm), { weekday: 'short' }, opts);
+  const lm_lw = _pick_widest_sample(ctx, weekdays_candidates(lm), { weekday: 'long' }, opts);
+  const lm_nw = _pick_widest_sample(ctx, weekdays_candidates(lm), { weekday: 'narrow' }, opts);
+
+  // ok now form the month/weekday permutations manually.
+  // it's simpler than looping
+  const perms: Record<string, Date> = {
+    'undefined/undefined': num,
+    'undefined/short': sm_sw,
+    'undefined/long': sm_lw,
+    'undefined/narrow': sm_nw,
+
+    'numeric/undefined': num,
+    'numeric/short': sm_sw,
+    'numeric/long': sm_lw,
+    'numeric/narrow': sm_nw,
+
+    '2-digit/undefined': num,
+    '2-digit/short': sm_sw,
+    '2-digit/long': sm_lw,
+    '2-digit/narrow': sm_nw,
+
+    'short/undefined': sm,
+    'short/short': sm_sw,
+    'short/long': sm_lw,
+    'short/narrow': sm_nw,
+
+    'long/undefined': lm,
+    'long/short': lm_sw,
+    'long/long': lm_lw,
+    'long/narrow': lm_nw,
+  };
+
+  const result: Record<string, DateObjectUnits> = Object.fromEntries(
+    Object.entries(perms).map(([k, v]) => [k, { year: v.getFullYear(), month: v.getMonth() + 1, day: v.getDate(), hour: v.getHours(), minute: v.getMinutes(), second: v.getSeconds() }])
+  );
+
+  _widest_dates_cache.set(key, result);
+
+  return result[id];
+}
+
+export function measure_max_label_width(
+  format: Intl.DateTimeFormatOptions,
+  ctx: CanvasRenderingContext2D,
+  opts: DateTimeJSOptions
+) {
+  const format_key = JSON.stringify(format);
+
+  const dt_key = `${opts.locale || 'default'}/${ctx.font}`;
+  const label_key = `${dt_key}/${format_key}`;
+
+  const cached = _widest_labels_cache.get(label_key);
+  if (cached) return cached;
+
+  const widest_date = find_widest_local_date(dt_key, format, ctx, opts);
+
+  const dt = makeDate(widest_date);
+  const label = formatDate(dt, format, opts);
+  const res = ctx.measureText(label).width;
+
+  _widest_labels_cache.set(label_key, res);
+  return res;
+}

--- a/src/lib/chart-timestack/scale.ts
+++ b/src/lib/chart-timestack/scale.ts
@@ -1,0 +1,291 @@
+import type { CartesianScaleOptions, Tick, Chart } from 'chart.js';
+// @ts-ignore: DeepPartial is not exported from chart.js public API, but needed for custom scale
+import type { DeepPartial } from 'chart.js/dist/types/utils';
+import type { TickGenerator } from './ticks';
+
+import { Scale } from 'chart.js';
+
+import { DEF_TICK_GENERATORS } from './defgens';
+import type { DateTimeJSOptions, DateObjectUnits } from './measure';
+
+export interface TimestackScaleOptions extends CartesianScaleOptions {
+  timestack: {
+    /**
+     DateTime creation options (zone, locale, etc)
+     */
+    datetime: DateTimeJSOptions;
+
+    /**
+     Desired labels density [0..1]. Defined as total labels width / scale width
+     @default 0.5
+     */
+    density: number;
+
+    /**
+     Maximum labels density
+     @default 0.75
+     */
+    max_density: number;
+
+    /**
+     Tooltip format options
+     */
+    tooltip_format: Intl.DateTimeFormatOptions;
+
+    /**
+     Add left bottom tick with ellipsis if there are no bottom ticks in first _[thres * axis_width]_ part of scale. Set `false` to disable the feature
+     @default 0.33 (first 1/3 of scale width)
+     */
+    left_floating_tick_thres: number | false;
+
+    /**
+     Add right bottom tick with ellipsis if there are no bottom ticks in last _[thres * axis_width]_ part of scale. Set `false` to disable the feature
+     @default false
+     */
+    right_floating_tick_thres: number | false;
+    /**
+     Factory function returning array of tick generators to replace the default ones. Would be called just once at chart creation
+     */
+    make_tick_generators: () => TickGenerator[];
+
+    /**
+     Formatting options _(Intl.DateTimeFormatOptions)_ to customize the default tick generators format style. i.e. `{hour12: true, month: 'long', minute: '2-digit'}` etc
+     @default undefined
+     */
+    format_style: Intl.DateTimeFormatOptions;
+  };
+}
+
+export const DEF_TOOLTIP_FORMAT: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+};
+
+export class TimestackScale extends Scale<TimestackScaleOptions> {
+  static id = 'timestack';
+  static defaults: DeepPartial<TimestackScaleOptions> = {
+    timestack: {
+      tooltip_format: DEF_TOOLTIP_FORMAT,
+      density: 0.75,
+      max_density: 0.9,
+      left_floating_tick_thres: 0.01,
+      right_floating_tick_thres: false,
+    },
+    ticks: {
+      // @ts-ignore : this one is needed to prevent the autoSkip purging our ticks.
+      // otherwise autoSkip=false is ignored by the core Scale class
+      source: '',
+
+      maxRotation: 0,
+      autoSkip: false,
+    },
+  };
+
+  _gens: TickGenerator[];
+  _dt_opts!: DateTimeJSOptions;
+
+  constructor(cfg: { id: string; type: string; ctx: CanvasRenderingContext2D; chart: Chart }) {
+    super(cfg);
+
+    // Init the generators just once taking it from raw config object to workaround the chart.js proxies magic.
+    // Chart.js assumes the options are promitive objects and doing some wrong proxy transforms upon our array of classes.
+    const opts: TimestackScaleOptions | undefined = cfg.chart?.config.options?.scales?.[cfg.id] as any;
+    const gens = opts?.timestack?.make_tick_generators ? opts?.timestack?.make_tick_generators() : DEF_TICK_GENERATORS;
+    this._gens = gens;
+
+    if (opts?.timestack.format_style) {
+      for (const gen of gens) {
+        gen.patch_formats(opts?.timestack.format_style);
+      }
+    }
+  }
+
+  init(options: TimestackScaleOptions) {
+    // the proxies resolving likely has a perfomance hit for creating many datetime object, so cache it here
+    this._dt_opts = options.timestack.datetime ?? {};
+
+    super.init(options);
+  }
+
+  determineDataLimits() {
+    let { min, max } = this.getMinMax(false);
+
+    // fallback, shouldn't happen
+    const now = this._dt_now();
+    const startOfDay = new Date(now.getTime());
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date(now.getTime());
+    endOfDay.setHours(23, 59, 59, 999);
+
+    min = isFinite(min) ? min : startOfDay.getTime();
+    max = isFinite(max) ? max : endOfDay.getTime() + 1;
+    // copy from the TimeScale. won't hurt to have range well-defined
+    this.min = Math.min(min, max - 1);
+    this.max = Math.max(min + 1, max);
+  }
+
+  _dt_from_ts(ts: number) {
+    return new Date(ts);
+  }
+
+  _dt_from_object(obj: DateObjectUnits) {
+    const year = obj.year ?? 2024;
+    const month = (obj.month ?? 1) - 1;
+    const day = obj.day ?? 1;
+    const hour = obj.hour ?? 0;
+    const minute = obj.minute ?? 0;
+    const second = obj.second ?? 0;
+    return new Date(year, month, day, hour, minute, second);
+  }
+
+  _dt_now() {
+    return new Date();
+  }
+
+  // Choosing the generator with density < max density and closest to the wanted one.
+  // Then number of ticks is checked against the maxTicksLimit too
+  _choose_gen(range: number) {
+    const gens = this._gens;
+
+    const density_limit = this.options.timestack.max_density;
+    const want_density = this.options.timestack.density;
+    const nticks_limit = this.options.ticks.maxTicksLimit ?? +Infinity;
+
+    const candidates: [TickGenerator, number][] = [];
+
+    for (const gen of gens) {
+      const { top, bottom } = gen.estimate(range, this.ctx, this._dt_opts);
+
+      const max_nticks = Math.max(top.nticks, bottom?.nticks ?? 0);
+
+      const top_density = (top.nticks * top.label_width) / this.width;
+      const bottom_density = bottom ? (bottom.nticks * bottom.label_width) / this.width : 0;
+      const max_density = Math.max(top_density, bottom_density);
+
+      if (max_density <= density_limit && max_nticks <= nticks_limit) {
+        candidates.push([gen, Math.abs(max_density - want_density)]);
+      }
+    }
+
+    if (!candidates.length) return undefined;
+
+    const best = candidates.reduce((prev, cur) => (cur[1] < prev[1] ? cur : prev));
+    return best[0];
+  }
+
+  _need_floating_left_tick(ticks_with_bottoms: Tick[]) {
+    const thres = this.options.timestack.left_floating_tick_thres;
+    if (thres === false) return false;
+    if (!ticks_with_bottoms.length) return true;
+    const neigh_rel = (ticks_with_bottoms[0].value - this.min) / (this.max - this.min);
+    return neigh_rel > thres;
+  }
+
+  _need_floating_right_tick(ticks_with_bottoms: Tick[]) {
+    const thres = this.options.timestack.right_floating_tick_thres;
+    if (thres === false) return false;
+    if (!ticks_with_bottoms.length) return true;
+    const neigh_rel = (this.max - ticks_with_bottoms[ticks_with_bottoms.length - 1].value) / (this.max - this.min);
+    return neigh_rel > thres;
+  }
+
+  _build_ticks() {
+    const { min, max } = this;
+
+    const gen = this._choose_gen(max - min);
+
+    if (!gen) {
+      console.warn('Failed to choose the tick generator');
+      return [];
+    }
+
+    const min_dt = this._dt_from_ts(min);
+    const max_dt = this._dt_from_ts(max);
+    const now_dt = this._dt_now();
+
+    const yearFmt = new Intl.DateTimeFormat(this._dt_opts?.locale, { timeZone: this._dt_opts?.timeZone, year: 'numeric' });
+    const prefer_long_bottom = (dt: Date) => yearFmt.format(dt) !== yearFmt.format(now_dt);
+
+    const ticks = gen.create(min_dt, max_dt, prefer_long_bottom, this._dt_opts);
+
+    if (!gen.bottom) return ticks;
+
+    const ticks_with_bottoms = ticks.filter((t) => Array.isArray(t.label) && t.label.length > 1);
+
+    if (this._need_floating_left_tick(ticks_with_bottoms)) {
+      let tick;
+      tick = gen.create_floating(min_dt, 'left', prefer_long_bottom, this._dt_opts);
+
+      if (ticks_with_bottoms.length) {
+        // need to check the fit with neighbour
+        const neigh = ticks_with_bottoms[0];
+        const width = this.ctx.measureText(tick.label[1]).width;
+        // can't use the getPixelForValue here, the margins are not configured yet.
+        // estimating the range manually with x2 safe factor
+        const space = ((neigh.value - this.min) * this.width) / (this.max - this.min);
+        if (width * 2 > space) tick = undefined;
+      }
+
+      if (tick) ticks.unshift(tick);
+    }
+
+    if (this._need_floating_right_tick(ticks_with_bottoms)) {
+      let tick;
+      tick = gen.create_floating(max_dt, 'right', prefer_long_bottom, this._dt_opts);
+
+      if (ticks_with_bottoms.length) {
+        const neigh = ticks_with_bottoms[ticks_with_bottoms.length - 1];
+        const width = this.ctx.measureText(tick.label[1]).width;
+        const space = ((this.max - neigh.value) * this.width) / (this.max - this.min);
+        if (width * 2 > space) tick = undefined;
+      }
+
+      if (tick) ticks.push(tick);
+    }
+
+    return ticks;
+  }
+
+  buildTicks() {
+    // The estimation process involves rendering the sample labels and measuring pixel widths,
+    // so the actual canvas font is activated to make the measurements more accurate.
+    // Because _resolveTickFontOptions is private method of Scale, it's wrapped in try/catch.
+    let font: string | undefined;
+    try {
+      font = (this as any)._resolveTickFontOptions(0).string;
+    } catch {
+      console.warn('failed to resolve the font');
+    }
+
+    this.ctx.save();
+    if (font) this.ctx.font = font;
+
+    const ticks = this._build_ticks();
+
+    this.ctx.restore();
+    return ticks;
+  }
+
+  getLabelForValue(value: number) {
+    const dt = this._dt_from_ts(value);
+    const fmt = new Intl.DateTimeFormat(this._dt_opts?.locale, { timeZone: this._dt_opts?.timeZone, ...this.options.timestack.tooltip_format });
+    return fmt.format(dt);
+  }
+
+  // noop. ticks are already generated in single pass
+  generateTickLabels(ticks: Tick[]) {}
+
+  // took these from timescale w/o offsets
+  getPixelForValue(value: number | null) {
+    const pos = value === null ? NaN : (value - this.min) / (this.max - this.min);
+    return this.getPixelForDecimal(pos);
+  }
+  getValueForPixel(pixel: number) {
+    const pos = this.getDecimalForPixel(pixel);
+    return this.min + pos * (this.max - this.min);
+  }
+}

--- a/src/lib/chart-timestack/ticks.ts
+++ b/src/lib/chart-timestack/ticks.ts
@@ -1,0 +1,269 @@
+import type { Tick } from 'chart.js';
+
+import type { DateTimeJSOptions } from './measure';
+import { measure_max_label_width } from './measure';
+
+export interface TopTickSpec {
+  fmt: Intl.DateTimeFormatOptions;
+  maj_fmt?: Intl.DateTimeFormatOptions;
+}
+
+export interface BottomTickSpec {
+  short_fmt: Intl.DateTimeFormatOptions;
+  long_fmt?: Intl.DateTimeFormatOptions;
+}
+
+type DateTimeUnit = 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year';
+export type DurationLikeObject = Partial<{ year: number; month: number; day: number; hour: number; minute: number; second: number }>;
+
+interface SeqTick {
+  dt: Date;
+  is_major: boolean;
+  with_bottom: boolean;
+}
+
+/**
+ Base tick generator class.
+ Concrete tick generators must implement the *seq method
+ */
+function formatDate(dt: Date, fmt: Intl.DateTimeFormatOptions, opts: DateTimeJSOptions) {
+  return new Intl.DateTimeFormat(opts.locale, { timeZone: opts.timeZone, ...fmt }).format(dt);
+}
+
+function startOfUnit(date: Date, unit: DateTimeUnit): Date {
+  const d = new Date(date.getTime());
+  switch (unit) {
+    case 'second':
+      d.setMilliseconds(0);
+      return d;
+    case 'minute':
+      d.setSeconds(0, 0);
+      return d;
+    case 'hour':
+      d.setMinutes(0, 0, 0);
+      return d;
+    case 'day':
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case 'month':
+      d.setDate(1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case 'year':
+      d.setMonth(0, 1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+  }
+}
+
+function isStartOf(date: Date, unit: DateTimeUnit): boolean {
+  return startOfUnit(date, unit).getTime() === date.getTime();
+}
+
+function addDuration(date: Date, step: DurationLikeObject): Date {
+  const d = new Date(date.getTime());
+  if (step.year) d.setFullYear(d.getFullYear() + step.year);
+  if (step.month) d.setMonth(d.getMonth() + step.month);
+  if (step.day) d.setDate(d.getDate() + step.day);
+  if (step.hour) d.setHours(d.getHours() + step.hour);
+  if (step.minute) d.setMinutes(d.getMinutes() + step.minute);
+  if (step.second) d.setSeconds(d.getSeconds() + step.second);
+  return d;
+}
+
+function durationMs(step: DurationLikeObject): number {
+  const sec = (step.second ?? 0) + (step.minute ?? 0) * 60 + (step.hour ?? 0) * 3600 + (step.day ?? 0) * 86400 + (step.month ?? 0) * 30 * 86400 + (step.year ?? 0) * 365 * 86400;
+  return sec * 1000;
+}
+
+export class TickGenerator {
+  top: TopTickSpec & { size: number };
+  bottom?: BottomTickSpec & { size: number };
+
+  /** Generator yielding (possibly infinite) sequence of _SeqTick-s. It's ok to return the ticks
+   * before the 'from'
+   */
+  *seq(from: Date): Generator<SeqTick> {}
+
+  constructor(top: TopTickSpec & { size: number }, bottom?: BottomTickSpec & { size: number }) {
+    this.top = top;
+    this.bottom = bottom;
+  }
+
+  estimate(range: number, ctx: CanvasRenderingContext2D, opts: DateTimeJSOptions, may_be_long: boolean = true) {
+    const top = this.top;
+    const bottom = this.bottom;
+
+    const normal = measure_max_label_width(top.fmt, ctx, opts);
+    const major = top.maj_fmt ? measure_max_label_width(top.maj_fmt, ctx, opts) : 0;
+    const top_est = { nticks: range / top.size, label_width: Math.max(normal, major) };
+
+    let bottom_est;
+
+    if (bottom) {
+      const short = measure_max_label_width(bottom.short_fmt, ctx, opts);
+      const long = may_be_long && bottom.long_fmt ? measure_max_label_width(bottom.long_fmt, ctx, opts) : 0;
+
+      bottom_est = { nticks: range / bottom.size, label_width: Math.max(short, long) };
+    }
+
+    return { top: top_est, bottom: bottom_est };
+  }
+
+  format(dt: Date, is_major: boolean, with_bottom: boolean, prefer_long_bottom: boolean, opts: DateTimeJSOptions) {
+    const top = formatDate(dt, is_major && this.top.maj_fmt ? this.top.maj_fmt : this.top.fmt, opts);
+
+    if (!with_bottom || !this.bottom) return top;
+
+    const bottom = formatDate(
+      dt,
+      prefer_long_bottom && this.bottom.long_fmt ? this.bottom.long_fmt : this.bottom.short_fmt,
+      opts
+    );
+    return [top, bottom];
+  }
+
+  create(from: Date, to: Date, prefer_long_bottom: (dt: Date) => boolean, opts: DateTimeJSOptions): Tick[] {
+    const ticks: Tick[] = [];
+
+    for (const { dt, is_major, with_bottom } of this.seq(from)) {
+      if (dt < from) continue;
+      if (dt >= to) break;
+      ticks.push({
+        value: dt.getTime(),
+        major: is_major,
+        label: this.format(dt, is_major, with_bottom, prefer_long_bottom(dt), opts),
+      });
+    }
+
+    return ticks;
+  }
+
+  create_floating(dt: Date, pos: 'left' | 'right', prefer_long_bottom: (dt: Date) => boolean, opts: DateTimeJSOptions) {
+    const bottom = this.bottom;
+    const fmt = bottom ? (prefer_long_bottom(dt) && bottom.long_fmt ? bottom.long_fmt : bottom.short_fmt) : undefined;
+    const text = fmt ? formatDate(dt, fmt, opts) : '';
+
+    return { value: dt.getTime(), label: ['', text] };
+  }
+
+  // Convenience method to apply some global changes to formats.
+  // Intended to override hour12, numeric => 2-digit etc
+  patch_formats(patch: Intl.DateTimeFormatOptions) {
+    function apply(dst: any) {
+      for (const e of Object.entries(patch)) {
+        const k = e[0];
+        const v = e[1];
+        if (k === 'hour12' && dst.hour) dst.hour12 = v;
+        if (dst[k]) dst[k] = e[1];
+      }
+    }
+
+    apply(this.top.fmt);
+    this.top.maj_fmt && apply(this.top.maj_fmt);
+    this.bottom?.short_fmt && apply(this.bottom.short_fmt);
+    this.bottom?.long_fmt && apply(this.bottom.long_fmt);
+  }
+}
+
+export class MonoTickGenerator extends TickGenerator {
+  step: DurationLikeObject;
+  align: DateTimeUnit;
+  bottom_unit?: DateTimeUnit;
+  maj_unit?: DateTimeUnit;
+
+  constructor(
+    top: TopTickSpec & DurationLikeObject & { align: DateTimeUnit; maj_unit?: DateTimeUnit },
+    bottom: (BottomTickSpec & { unit: DateTimeUnit }) | undefined
+  ) {
+    const { fmt, maj_fmt, align, maj_unit, ...top_duration } = top;
+    super(
+      {
+        fmt,
+        maj_fmt,
+        size: durationMs(top_duration),
+      },
+      bottom && {
+        ...bottom,
+        size: durationMs({ [bottom.unit]: 1 } as any),
+      }
+    );
+
+    this.step = top_duration;
+    this.bottom_unit = bottom?.unit;
+    this.align = align;
+    this.maj_unit = maj_unit;
+  }
+
+  *seq(from: Date) {
+    let dt = startOfUnit(from, this.align);
+    while (true) {
+      const with_bottom = this.bottom_unit ? isStartOf(dt, this.bottom_unit) : false;
+      const is_major = this.maj_unit ? isStartOf(dt, this.maj_unit) : false;
+      yield { dt, is_major, with_bottom };
+      dt = addDuration(dt, this.step);
+    }
+  }
+}
+
+export class DaysTickGenerator extends TickGenerator {
+  days: number[];
+  maj_days: number[];
+  bottom_days: number[];
+
+  constructor(
+    top: TopTickSpec & { days: number[]; step: number; maj_days?: number[] },
+    bottom?: BottomTickSpec & { days?: number[] }
+  ) {
+    super(
+      {
+        ...top,
+        size: top.step * 86400 * 1000,
+      },
+      bottom && {
+        ...bottom,
+        size: 30 * 86400 * 1000,
+      }
+    );
+
+    this.days = top.days;
+    this.maj_days = top.maj_days ?? [1];
+    this.bottom_days = bottom ? bottom.days ?? [1] : [];
+  }
+
+  *seq(from: Date) {
+    let mdt = startOfUnit(from, 'month');
+    while (true) {
+      for (const day of this.days) {
+        const dt = new Date(mdt.getFullYear(), mdt.getMonth(), day, mdt.getHours(), mdt.getMinutes(), mdt.getSeconds());
+        const is_major = this.maj_days.includes(day);
+        const with_bottom = this.bottom_days.includes(day);
+        yield { dt, is_major, with_bottom };
+      }
+      mdt = addDuration(mdt, { month: 1 });
+    }
+  }
+}
+
+export class YearsTickGenerator extends TickGenerator {
+  by_years: number;
+
+  constructor(by_years: number, top: TopTickSpec) {
+    super({
+      ...top,
+      size: by_years * 365 * 86400 * 1000,
+    });
+    this.by_years = by_years;
+  }
+
+  *seq(from: Date) {
+    const start = (Math.floor(from.getFullYear() / this.by_years)) * this.by_years;
+    let dt = startOfUnit(from, 'year');
+    dt.setFullYear(start);
+
+    while (true) {
+      yield { dt, is_major: false, with_bottom: false };
+      dt = addDuration(dt, { year: this.by_years });
+    }
+  }
+}


### PR DESCRIPTION
Reworks the season MMR/RP chart on the player profile into a reusable `TimelineChart`, with the readability fixes below. Self-contained — it improves the existing Stats tab on its own and does not depend on anything else in flight.

### Stepped lines

MMR holds its value between games, so the line is now stepped rather than interpolated. `stepped: "before"`, not `"after"` — `"after"` carries the *next* point's value across the interval, which desynchronises the readout from the line under the cursor.

### Crosshair hover

Hovering anywhere shows every series' value at that x with a vertical line, instead of only the nearest point. Three pieces:

- a `steppedIndex` interaction mode that binary-searches pixel x for the last point at or before the pointer
- a `crosshair` tooltip positioner, so the tooltip follows the cursor rather than anchoring to a data point that may be weeks away
- a plugin recording the pointer in `beforeEvent` — `afterEvent` is too late, the tooltip has already built its contents by then

These are registered per-chart via the `:plugins` prop, not globally, so no other chart on the site grows a crosshair.

### Axis behaviour

The y-axis no longer rescales as you zoom. Bounds are computed once from all visible series, padded and snapped, then pinned — a range that jumps as you pan feels like the data is moving. Each axis takes a `minRange` so a flat stretch doesn't magnify noise into drama.

Horizontal wheel now pans instead of zooming out. A trackpad's horizontal scroll reads as a zoom gesture to `chartjs-plugin-zoom`, in both directions, which is not what anyone means by it.

### Vendored `chart-timestack`

MIT, vendored under `src/lib/chart-timestack/`, for hierarchical time ticks — the default adapter shows hours on a multi-year axis. Excluded from eslint and dprint as third-party. One local change: it augments `CartesianScaleTypeRegistry` rather than `ScaleTypeRegistry` so the scale type-checks as a line chart x-axis.

### Test plan

Manual, driven through the running dev server against prod endpoints. `vue-tsc`, `eslint --max-warnings=0` and `dprint check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
