### PR TITLE
Rename Survival Chaos (OZ) to Survival Chaos Reborn

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -38,7 +38,7 @@ const en = {
     GM_PTR_1ON1: "PTR Balance 1v1",
     GM_DOTA_5ON5: "Dota 5v5",
     GM_SC_FFA_4: "Survival Chaos",
-    GM_SC_OZ: "Survival Chaos (OZ)",
+    GM_SC_OZ: "Survival Chaos Reborn",
     GM_DS: "Direct Strike 3v3",
     GM_DS_AT: "Direct Strike 3v3 AT",
     GM_WARHAMMER_1ON1: "Warhammer 1v1",


### PR DESCRIPTION
The `en` override in `src/locales/en.ts` still displayed **Survival Chaos (OZ)**. The sheet-generated `src/locales/data.ts` already carries the new name, but `languages.ts` does `merge(data, { en })`, so the stale override won and users saw the old label everywhere.

Mode names aren't translated, and no other locale defines `GM_SC_OZ` — with `fallbackLocale: "en"` they all resolve to this value, so every language now reads **Survival Chaos Reborn**.

Matches the name matchmaking-service already serves for the mode (`GmSurvivalChaosOz.name`), which is what the launcher displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)